### PR TITLE
BEAM Nif integration for Pasta Curves

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ harness = false
 required-features = ["alloc"]
 
 [dependencies]
+rustler = "0.29.1"
 ff = { version = "0.13", default-features = false }
 group = { version = "0.13", default-features = false }
 rand = { version = "0.8", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ harness = false
 required-features = ["alloc"]
 
 [dependencies]
-rustler = "0.29.1"
+rustler = { version = "0.29.1", optional = true}
 ff = { version = "0.13", default-features = false }
 group = { version = "0.13", default-features = false }
 rand = { version = "0.8", default-features = false }
@@ -74,3 +74,4 @@ sqrt-table = ["alloc", "lazy_static"]
 repr-c = []
 uninline-portable = []
 serde = ["hex", "serde_crate"]
+repr-erlang=["rustler"]

--- a/src/curves.rs
+++ b/src/curves.rs
@@ -16,6 +16,7 @@ use group::{
     Curve as _, Group as _, GroupEncoding,
 };
 use rand::RngCore;
+use rustler::NifRecord;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
 #[cfg(feature = "alloc")]
@@ -26,12 +27,15 @@ use super::{Fp, Fq};
 #[cfg(feature = "alloc")]
 use crate::arithmetic::{Coordinates, CurveAffine, CurveExt};
 
+use alloc::format;
+
 macro_rules! new_curve_impl {
     (($($privacy:tt)*), $name:ident, $name_affine:ident, $iso:ident, $base:ident, $scalar:ident,
-     $curve_id:literal, $a_raw:expr, $b_raw:expr, $curve_type:ident) => {
+     $curve_id:literal, $a_raw:expr, $b_raw:expr, $curve_type:ident, $name_string:literal, $name_affine_string:literal) => {
         /// Represents a point in the projective coordinate space.
-        #[derive(Copy, Clone, Debug)]
+        #[derive(Copy, Clone, Debug, NifRecord)]
         #[cfg_attr(feature = "repr-c", repr(C))]
+        #[tag = $name_string]
         $($privacy)* struct $name {
             x: $base,
             y: $base,
@@ -50,8 +54,9 @@ macro_rules! new_curve_impl {
 
         /// Represents a point in the affine coordinate space (or the point at
         /// infinity).
-        #[derive(Copy, Clone)]
+        #[derive(Copy, Clone, NifRecord)]
         #[cfg_attr(feature = "repr-c", repr(C))]
+        #[tag = $name_affine_string]
         $($privacy)* struct $name_affine {
             x: $base,
             y: $base,
@@ -955,7 +960,9 @@ new_curve_impl!(
     "pallas",
     [0, 0, 0, 0],
     [5, 0, 0, 0],
-    special_a0_b5
+    special_a0_b5,
+    "Ep",
+    "EpAffine"
 );
 new_curve_impl!(
     (pub),
@@ -967,7 +974,9 @@ new_curve_impl!(
     "vesta",
     [0, 0, 0, 0],
     [5, 0, 0, 0],
-    special_a0_b5
+    special_a0_b5,
+    "Eq",
+    "EqAffine"
 );
 new_curve_impl!(
     (pub(crate)),
@@ -984,7 +993,9 @@ new_curve_impl!(
         0x18354a2eb0ea8c9c,
     ],
     [1265, 0, 0, 0],
-    general
+    general,
+    "IsoEp",
+    "IsoEpAffine"
 );
 new_curve_impl!(
     (pub(crate)),
@@ -1001,7 +1012,9 @@ new_curve_impl!(
         0x267f9b2ee592271a,
     ],
     [1265, 0, 0, 0],
-    general
+    general,
+    "IsoEq",
+    "IsoEqAffine"
 );
 
 impl Ep {

--- a/src/curves.rs
+++ b/src/curves.rs
@@ -16,6 +16,7 @@ use group::{
     Curve as _, Group as _, GroupEncoding,
 };
 use rand::RngCore;
+#[cfg(feature = "repr-erlang")]
 use rustler::NifRecord;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
@@ -27,15 +28,17 @@ use super::{Fp, Fq};
 #[cfg(feature = "alloc")]
 use crate::arithmetic::{Coordinates, CurveAffine, CurveExt};
 
+#[cfg(feature = "repr-erlang")]
 use alloc::format;
 
 macro_rules! new_curve_impl {
     (($($privacy:tt)*), $name:ident, $name_affine:ident, $iso:ident, $base:ident, $scalar:ident,
      $curve_id:literal, $a_raw:expr, $b_raw:expr, $curve_type:ident, $name_string:literal, $name_affine_string:literal) => {
         /// Represents a point in the projective coordinate space.
-        #[derive(Copy, Clone, Debug, NifRecord)]
+        #[derive(Copy, Clone, Debug)]
         #[cfg_attr(feature = "repr-c", repr(C))]
-        #[tag = $name_string]
+        #[cfg_attr(feature = "repr-erlang", derive(NifRecord))]
+        #[cfg_attr(feature = "repr-erlang", tag = $name_string)]
         $($privacy)* struct $name {
             x: $base,
             y: $base,
@@ -54,9 +57,10 @@ macro_rules! new_curve_impl {
 
         /// Represents a point in the affine coordinate space (or the point at
         /// infinity).
-        #[derive(Copy, Clone, NifRecord)]
+        #[derive(Copy, Clone)]
+        #[cfg_attr(feature = "repr-erlang", derive(NifRecord))]
+        #[cfg_attr(feature = "repr-erlang", tag = $name_affine_string)]
         #[cfg_attr(feature = "repr-c", repr(C))]
-        #[tag = $name_affine_string]
         $($privacy)* struct $name_affine {
             x: $base,
             y: $base,

--- a/src/fields/fp.rs
+++ b/src/fields/fp.rs
@@ -5,6 +5,8 @@ use ff::{Field, FromUniformBytes, PrimeField, WithSmallOrderMulGroup};
 use rand::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
+use rustler::{Decoder, Encoder, Env, NifResult, Term};
+
 #[cfg(feature = "sqrt-table")]
 use lazy_static::lazy_static;
 
@@ -182,6 +184,19 @@ impl<T: ::core::borrow::Borrow<Fp>> ::core::iter::Sum<T> for Fp {
 impl<T: ::core::borrow::Borrow<Fp>> ::core::iter::Product<T> for Fp {
     fn product<I: Iterator<Item = T>>(iter: I) -> Self {
         iter.fold(Self::ONE, |acc, item| acc * item.borrow())
+    }
+}
+
+impl Encoder for Fp {
+    fn encode<'a>(&self, env: Env<'a>) -> Term<'a> {
+        (self.0[0], self.0[1], self.0[2], self.0[3]).encode(env)
+    }
+}
+
+impl<'a> Decoder<'a> for Fp {
+    fn decode(term: Term<'a>) -> NifResult<Self> {
+        let tuple: NifResult<(u64, u64, u64, u64)> = Decoder::decode(term);
+        tuple.map(|res| Fp([res.0, res.1, res.2, res.3]))
     }
 }
 

--- a/src/fields/fp.rs
+++ b/src/fields/fp.rs
@@ -5,6 +5,7 @@ use ff::{Field, FromUniformBytes, PrimeField, WithSmallOrderMulGroup};
 use rand::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
+#[cfg(feature = "repr-erlang")]
 use rustler::{Decoder, Encoder, Env, NifResult, Term};
 
 #[cfg(feature = "sqrt-table")]
@@ -187,12 +188,14 @@ impl<T: ::core::borrow::Borrow<Fp>> ::core::iter::Product<T> for Fp {
     }
 }
 
+#[cfg(feature = "repr-erlang")]
 impl Encoder for Fp {
     fn encode<'a>(&self, env: Env<'a>) -> Term<'a> {
         (self.0[0], self.0[1], self.0[2], self.0[3]).encode(env)
     }
 }
 
+#[cfg(feature = "repr-erlang")]
 impl<'a> Decoder<'a> for Fp {
     fn decode(term: Term<'a>) -> NifResult<Self> {
         let tuple: NifResult<(u64, u64, u64, u64)> = Decoder::decode(term);

--- a/src/fields/fq.rs
+++ b/src/fields/fq.rs
@@ -5,6 +5,8 @@ use ff::{Field, FromUniformBytes, PrimeField, WithSmallOrderMulGroup};
 use rand::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
+use rustler::{Decoder, Encoder, Env, NifResult, Term};
+
 #[cfg(feature = "sqrt-table")]
 use lazy_static::lazy_static;
 
@@ -100,6 +102,19 @@ impl ConditionallySelectable for Fq {
             u64::conditional_select(&a.0[2], &b.0[2], choice),
             u64::conditional_select(&a.0[3], &b.0[3], choice),
         ])
+    }
+}
+
+impl Encoder for Fq {
+    fn encode<'a>(&self, env: Env<'a>) -> Term<'a> {
+        (self.0[0], self.0[1], self.0[2], self.0[3]).encode(env)
+    }
+}
+
+impl<'a> Decoder<'a> for Fq {
+    fn decode(term: Term<'a>) -> NifResult<Self> {
+        let tuple: NifResult<(u64, u64, u64, u64)> = Decoder::decode(term);
+        tuple.map(|res| Fq([res.0, res.1, res.2, res.3]))
     }
 }
 

--- a/src/fields/fq.rs
+++ b/src/fields/fq.rs
@@ -5,6 +5,7 @@ use ff::{Field, FromUniformBytes, PrimeField, WithSmallOrderMulGroup};
 use rand::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
+#[cfg(feature = "repr-erlang")]
 use rustler::{Decoder, Encoder, Env, NifResult, Term};
 
 #[cfg(feature = "sqrt-table")]
@@ -105,12 +106,14 @@ impl ConditionallySelectable for Fq {
     }
 }
 
+#[cfg(feature = "repr-erlang")]
 impl Encoder for Fq {
     fn encode<'a>(&self, env: Env<'a>) -> Term<'a> {
         (self.0[0], self.0[1], self.0[2], self.0[3]).encode(env)
     }
 }
 
+#[cfg(feature = "repr-erlang")]
 impl<'a> Decoder<'a> for Fq {
     fn decode(term: Term<'a>) -> NifResult<Self> {
         let tuple: NifResult<(u64, u64, u64, u64)> = Decoder::decode(term);


### PR DESCRIPTION
I've added Erlang/Elixir [NIF](https://www.erlang.org/doc/tutorial/nif.html) integration into pasta curves using [rustler](https://github.com/rusterlium/rustler). The feature is feature flagged so it has no effect on the codebase when it is not in use.

Tell me if there is anything I should change, or anything more that needs to be done for this to be considered.

The CI will fail as I have not merged #68 into the topic, I can setup an integration branch with these two topics, if you want to see if CI passes or fails. 