### PR TITLE
Re-export group crate.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,8 @@ pub mod vesta;
 pub use curves::*;
 pub use fields::*;
 
+pub extern crate group;
+
 #[test]
 fn test_endo_consistency() {
     use crate::arithmetic::{CurveExt, FieldExt};


### PR DESCRIPTION
This makes it possible to use traits from `group` without making `group` a dependency. The latter blows up with compilation errors, for whatever reason.