### PR TITLE
Move whole crate to no_std

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 Cargo.lock
 .vscode
 **/*.html
+.idea

--- a/src/arithmetic.rs
+++ b/src/arithmetic.rs
@@ -10,13 +10,11 @@ mod fields;
 pub(crate) use fields::*;
 
 pub use curves::*;
-#[cfg(feature = "std")]
 pub use fields::*;
 
 /// This represents an element of a group with basic operations that can be
 /// performed. This allows an FFT implementation (for example) to operate
 /// generically over either a field or elliptic curve group.
-#[cfg(feature = "std")]
 pub trait Group: Copy + Clone + Send + Sync + 'static {
     /// The group is assumed to be of prime order $p$. `Scalar` is the
     /// associated scalar field of size $p$.

--- a/src/arithmetic/fields.rs
+++ b/src/arithmetic/fields.rs
@@ -9,7 +9,6 @@ use subtle::Choice;
 #[cfg(not(feature = "std"))]
 use subtle::CtOption;
 
-#[cfg(feature = "std")]
 use super::Group;
 
 #[cfg(feature = "std")]
@@ -19,7 +18,6 @@ const_assert!(size_of::<usize>() >= 4);
 
 /// A trait that exposes additional operations related to calculating square roots of
 /// prime-order finite fields.
-#[cfg(feature = "std")]
 pub trait SqrtRatio: ff::PrimeField {
     /// The value $(T-1)/2$ such that $2^S \cdot T = p - 1$ with $T$ odd.
     const T_MINUS1_OVER2: [u64; 4];
@@ -64,7 +62,6 @@ pub trait SqrtRatio: ff::PrimeField {
 
 /// This trait is a common interface for dealing with elements of a finite
 /// field.
-#[cfg(feature = "std")]
 pub trait FieldExt: SqrtRatio + From<bool> + Ord + Group<Scalar = Self> {
     /// Modulus of the field written as a string for display purposes
     const MODULUS: &'static str;

--- a/src/arithmetic/fields.rs
+++ b/src/arithmetic/fields.rs
@@ -80,7 +80,13 @@ pub trait FieldExt: SqrtRatio + From<bool> + Ord + Group<Scalar = Self> {
 
     /// This computes a random element of the field using system randomness.
     fn rand() -> Self {
-        Self::random(rand::rngs::OsRng)
+        #[cfg(feature = "std")]
+        {
+            Self::random(rand::rngs::OsRng)
+        }
+
+        #[cfg(not(feature = "std"))]
+        unimplemented!()
     }
 
     /// Obtains a field element congruent to the integer `v`.

--- a/src/curves.rs
+++ b/src/curves.rs
@@ -918,7 +918,7 @@ macro_rules! impl_projective_curve_ext {
         fn hash_to_curve<'a>(_domain_prefix: &'a str) -> Box<dyn Fn(&[u8]) -> Self + 'a> {
             unimplemented!()
         }
-        fn unboxed_hash_to_curve(domain_prefix: &str, message: &[u8]) -> Self {
+        fn unboxed_hash_to_curve(_domain_prefix: &str, _message: &[u8]) -> Self {
             unimplemented!()
         }
 

--- a/src/fields/fp.rs
+++ b/src/fields/fp.rs
@@ -730,31 +730,27 @@ impl SqrtRatio for Fp {
 
         tmp.0[0] as u32
     }
-    /// - $(\textsf{true}, \sqrt{\textsf{num}/\textsf{div}})$, if $\textsf{num}$ and
-    ///   $\textsf{div}$ are nonzero and $\textsf{num}/\textsf{div}$ is a square in the
-    ///   field;
-    /// - $(\textsf{true}, 0)$, if $\textsf{num}$ is zero;
-    /// - $(\textsf{false}, 0)$, if $\textsf{num}$ is nonzero and $\textsf{div}$ is zero;
-    /// - $(\textsf{false}, \sqrt{G_S \cdot \textsf{num}/\textsf{div}})$, if
-    ///   $\textsf{num}$ and $\textsf{div}$ are nonzero and $\textsf{num}/\textsf{div}$ is
-    ///   a nonsquare in the field;
+
     fn sqrt_ratio(num: &Self, div: &Self) -> (Choice, Self) {
         use ff::Field;
-        if (num.is_zero() | div.is_zero()).into() {
-            return (!div.is_zero(), Self::zero());
-        }
 
-        let div_inv = (*div).invert().unwrap();
-        let x = (*num) * div_inv;
-        let y = x * Self::root_of_unity();
+        //invert div
+        let div_inv = (*div).invert().unwrap_or(Self::zero());
 
+        let x = (*num) * div_inv; // x = num/div
+        let y = x * Self::root_of_unity(); // y = lambda*num/div
+
+        // Either x is square or y is square
         let x_sqrt = x.sqrt();
         let y_sqrt = y.sqrt();
-
         let x_is_sqrt = x_sqrt.is_some();
         let sqrt = CtOption::conditional_select(&y_sqrt, &x_sqrt, x_is_sqrt);
 
-        (x_is_sqrt, sqrt.unwrap())
+        if (num.is_zero() | div.is_zero()).into() {
+            (!div.is_zero(), Self::zero()) // special cases
+        } else {
+            (x_is_sqrt, sqrt.unwrap())
+        }
     }
 }
 

--- a/src/fields/fp.rs
+++ b/src/fields/fp.rs
@@ -730,28 +730,6 @@ impl SqrtRatio for Fp {
 
         tmp.0[0] as u32
     }
-
-    fn sqrt_ratio(num: &Self, div: &Self) -> (Choice, Self) {
-        use ff::Field;
-
-        //invert div
-        let div_inv = (*div).invert().unwrap_or(Self::zero());
-
-        let x = (*num) * div_inv; // x = num/div
-        let y = x * Self::root_of_unity(); // y = lambda*num/div
-
-        // Either x is square or y is square
-        let x_sqrt = x.sqrt();
-        let y_sqrt = y.sqrt();
-        let x_is_sqrt = x_sqrt.is_some();
-        let sqrt = CtOption::conditional_select(&y_sqrt, &x_sqrt, x_is_sqrt);
-
-        if (num.is_zero() | div.is_zero()).into() {
-            (!div.is_zero(), Self::zero()) // special cases
-        } else {
-            (x_is_sqrt, sqrt.unwrap())
-        }
-    }
 }
 
 impl FieldExt for Fp {

--- a/src/fields/fp.rs
+++ b/src/fields/fp.rs
@@ -739,7 +739,22 @@ impl SqrtRatio for Fp {
     ///   $\textsf{num}$ and $\textsf{div}$ are nonzero and $\textsf{num}/\textsf{div}$ is
     ///   a nonsquare in the field;
     fn sqrt_ratio(num: &Self, div: &Self) -> (Choice, Self) {
-        unimplemented!()
+        use ff::Field;
+        if (num.is_zero() | div.is_zero()).into() {
+            return (!div.is_zero(), Self::zero());
+        }
+
+        let div_inv = (*div).invert().unwrap();
+        let x = (*num) * div_inv;
+        let y = x * Self::root_of_unity();
+
+        let x_sqrt = x.sqrt();
+        let y_sqrt = y.sqrt();
+
+        let x_is_sqrt = x_sqrt.is_some();
+        let sqrt = CtOption::conditional_select(&y_sqrt, &x_sqrt, x_is_sqrt);
+
+        (x_is_sqrt, sqrt.unwrap())
     }
 }
 
@@ -838,7 +853,7 @@ fn test_sqrt_ratio_and_alt() {
     let (is_square_alt, v_alt) = Fp::sqrt_alt(&(num * div_inverse));
     assert!(bool::from(is_square_alt));
     assert!(v_alt == v);
-
+    /*
     // (false, sqrt(ROOT_OF_UNITY * num/div)), if num and div are nonzero and num/div is a nonsquare in the field
     let num = num * Fp::root_of_unity();
     let expected = Fp::TWO_INV * Fp::root_of_unity() * Fp::from(5).invert().unwrap();
@@ -848,7 +863,7 @@ fn test_sqrt_ratio_and_alt() {
 
     let (is_square_alt, v_alt) = Fp::sqrt_alt(&(num * div_inverse));
     assert!(!bool::from(is_square_alt));
-    assert!(v_alt == v);
+    assert!(v_alt == v);*/
 
     // (true, 0), if num is zero
     let num = Fp::zero();

--- a/src/fields/fp.rs
+++ b/src/fields/fp.rs
@@ -730,6 +730,9 @@ impl SqrtRatio for Fp {
 
         tmp.0[0] as u32
     }
+
+    // TODO: use squareness test from Tonelli-Shanks algorithm
+    // for more effective implementation of sqrt_ratio
 }
 
 impl FieldExt for Fp {
@@ -827,7 +830,7 @@ fn test_sqrt_ratio_and_alt() {
     let (is_square_alt, v_alt) = Fp::sqrt_alt(&(num * div_inverse));
     assert!(bool::from(is_square_alt));
     assert!(v_alt == v);
-    /*
+
     // (false, sqrt(ROOT_OF_UNITY * num/div)), if num and div are nonzero and num/div is a nonsquare in the field
     let num = num * Fp::root_of_unity();
     let expected = Fp::TWO_INV * Fp::root_of_unity() * Fp::from(5).invert().unwrap();
@@ -837,7 +840,7 @@ fn test_sqrt_ratio_and_alt() {
 
     let (is_square_alt, v_alt) = Fp::sqrt_alt(&(num * div_inverse));
     assert!(!bool::from(is_square_alt));
-    assert!(v_alt == v);*/
+    assert!(v_alt == v);
 
     // (true, 0), if num is zero
     let num = Fp::zero();

--- a/src/fields/fq.rs
+++ b/src/fields/fq.rs
@@ -728,6 +728,9 @@ impl SqrtRatio for Fq {
 
         tmp.0[0] as u32
     }
+
+    // TODO: use squareness test from Tonelli-Shanks algorithm
+    // for more effective implementation of sqrt_ratio
 }
 
 impl FieldExt for Fq {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,6 @@ pub mod arithmetic;
 pub mod pallas;
 pub mod vesta;
 
-#[cfg(feature = "std")]
 mod hashtocurve;
 
 pub use curves::*;
@@ -30,7 +29,6 @@ pub use fields::*;
 
 pub extern crate group;
 
-#[cfg(feature = "std")]
 #[test]
 fn test_endo_consistency() {
     use crate::arithmetic::{CurveExt, FieldExt};

--- a/src/pallas.rs
+++ b/src/pallas.rs
@@ -14,7 +14,6 @@ pub type Point = Ep;
 /// A Pallas point in the affine coordinate space (or the point at infinity).
 pub type Affine = EpAffine;
 
-#[cfg(feature = "std")]
 #[test]
 #[allow(clippy::many_single_char_names)]
 fn test_iso_map() {
@@ -65,7 +64,6 @@ fn test_iso_map() {
     assert!(p2 == p.double());
 }
 
-#[cfg(feature = "std")]
 #[test]
 fn test_iso_map_identity() {
     use crate::arithmetic::CurveExt;
@@ -100,7 +98,6 @@ fn test_iso_map_identity() {
     assert!(bool::from(p.is_identity()));
 }
 
-#[cfg(feature = "std")]
 #[test]
 fn test_map_to_curve_simple_swu() {
     use crate::arithmetic::CurveExt;
@@ -145,6 +142,32 @@ fn test_hash_to_curve() {
     // "branch" and the second takes the gx1 non-square "branch" (opposite to the Vesta test vector).
     let hash = Point::hash_to_curve("z.cash:test");
     let p: Point = hash(b"Trans rights now!");
+    let (x, y, z) = p.jacobian_coordinates();
+
+    assert!(
+        format!("{:?}", x) == "0x36a6e3a9c50b7b6540cb002c977c82f37f8a875fb51eb35327ee1452e6ce7947"
+    );
+    assert!(
+        format!("{:?}", y) == "0x01da3b4403d73252f2d7e9c19bc23dc6a080f2d02f8262fca4f7e3d756ac6a7c"
+    );
+    assert!(
+        format!("{:?}", z) == "0x1d48103df8fcbb70d1809c1806c95651dd884a559fec0549658537ce9d94bed9"
+    );
+    assert!(bool::from(p.is_on_curve()));
+
+    let p = (p * -Fq::one()) + p;
+    assert!(bool::from(p.is_on_curve()));
+    assert!(bool::from(p.is_identity()));
+}
+
+#[test]
+fn test_unboxed_hash_to_curve() {
+    use crate::arithmetic::CurveExt;
+    use group::Group;
+
+    // This test vector is chosen so that the first map_to_curve_simple_swu takes the gx1 square
+    // "branch" and the second takes the gx1 non-square "branch" (opposite to the Vesta test vector).
+    let p = Point::unboxed_hash_to_curve("z.cash:test", b"Trans rights now!");
     let (x, y, z) = p.jacobian_coordinates();
 
     assert!(


### PR DESCRIPTION
I removed std-only flags from `FieldExt` and `SqrtRatio` traits and I implemented generic sqrt_ratio function.

Further I removed std-only flags from `group` traits, `CurveExt`, `CurveAffine` and all tests.

I added unboxed version of `hash_to_curve`. It works. I tested on Trezor.

I suggest moving `read` and `write` methods of `CurveAffine` trait to another std-only trait. For example `read` could be replaced by `TryFrom` trait.  

If I didn't realize std dependency of some external crate, give me know.