### PR TITLE
Fix an overflow bug in the square root implementation on 32-bit platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix a bug on 32-bit platforms that could cause the square root implementation
+  to return an incorrect result.
 
 ## [0.5.0] - 2022-12-06
 ### Added

--- a/src/arithmetic/fields.rs
+++ b/src/arithmetic/fields.rs
@@ -226,7 +226,7 @@ impl<F: SqrtTableHelpers> SqrtTables<F> {
 
         t_ += inv(alpha) << 24; // = t << 1
                                 // 1 == x3 * ROOT_OF_UNITY^t_
-        t_ = (t_ + 1) >> 1;
+        t_ = (((t_ as u64) + 1) >> 1) as usize;
         assert!(t_ <= 0x80000000);
 
         *uv * self.g0[t_ & 0xFF]

--- a/src/fields/fp.rs
+++ b/src/fields/fp.rs
@@ -799,6 +799,11 @@ fn test_sqrt() {
 }
 
 #[test]
+fn test_sqrt_32bit_overflow() {
+    assert!((Fp::from(5)).sqrt().is_none().unwrap_u8() == 1);
+}
+
+#[test]
 fn test_pow_by_t_minus1_over2() {
     // NB: TWO_INV is standing in as a "random" field element
     let v = (Fp::TWO_INV).pow_by_t_minus1_over2();

--- a/src/fields/fq.rs
+++ b/src/fields/fq.rs
@@ -798,6 +798,11 @@ fn test_sqrt() {
 }
 
 #[test]
+fn test_sqrt_32bit_overflow() {
+    assert!((Fq::from(5)).sqrt().is_none().unwrap_u8() == 1);
+}
+
+#[test]
 fn test_pow_by_t_minus1_over2() {
     // NB: TWO_INV is standing in as a "random" field element
     let v = (Fq::TWO_INV).pow_by_t_minus1_over2();


### PR DESCRIPTION
Fix a bug on 32-bit platforms that could cause the square root implementation to return an incorrect result.