### PR TITLE
Improve 64-bit to 32-bit limb conversion

### DIFF
--- a/src/fields.rs
+++ b/src/fields.rs
@@ -12,10 +12,28 @@ pub use fq::*;
 fn u64_to_u32(limbs: &[u64]) -> alloc::vec::Vec<u32> {
     limbs
         .iter()
-        .flat_map(|limb| {
-            Some((limb & 0xFFFF_FFFF) as u32)
-                .into_iter()
-                .chain(Some((limb >> 32) as u32))
-        })
+        .flat_map(|limb| [(limb & 0xFFFF_FFFF) as u32, (limb >> 32) as u32].into_iter())
         .collect()
+}
+
+#[cfg(feature = "gpu")]
+#[test]
+fn test_u64_to_u32() {
+    use rand::{RngCore, SeedableRng};
+    use rand_xorshift::XorShiftRng;
+
+    let mut rng = XorShiftRng::from_seed([0; 16]);
+    let u64_limbs: alloc::vec::Vec<u64> = (0..6).map(|_| rng.next_u64()).collect();
+    let u32_limbs = crate::fields::u64_to_u32(&u64_limbs);
+
+    let u64_le_bytes: alloc::vec::Vec<u8> = u64_limbs
+        .iter()
+        .flat_map(|limb| limb.to_le_bytes())
+        .collect();
+    let u32_le_bytes: alloc::vec::Vec<u8> = u32_limbs
+        .iter()
+        .flat_map(|limb| limb.to_le_bytes())
+        .collect();
+
+    assert_eq!(u64_le_bytes, u32_le_bytes);
 }


### PR DESCRIPTION
The code base is now on Rust 1.56 and Rust edition 2021. As per https://github.com/zcash/pasta_curves/pull/31#discussion_r824826344 the code can now be simplified. This commit is also adding a test for the u64_to_u32 function.

I've based it on `main`, but I'll happily rebase once other PRs are merged first.