### PR TITLE
Implement ec_gpu:GpuField for Fp/Fq

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,8 +53,12 @@ blake2b_simd = { version = "1", optional = true, default-features = false }
 # sqrt-table dependencies
 lazy_static = { version = "1.4.0", optional = true }
 
+# gpu dependencies
+ec-gpu = { version = "0.1.0", optional = true }
+
 [features]
 default = ["bits", "sqrt-table"]
 alloc = ["group/alloc", "blake2b_simd"]
 bits = ["ff/bits"]
+gpu = ["alloc", "ec-gpu"]
 sqrt-table = ["alloc", "lazy_static"]

--- a/src/fields.rs
+++ b/src/fields.rs
@@ -11,6 +11,6 @@ pub use fq::*;
 fn u64_to_u32(limbs: &[u64]) -> alloc::vec::Vec<u32> {
     limbs
         .iter()
-        .flat_map(|limb| alloc::vec![(limb & 0xFFFF_FFFF) as u32, (limb >> 32) as u32])
+        .flat_map(|limb| Some((limb & 0xFFFF_FFFF) as u32).into_iter().chain(Some((limb >> 32) as u32)))
         .collect()
 }

--- a/src/fields.rs
+++ b/src/fields.rs
@@ -6,3 +6,11 @@ mod fq;
 
 pub use fp::*;
 pub use fq::*;
+
+#[cfg(feature = "gpu")]
+fn u64_to_u32(limbs: &[u64]) -> alloc::vec::Vec<u32> {
+    limbs
+        .iter()
+        .flat_map(|limb| alloc::vec![(limb & 0xFFFF_FFFF) as u32, (limb >> 32) as u32])
+        .collect()
+}

--- a/src/fields.rs
+++ b/src/fields.rs
@@ -7,6 +7,7 @@ mod fq;
 pub use fp::*;
 pub use fq::*;
 
+/// Converts 64-bit little-endian limbs to 32-bit little endian limbs.
 #[cfg(feature = "gpu")]
 fn u64_to_u32(limbs: &[u64]) -> alloc::vec::Vec<u32> {
     limbs

--- a/src/fields.rs
+++ b/src/fields.rs
@@ -12,6 +12,10 @@ pub use fq::*;
 fn u64_to_u32(limbs: &[u64]) -> alloc::vec::Vec<u32> {
     limbs
         .iter()
-        .flat_map(|limb| Some((limb & 0xFFFF_FFFF) as u32).into_iter().chain(Some((limb >> 32) as u32)))
+        .flat_map(|limb| {
+            Some((limb & 0xFFFF_FFFF) as u32)
+                .into_iter()
+                .chain(Some((limb >> 32) as u32))
+        })
         .collect()
 }

--- a/src/fields/fp.rs
+++ b/src/fields/fp.rs
@@ -770,6 +770,21 @@ impl FieldExt for Fp {
     }
 }
 
+#[cfg(feature = "gpu")]
+impl ec_gpu::GpuField for Fp {
+    fn one() -> alloc::vec::Vec<u32> {
+        crate::fields::u64_to_u32(&R.0[..])
+    }
+
+    fn r2() -> alloc::vec::Vec<u32> {
+        crate::fields::u64_to_u32(&R2.0[..])
+    }
+
+    fn modulus() -> alloc::vec::Vec<u32> {
+        crate::fields::u64_to_u32(&MODULUS.0[..])
+    }
+}
+
 #[cfg(test)]
 use ff::Field;
 

--- a/src/fields/fq.rs
+++ b/src/fields/fq.rs
@@ -769,6 +769,21 @@ impl FieldExt for Fq {
     }
 }
 
+#[cfg(feature = "gpu")]
+impl ec_gpu::GpuField for Fq {
+    fn one() -> alloc::vec::Vec<u32> {
+        crate::fields::u64_to_u32(&R.0[..])
+    }
+
+    fn r2() -> alloc::vec::Vec<u32> {
+        crate::fields::u64_to_u32(&R2.0[..])
+    }
+
+    fn modulus() -> alloc::vec::Vec<u32> {
+        crate::fields::u64_to_u32(&MODULUS.0[..])
+    }
+}
+
 #[cfg(test)]
 use ff::Field;
 


### PR DESCRIPTION
This commit introduces a new feature called "gpu", which enables an
`ec_gpu:GpuField` implementation of `Fp` and `Fq`. This enables the
field arithmetics to be run on a GPU.

The code to convert from a u64 to a u32 vector was taken from
https://github.com/filecoin-project/blstrs/blob/07a84f9727d2fb7387efb2df0f17ddc5d35571d3/src/lib.rs#L102-L108