### PR TITLE
impl CofactorCurve for Pallas and Vesta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## Added
+- Implementations of `group::cofactor::{CofactorCurve, CofactorCurveAffine}` for
+  Pallas and Vesta, enabling them to be used in cofactor-aware protocols that
+  also want to leverage the affine point representation.
 
 ## [0.1.0] - 2021-06-01
 Initial release!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.1.1] - 2021-06-04
 ## Added
 - Implementations of `group::cofactor::{CofactorCurve, CofactorCurveAffine}` for
   Pallas and Vesta, enabling them to be used in cofactor-aware protocols that

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pasta_curves"
 description = "Implementation of the Pallas and Vesta (Pasta) curve cycle"
-version = "0.1.0"
+version = "0.1.1"
 authors = [
     "Sean Bowe <sean@electriccoin.co>",
     "Ying Tong Lai <yingtong@electriccoin.co>",

--- a/src/curves.rs
+++ b/src/curves.rs
@@ -7,7 +7,7 @@ use core::iter::Sum;
 use core::ops::{Add, Mul, Neg, Sub};
 use ff::Field;
 use group::{
-    cofactor::CofactorGroup,
+    cofactor::{CofactorCurve, CofactorGroup},
     prime::{PrimeCurve, PrimeCurveAffine, PrimeGroup},
     Curve as _, Group as _, GroupEncoding,
 };
@@ -215,6 +215,10 @@ macro_rules! new_curve_impl {
         }
 
         impl PrimeCurve for $name {
+            type Affine = $name_affine;
+        }
+
+        impl CofactorCurve for $name {
             type Affine = $name_affine;
         }
 
@@ -591,6 +595,27 @@ macro_rules! new_curve_impl {
                     y: self.y,
                     z: $base::conditional_select(&$base::one(), &$base::zero(), self.infinity),
                 }
+            }
+        }
+
+        impl group::cofactor::CofactorCurveAffine for $name_affine {
+            type Curve = $name;
+            type Scalar = $scalar;
+
+            fn identity() -> Self {
+                <Self as PrimeCurveAffine>::identity()
+            }
+
+            fn generator() -> Self {
+                <Self as PrimeCurveAffine>::generator()
+            }
+
+            fn is_identity(&self) -> Choice {
+                <Self as PrimeCurveAffine>::is_identity(self)
+            }
+
+            fn to_curve(&self) -> Self::Curve {
+                <Self as PrimeCurveAffine>::to_curve(self)
             }
         }
 


### PR DESCRIPTION
They already implement CofactorGroup (trivially, with the prime-order
subgroup being Self); this just enables Pallas and Vesta to be used in
cofactor-aware protocols that also want to leverage the affine point
representation.