### PR TITLE
Update to ec-gpu 0.2 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ blake2b_simd = { version = "1", optional = true, default-features = false }
 lazy_static = { version = "1.4.0", optional = true }
 
 # gpu dependencies
-ec-gpu = { version = "0.1.0", optional = true }
+ec-gpu = { version = "0.2.0", optional = true }
 
 [features]
 default = ["bits", "sqrt-table"]

--- a/src/curves.rs
+++ b/src/curves.rs
@@ -799,6 +799,13 @@ macro_rules! new_curve_impl {
                 *self *= *by;
             }
         }
+
+        #[cfg(feature = "gpu")]
+        impl ec_gpu::GpuName for $name_affine {
+            fn name() -> alloc::string::String {
+                ec_gpu::name!()
+            }
+        }
     };
 }
 

--- a/src/fields/fp.rs
+++ b/src/fields/fp.rs
@@ -771,6 +771,13 @@ impl FieldExt for Fp {
 }
 
 #[cfg(feature = "gpu")]
+impl ec_gpu::GpuName for Fp {
+    fn name() -> alloc::string::String {
+        ec_gpu::name!()
+    }
+}
+
+#[cfg(feature = "gpu")]
 impl ec_gpu::GpuField for Fp {
     fn one() -> alloc::vec::Vec<u32> {
         crate::fields::u64_to_u32(&R.0[..])

--- a/src/fields/fq.rs
+++ b/src/fields/fq.rs
@@ -770,6 +770,13 @@ impl FieldExt for Fq {
 }
 
 #[cfg(feature = "gpu")]
+impl ec_gpu::GpuName for Fq {
+    fn name() -> alloc::string::String {
+        ec_gpu::name!()
+    }
+}
+
+#[cfg(feature = "gpu")]
 impl ec_gpu::GpuField for Fq {
     fn one() -> alloc::vec::Vec<u32> {
         crate::fields::u64_to_u32(&R.0[..])


### PR DESCRIPTION
The traits of ec-gpu changed a bit, there's now also a `GpuName`
trait that needs to be implemented.

BREAKING CHANGE: `ec-gpu` v0.2 traits are not compatible with v0.1

All dependencies that use `ec-gpu` need to be on v0.2.