### PR TITLE
Configure lazy_static to use no_std setup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ subtle = { version = "2.3", default-features = false }
 blake2b_simd = { version = "1", optional = true, default-features = false }
 
 # sqrt-table dependencies
-lazy_static = { version = "1.4.0", optional = true }
+lazy_static = { version = "1.4.0", optional = true, features = ["spin_no_std"] }
 
 # gpu dependencies
 ec-gpu = { version = "0.2.0", optional = true }


### PR DESCRIPTION
While pasta_curves is written as a [no_std](https://github.com/zcash/pasta_curves/blob/4c94f3974eaca9fcadb6ebb4240bdca7b793626b/src/lib.rs#L3) library, `lazy_static` still uses `std`, this means compiling will fail in a `no_std` environment with `sqrt-table` feature enabled.

This PR changes to use `no_std` version of `lazy_static`, which fixes the problem.