### PR TITLE
Add optional support for borsh (de)serialization via borsh feature for Fp, Fq, Ep, Eq.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,9 @@ blake2b_simd = { version = "1", optional = true, default-features = false }
 # sqrt-table dependencies
 lazy_static = { version = "1.4.0", optional = true }
 
+# optional borsh (de)serialization
+borsh = { version = "0.9", optional = true }
+
 [features]
 default = ["bits", "sqrt-table"]
 alloc = ["group/alloc", "blake2b_simd"]

--- a/src/curves.rs
+++ b/src/curves.rs
@@ -29,6 +29,8 @@ macro_rules! new_curve_impl {
      $curve_id:literal, $a_raw:expr, $b_raw:expr, $curve_type:ident) => {
         /// Represents a point in the projective coordinate space.
         #[derive(Copy, Clone, Debug)]
+        #[cfg(feature = "borsh")]
+        #[derive(borsh::BorshSerialize, borsh::BorshDeserialize)]
         $($privacy)* struct $name {
             x: $base,
             y: $base,

--- a/src/fields/fp.rs
+++ b/src/fields/fp.rs
@@ -26,6 +26,8 @@ use crate::arithmetic::SqrtTables;
 // integers in little-endian order. `Fp` values are always in
 // Montgomery form; i.e., Fp(a) = aR mod p, with R = 2^256.
 #[derive(Clone, Copy, Eq)]
+#[cfg(feature = "borsh")]
+#[derive(borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct Fp(pub(crate) [u64; 4]);
 
 impl fmt::Debug for Fp {

--- a/src/fields/fq.rs
+++ b/src/fields/fq.rs
@@ -26,6 +26,8 @@ use crate::arithmetic::SqrtTables;
 // integers in little-endian order. `Fq` values are always in
 // Montgomery form; i.e., Fq(a) = aR mod q, with R = 2^256.
 #[derive(Clone, Copy, Eq)]
+#[cfg(feature = "borsh")]
+#[derive(borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct Fq(pub(crate) [u64; 4]);
 
 impl fmt::Debug for Fq {


### PR DESCRIPTION
Through the `borsh` feature, we can add `derive` macros to `Fp`, `Fq`,
and `Ep`, `Eq` types.
This feature is useful for developers using borsh because this allows seamless
integration of pasta curves into structs that have to be serialized or deserialized
using borsh.