### PR TITLE
Remove `FieldExt` and `Group` traits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to Rust's notion of
 
 ### Removed
 - `pasta_curves::arithmetic`:
+  - `FieldExt` (use `ff::PrimeField` or `ff::WithSmallOrderMulGroup` instead).
   - `Group`
   - `SqrtRatio` (use `ff::Field::{sqrt_ratio, sqrt_alt}` instead).
   - `SqrtTables` (from public API, as it isn't suitable for generic usage).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,10 @@ and this project adheres to Rust's notion of
 - Migrated to `ff 0.13`, `group 0.13`.
 
 ### Removed
-- `pasta_curves::arithmetic::SqrtRatio` (use `ff::Field::{sqrt_ratio, sqrt_alt}`
-  instead).
-- `pasta_curves::arithmetic::SqrtTables` (from public API, as it isn't suitable
-  for generic usage).
+- `pasta_curves::arithmetic`:
+  - `Group`
+  - `SqrtRatio` (use `ff::Field::{sqrt_ratio, sqrt_alt}` instead).
+  - `SqrtTables` (from public API, as it isn't suitable for generic usage).
 
 ## [0.4.1] - 2022-10-13
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,4 +74,4 @@ uninline-portable = []
 serde = ["hex", "serde_crate"]
 
 [patch.crates-io]
-ff = { git = "https://github.com/zkcrypto/ff.git", rev = "c070ffbaea8cb17e57f817a91ed0e364ff679b7c" }
+ff = { git = "https://github.com/zkcrypto/ff.git", rev = "054a4d2daf9a9540d4c436fa51f0222e997ad15c" }

--- a/src/arithmetic.rs
+++ b/src/arithmetic.rs
@@ -8,4 +8,4 @@ mod curves;
 mod fields;
 
 pub use curves::*;
-pub use fields::*;
+pub(crate) use fields::*;

--- a/src/arithmetic.rs
+++ b/src/arithmetic.rs
@@ -9,24 +9,3 @@ mod fields;
 
 pub use curves::*;
 pub use fields::*;
-
-/// This represents an element of a group with basic operations that can be
-/// performed. This allows an FFT implementation (for example) to operate
-/// generically over either a field or elliptic curve group.
-pub trait Group: Copy + Clone + Send + Sync + 'static {
-    /// The group is assumed to be of prime order $p$. `Scalar` is the
-    /// associated scalar field of size $p$.
-    type Scalar: FieldExt;
-
-    /// Returns the additive identity of the group.
-    fn group_zero() -> Self;
-
-    /// Adds `rhs` to this group element.
-    fn group_add(&mut self, rhs: &Self);
-
-    /// Subtracts `rhs` from this group element.
-    fn group_sub(&mut self, rhs: &Self);
-
-    /// Scales this group element by a scalar.
-    fn group_scale(&mut self, by: &Self::Scalar);
-}

--- a/src/arithmetic/curves.rs
+++ b/src/arithmetic/curves.rs
@@ -7,9 +7,6 @@ use group::prime::{PrimeCurve, PrimeCurveAffine};
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
 #[cfg(feature = "alloc")]
-use super::FieldExt;
-
-#[cfg(feature = "alloc")]
 use alloc::boxed::Box;
 #[cfg(feature = "alloc")]
 use core::ops::{Add, Mul, Sub};
@@ -30,9 +27,9 @@ pub trait CurveExt:
     + From<<Self as PrimeCurve>::Affine>
 {
     /// The scalar field of this elliptic curve.
-    type ScalarExt: FieldExt;
+    type ScalarExt: ff::WithSmallOrderMulGroup<3>;
     /// The base field over which this elliptic curve is constructed.
-    type Base: FieldExt;
+    type Base: ff::WithSmallOrderMulGroup<3>;
     /// The affine version of the curve
     type AffineExt: CurveAffine<CurveExt = Self, ScalarExt = <Self as CurveExt>::ScalarExt>
         + Mul<Self::ScalarExt, Output = Self>
@@ -102,9 +99,9 @@ pub trait CurveAffine:
     + From<<Self as PrimeCurveAffine>::Curve>
 {
     /// The scalar field of this elliptic curve.
-    type ScalarExt: FieldExt + Ord;
+    type ScalarExt: ff::WithSmallOrderMulGroup<3> + Ord;
     /// The base field over which this elliptic curve is constructed.
-    type Base: FieldExt + Ord;
+    type Base: ff::WithSmallOrderMulGroup<3> + Ord;
     /// The projective form of the curve
     type CurveExt: CurveExt<AffineExt = Self, ScalarExt = <Self as CurveAffine>::ScalarExt>;
 

--- a/src/arithmetic/curves.rs
+++ b/src/arithmetic/curves.rs
@@ -102,9 +102,9 @@ pub trait CurveAffine:
     + From<<Self as PrimeCurveAffine>::Curve>
 {
     /// The scalar field of this elliptic curve.
-    type ScalarExt: FieldExt;
+    type ScalarExt: FieldExt + Ord;
     /// The base field over which this elliptic curve is constructed.
-    type Base: FieldExt;
+    type Base: FieldExt + Ord;
     /// The projective form of the curve
     type CurveExt: CurveExt<AffineExt = Self, ScalarExt = <Self as CurveAffine>::ScalarExt>;
 

--- a/src/arithmetic/curves.rs
+++ b/src/arithmetic/curves.rs
@@ -7,7 +7,7 @@ use group::prime::{PrimeCurve, PrimeCurveAffine};
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
 #[cfg(feature = "alloc")]
-use super::{FieldExt, Group};
+use super::FieldExt;
 
 #[cfg(feature = "alloc")]
 use alloc::boxed::Box;
@@ -28,7 +28,6 @@ pub trait CurveExt:
     + ConditionallySelectable
     + ConstantTimeEq
     + From<<Self as PrimeCurve>::Affine>
-    + Group<Scalar = <Self as group::Group>::Scalar>
 {
     /// The scalar field of this elliptic curve.
     type ScalarExt: FieldExt;

--- a/src/arithmetic/fields.rs
+++ b/src/arithmetic/fields.rs
@@ -28,10 +28,6 @@ pub(crate) trait SqrtTableHelpers: ff::PrimeField {
     fn get_lower_32(&self) -> u32;
 }
 
-/// This trait is a common interface for dealing with elements of a finite
-/// field.
-pub trait FieldExt: ff::WithSmallOrderMulGroup<3> {}
-
 /// Parameters for a perfect hash function used in square root computation.
 #[cfg(feature = "sqrt-table")]
 #[cfg_attr(docsrs, doc(cfg(feature = "sqrt-table")))]

--- a/src/arithmetic/fields.rs
+++ b/src/arithmetic/fields.rs
@@ -32,7 +32,7 @@ pub(crate) trait SqrtTableHelpers: ff::PrimeField {
 
 /// This trait is a common interface for dealing with elements of a finite
 /// field.
-pub trait FieldExt: ff::PrimeField + From<bool> + Ord + Group<Scalar = Self> {
+pub trait FieldExt: ff::PrimeField + Ord + Group<Scalar = Self> {
     /// Modulus of the field written as a string for display purposes
     const MODULUS: &'static str;
 
@@ -54,10 +54,6 @@ pub trait FieldExt: ff::PrimeField + From<bool> + Ord + Group<Scalar = Self> {
     /// Obtains a field element that is congruent to the provided little endian
     /// byte representation of an integer.
     fn from_bytes_wide(bytes: &[u8; 64]) -> Self;
-
-    /// Gets the lower 128 bits of this field element when expressed
-    /// canonically.
-    fn get_lower_128(&self) -> u128;
 }
 
 /// Parameters for a perfect hash function used in square root computation.

--- a/src/arithmetic/fields.rs
+++ b/src/arithmetic/fields.rs
@@ -30,7 +30,7 @@ pub(crate) trait SqrtTableHelpers: ff::PrimeField {
 
 /// This trait is a common interface for dealing with elements of a finite
 /// field.
-pub trait FieldExt: ff::WithSmallOrderMulGroup<3> + Ord {}
+pub trait FieldExt: ff::WithSmallOrderMulGroup<3> {}
 
 /// Parameters for a perfect hash function used in square root computation.
 #[cfg(feature = "sqrt-table")]

--- a/src/arithmetic/fields.rs
+++ b/src/arithmetic/fields.rs
@@ -30,29 +30,7 @@ pub(crate) trait SqrtTableHelpers: ff::PrimeField {
 
 /// This trait is a common interface for dealing with elements of a finite
 /// field.
-pub trait FieldExt: ff::PrimeField + Ord {
-    /// Modulus of the field written as a string for display purposes
-    const MODULUS: &'static str;
-
-    /// Inverse of `PrimeField::ROOT_OF_UNITY`
-    const ROOT_OF_UNITY_INV: Self;
-
-    /// Generator of the $t-order$ multiplicative subgroup
-    const DELTA: Self;
-
-    /// Inverse of $2$ in the field.
-    const TWO_INV: Self;
-
-    /// Element of multiplicative order $3$.
-    const ZETA: Self;
-
-    /// Obtains a field element congruent to the integer `v`.
-    fn from_u128(v: u128) -> Self;
-
-    /// Obtains a field element that is congruent to the provided little endian
-    /// byte representation of an integer.
-    fn from_bytes_wide(bytes: &[u8; 64]) -> Self;
-}
+pub trait FieldExt: ff::WithSmallOrderMulGroup<3> + Ord {}
 
 /// Parameters for a perfect hash function used in square root computation.
 #[cfg(feature = "sqrt-table")]

--- a/src/arithmetic/fields.rs
+++ b/src/arithmetic/fields.rs
@@ -60,14 +60,14 @@ pub trait FieldExt: ff::PrimeField + Ord + Group<Scalar = Self> {
 #[cfg(feature = "sqrt-table")]
 #[cfg_attr(docsrs, doc(cfg(feature = "sqrt-table")))]
 #[derive(Debug)]
-struct SqrtHasher<F: FieldExt> {
+struct SqrtHasher<F: SqrtTableHelpers> {
     hash_xor: u32,
     hash_mod: usize,
     marker: PhantomData<F>,
 }
 
 #[cfg(feature = "sqrt-table")]
-impl<F: FieldExt + SqrtTableHelpers> SqrtHasher<F> {
+impl<F: SqrtTableHelpers> SqrtHasher<F> {
     /// Returns a perfect hash of x for use with SqrtTables::inv.
     fn hash(&self, x: &F) -> usize {
         // This is just the simplest constant-time perfect hash construction that could
@@ -82,7 +82,7 @@ impl<F: FieldExt + SqrtTableHelpers> SqrtHasher<F> {
 #[cfg(feature = "sqrt-table")]
 #[cfg_attr(docsrs, doc(cfg(feature = "sqrt-table")))]
 #[derive(Debug)]
-pub(crate) struct SqrtTables<F: FieldExt> {
+pub(crate) struct SqrtTables<F: SqrtTableHelpers> {
     hasher: SqrtHasher<F>,
     inv: Vec<u8>,
     g0: Box<[F; 256]>,
@@ -92,7 +92,7 @@ pub(crate) struct SqrtTables<F: FieldExt> {
 }
 
 #[cfg(feature = "sqrt-table")]
-impl<F: FieldExt + SqrtTableHelpers> SqrtTables<F> {
+impl<F: SqrtTableHelpers> SqrtTables<F> {
     /// Build tables given parameters for the perfect hash.
     pub fn new(hash_xor: u32, hash_mod: usize) -> Self {
         use alloc::vec;

--- a/src/arithmetic/fields.rs
+++ b/src/arithmetic/fields.rs
@@ -5,8 +5,6 @@ use core::mem::size_of;
 
 use static_assertions::const_assert;
 
-use super::Group;
-
 #[cfg(feature = "sqrt-table")]
 use alloc::{boxed::Box, vec::Vec};
 #[cfg(feature = "sqrt-table")]
@@ -32,7 +30,7 @@ pub(crate) trait SqrtTableHelpers: ff::PrimeField {
 
 /// This trait is a common interface for dealing with elements of a finite
 /// field.
-pub trait FieldExt: ff::PrimeField + Ord + Group<Scalar = Self> {
+pub trait FieldExt: ff::PrimeField + Ord {
     /// Modulus of the field written as a string for display purposes
     const MODULUS: &'static str;
 

--- a/src/curves.rs
+++ b/src/curves.rs
@@ -19,7 +19,6 @@ use rand::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
 use super::{Fp, Fq};
-use crate::arithmetic::Group;
 
 #[cfg(feature = "alloc")]
 use crate::arithmetic::{Coordinates, CurveAffine, CurveExt, FieldExt};
@@ -782,23 +781,6 @@ macro_rules! new_curve_impl {
         impl_binops_additive_specify_output!($name_affine, $name, $name);
         impl_binops_multiplicative!($name, $scalar);
         impl_binops_multiplicative_mixed!($name_affine, $scalar, $name);
-
-        impl Group for $name {
-            type Scalar = $scalar;
-
-            fn group_zero() -> Self {
-                Self::identity()
-            }
-            fn group_add(&mut self, rhs: &Self) {
-                *self += *rhs;
-            }
-            fn group_sub(&mut self, rhs: &Self) {
-                *self -= *rhs;
-            }
-            fn group_scale(&mut self, by: &Self::Scalar) {
-                *self *= *by;
-            }
-        }
 
         #[cfg(feature = "gpu")]
         impl ec_gpu::GpuName for $name_affine {

--- a/src/curves.rs
+++ b/src/curves.rs
@@ -18,10 +18,13 @@ use group::{
 use rand::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
+#[cfg(feature = "alloc")]
+use ff::WithSmallOrderMulGroup;
+
 use super::{Fp, Fq};
 
 #[cfg(feature = "alloc")]
-use crate::arithmetic::{Coordinates, CurveAffine, CurveExt, FieldExt};
+use crate::arithmetic::{Coordinates, CurveAffine, CurveExt};
 
 macro_rules! new_curve_impl {
     (($($privacy:tt)*), $name:ident, $name_affine:ident, $iso:ident, $base:ident, $scalar:ident,

--- a/src/fields/fp.rs
+++ b/src/fields/fp.rs
@@ -11,7 +11,7 @@ use lazy_static::lazy_static;
 #[cfg(feature = "bits")]
 use ff::{FieldBits, PrimeFieldBits};
 
-use crate::arithmetic::{adc, mac, sbb, FieldExt, Group, SqrtTableHelpers};
+use crate::arithmetic::{adc, mac, sbb, FieldExt, SqrtTableHelpers};
 
 #[cfg(feature = "sqrt-table")]
 use crate::arithmetic::SqrtTables;
@@ -472,23 +472,6 @@ impl From<Fp> for [u8; 32] {
 impl<'a> From<&'a Fp> for [u8; 32] {
     fn from(value: &'a Fp) -> [u8; 32] {
         value.to_repr()
-    }
-}
-
-impl Group for Fp {
-    type Scalar = Fp;
-
-    fn group_zero() -> Self {
-        Self::zero()
-    }
-    fn group_add(&mut self, rhs: &Self) {
-        *self += *rhs;
-    }
-    fn group_sub(&mut self, rhs: &Self) {
-        *self -= *rhs;
-    }
-    fn group_scale(&mut self, by: &Self::Scalar) {
-        *self *= *by;
     }
 }
 

--- a/src/fields/fp.rs
+++ b/src/fields/fp.rs
@@ -767,12 +767,6 @@ impl FieldExt for Fp {
             u64::from_le_bytes(bytes[56..64].try_into().unwrap()),
         ])
     }
-
-    fn get_lower_128(&self) -> u128 {
-        let tmp = Fp::montgomery_reduce(self.0[0], self.0[1], self.0[2], self.0[3], 0, 0, 0, 0);
-
-        u128::from(tmp.0[0]) | (u128::from(tmp.0[1]) << 64)
-    }
 }
 
 #[cfg(feature = "gpu")]

--- a/src/fields/fp.rs
+++ b/src/fields/fp.rs
@@ -11,7 +11,7 @@ use lazy_static::lazy_static;
 #[cfg(feature = "bits")]
 use ff::{FieldBits, PrimeFieldBits};
 
-use crate::arithmetic::{adc, mac, sbb, FieldExt, SqrtTableHelpers};
+use crate::arithmetic::{adc, mac, sbb, SqrtTableHelpers};
 
 #[cfg(feature = "sqrt-table")]
 use crate::arithmetic::SqrtTables;
@@ -727,8 +727,6 @@ impl SqrtTableHelpers for Fp {
         tmp.0[0] as u32
     }
 }
-
-impl FieldExt for Fp {}
 
 impl WithSmallOrderMulGroup<3> for Fp {
     const ZETA: Self = Fp::from_raw([

--- a/src/fields/fq.rs
+++ b/src/fields/fq.rs
@@ -766,12 +766,6 @@ impl FieldExt for Fq {
             u64::from_le_bytes(bytes[56..64].try_into().unwrap()),
         ])
     }
-
-    fn get_lower_128(&self) -> u128 {
-        let tmp = Fq::montgomery_reduce(self.0[0], self.0[1], self.0[2], self.0[3], 0, 0, 0, 0);
-
-        u128::from(tmp.0[0]) | (u128::from(tmp.0[1]) << 64)
-    }
 }
 
 #[cfg(feature = "gpu")]

--- a/src/fields/fq.rs
+++ b/src/fields/fq.rs
@@ -11,7 +11,7 @@ use lazy_static::lazy_static;
 #[cfg(feature = "bits")]
 use ff::{FieldBits, PrimeFieldBits};
 
-use crate::arithmetic::{adc, mac, sbb, FieldExt, Group, SqrtTableHelpers};
+use crate::arithmetic::{adc, mac, sbb, FieldExt, SqrtTableHelpers};
 
 #[cfg(feature = "sqrt-table")]
 use crate::arithmetic::SqrtTables;
@@ -472,23 +472,6 @@ impl From<Fq> for [u8; 32] {
 impl<'a> From<&'a Fq> for [u8; 32] {
     fn from(value: &'a Fq) -> [u8; 32] {
         value.to_repr()
-    }
-}
-
-impl Group for Fq {
-    type Scalar = Fq;
-
-    fn group_zero() -> Self {
-        Self::zero()
-    }
-    fn group_add(&mut self, rhs: &Self) {
-        *self += *rhs;
-    }
-    fn group_sub(&mut self, rhs: &Self) {
-        *self -= *rhs;
-    }
-    fn group_scale(&mut self, by: &Self::Scalar) {
-        *self *= *by;
     }
 }
 

--- a/src/fields/fq.rs
+++ b/src/fields/fq.rs
@@ -11,7 +11,7 @@ use lazy_static::lazy_static;
 #[cfg(feature = "bits")]
 use ff::{FieldBits, PrimeFieldBits};
 
-use crate::arithmetic::{adc, mac, sbb, FieldExt, SqrtTableHelpers};
+use crate::arithmetic::{adc, mac, sbb, SqrtTableHelpers};
 
 #[cfg(feature = "sqrt-table")]
 use crate::arithmetic::SqrtTables;
@@ -726,8 +726,6 @@ impl SqrtTableHelpers for Fq {
         tmp.0[0] as u32
     }
 }
-
-impl FieldExt for Fq {}
 
 impl WithSmallOrderMulGroup<3> for Fq {
     const ZETA: Self = Fq::from_raw([

--- a/src/hashtocurve.rs
+++ b/src/hashtocurve.rs
@@ -1,14 +1,14 @@
 //! This module implements "simplified SWU" hashing to short Weierstrass curves
 //! with a = 0.
 
-use ff::{Field, PrimeField};
+use ff::{Field, FromUniformBytes, PrimeField};
 use static_assertions::const_assert;
 use subtle::ConstantTimeEq;
 
-use crate::arithmetic::{CurveExt, FieldExt};
+use crate::arithmetic::CurveExt;
 
 /// Hashes over a message and writes the output to all of `buf`.
-pub fn hash_to_field<F: FieldExt>(
+pub fn hash_to_field<F: FromUniformBytes<64>>(
     curve_id: &str,
     domain_prefix: &str,
     message: &[u8],
@@ -73,7 +73,7 @@ pub fn hash_to_field<F: FieldExt>(
         let mut little = [0u8; CHUNKLEN];
         little.copy_from_slice(big.as_array());
         little.reverse();
-        *buf = F::from_bytes_wide(&little);
+        *buf = F::from_uniform_bytes(&little);
     }
 }
 

--- a/src/hashtocurve.rs
+++ b/src/hashtocurve.rs
@@ -1,6 +1,7 @@
 //! This module implements "simplified SWU" hashing to short Weierstrass curves
 //! with a = 0.
 
+use ff::{Field, PrimeField};
 use static_assertions::const_assert;
 use subtle::ConstantTimeEq;
 
@@ -77,7 +78,7 @@ pub fn hash_to_field<F: FieldExt>(
 }
 
 /// Implements a degree 3 isogeny map.
-pub fn iso_map<F: FieldExt, C: CurveExt<Base = F>, I: CurveExt<Base = F>>(
+pub fn iso_map<F: Field, C: CurveExt<Base = F>, I: CurveExt<Base = F>>(
     p: &I,
     iso: &[C::Base; 13],
 ) -> C {
@@ -105,7 +106,7 @@ pub fn iso_map<F: FieldExt, C: CurveExt<Base = F>, I: CurveExt<Base = F>>(
 }
 
 #[allow(clippy::many_single_char_names)]
-pub fn map_to_curve_simple_swu<F: FieldExt, C: CurveExt<Base = F>, I: CurveExt<Base = F>>(
+pub fn map_to_curve_simple_swu<F: PrimeField, C: CurveExt<Base = F>, I: CurveExt<Base = F>>(
     u: &F,
     theta: F,
     z: F,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,8 +39,8 @@ pub extern crate group;
 #[cfg(feature = "alloc")]
 #[test]
 fn test_endo_consistency() {
-    use crate::arithmetic::{CurveExt, FieldExt};
-    use group::Group;
+    use crate::arithmetic::CurveExt;
+    use group::{ff::WithSmallOrderMulGroup, Group};
 
     let a = pallas::Point::generator();
     assert_eq!(a * pallas::Scalar::ZETA, a.endo());


### PR DESCRIPTION
```
One, two! One, two! And through and through
    The vorpal blade went snicker-snack!
He left it dead, and with its head
    He went galumphing back.
```

Depends on https://github.com/zkcrypto/ff/pull/98.
Closes zcash/pasta_curves#42.