### PR TITLE
chore: Investigating lazy reduction

### DIFF
--- a/src/arithmetic/curves.rs
+++ b/src/arithmetic/curves.rs
@@ -124,6 +124,26 @@ pub trait CurveAffine:
 
     /// Returns the curve constant $b$.
     fn b() -> Self::Base;
+
+    /// Returns the $x$-coordinate of this point directly.
+    ///
+    /// For the identity point, returns zero.
+    fn x(&self) -> Self::Base;
+
+    /// Returns the $y$-coordinate of this point directly.
+    ///
+    /// For the identity point, returns zero.
+    fn y(&self) -> Self::Base;
+
+    /// Constructs a point from $(x, y)$ without validating that the point
+    /// is on the curve. The caller must ensure the coordinates satisfy
+    /// $y^2 = x^3 + ax + b$.
+    ///
+    /// # Safety
+    ///
+    /// Using coordinates that are not on the curve will produce incorrect
+    /// results in subsequent operations.
+    fn from_xy_unchecked(x: Self::Base, y: Self::Base) -> Self;
 }
 
 /// The affine coordinates of a point on an elliptic curve.

--- a/src/curves.rs
+++ b/src/curves.rs
@@ -735,6 +735,18 @@ macro_rules! new_curve_impl {
             fn b() -> Self::Base {
                 $name::curve_constant_b()
             }
+
+            fn x(&self) -> Self::Base {
+                self.x
+            }
+
+            fn y(&self) -> Self::Base {
+                self.y
+            }
+
+            fn from_xy_unchecked(x: Self::Base, y: Self::Base) -> Self {
+                $name_affine { x, y }
+            }
         }
 
         impl Default for $name_affine {

--- a/src/fields.rs
+++ b/src/fields.rs
@@ -3,9 +3,11 @@
 
 mod fp;
 mod fq;
+mod mont_product;
 
 pub use fp::*;
 pub use fq::*;
+pub use mont_product::*;
 
 /// Converts 64-bit little-endian limbs to 32-bit little endian limbs.
 #[cfg(feature = "gpu")]

--- a/src/fields/fp.rs
+++ b/src/fields/fp.rs
@@ -433,6 +433,16 @@ impl MontgomeryRepr for Fp {
             limbs[0], limbs[1], limbs[2], limbs[3], limbs[4], limbs[5], limbs[6], limbs[7],
         )
     }
+
+    #[cfg_attr(not(feature = "uninline-portable"), inline)]
+    fn mul_unreduced(&self, rhs: &Self) -> MontProduct<Fp> {
+        Fp::mul_unreduced(self, rhs)
+    }
+
+    #[cfg_attr(not(feature = "uninline-portable"), inline)]
+    fn square_unreduced(&self) -> MontProduct<Fp> {
+        Fp::square_unreduced(self)
+    }
 }
 
 impl Fp {

--- a/src/fields/fp.rs
+++ b/src/fields/fp.rs
@@ -13,6 +13,8 @@ use ff::{FieldBits, PrimeFieldBits};
 
 use crate::arithmetic::{adc, mac, sbb, SqrtTableHelpers};
 
+use super::mont_product::{sealed, MontProduct, MontgomeryRepr};
+
 #[cfg(feature = "sqrt-table")]
 use crate::arithmetic::SqrtTables;
 
@@ -308,33 +310,11 @@ impl Fp {
     /// Squares this element.
     #[cfg_attr(not(feature = "uninline-portable"), inline)]
     pub const fn square(&self) -> Fp {
-        let (r1, carry) = mac(0, self.0[0], self.0[1], 0);
-        let (r2, carry) = mac(0, self.0[0], self.0[2], carry);
-        let (r3, r4) = mac(0, self.0[0], self.0[3], carry);
-
-        let (r3, carry) = mac(r3, self.0[1], self.0[2], 0);
-        let (r4, r5) = mac(r4, self.0[1], self.0[3], carry);
-
-        let (r5, r6) = mac(r5, self.0[2], self.0[3], 0);
-
-        let r7 = r6 >> 63;
-        let r6 = (r6 << 1) | (r5 >> 63);
-        let r5 = (r5 << 1) | (r4 >> 63);
-        let r4 = (r4 << 1) | (r3 >> 63);
-        let r3 = (r3 << 1) | (r2 >> 63);
-        let r2 = (r2 << 1) | (r1 >> 63);
-        let r1 = r1 << 1;
-
-        let (r0, carry) = mac(0, self.0[0], self.0[0], 0);
-        let (r1, carry) = adc(0, r1, carry);
-        let (r2, carry) = mac(r2, self.0[1], self.0[1], carry);
-        let (r3, carry) = adc(0, r3, carry);
-        let (r4, carry) = mac(r4, self.0[2], self.0[2], carry);
-        let (r5, carry) = adc(0, r5, carry);
-        let (r6, carry) = mac(r6, self.0[3], self.0[3], carry);
-        let (r7, _) = adc(0, r7, carry);
-
-        Fp::montgomery_reduce(r0, r1, r2, r3, r4, r5, r6, r7)
+        let u = self.square_unreduced();
+        Fp::montgomery_reduce(
+            u.limbs[0], u.limbs[1], u.limbs[2], u.limbs[3], u.limbs[4], u.limbs[5], u.limbs[6],
+            u.limbs[7],
+        )
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -388,29 +368,11 @@ impl Fp {
     /// Multiplies `rhs` by `self`, returning the result.
     #[cfg_attr(not(feature = "uninline-portable"), inline)]
     pub const fn mul(&self, rhs: &Self) -> Self {
-        // Schoolbook multiplication
-
-        let (r0, carry) = mac(0, self.0[0], rhs.0[0], 0);
-        let (r1, carry) = mac(0, self.0[0], rhs.0[1], carry);
-        let (r2, carry) = mac(0, self.0[0], rhs.0[2], carry);
-        let (r3, r4) = mac(0, self.0[0], rhs.0[3], carry);
-
-        let (r1, carry) = mac(r1, self.0[1], rhs.0[0], 0);
-        let (r2, carry) = mac(r2, self.0[1], rhs.0[1], carry);
-        let (r3, carry) = mac(r3, self.0[1], rhs.0[2], carry);
-        let (r4, r5) = mac(r4, self.0[1], rhs.0[3], carry);
-
-        let (r2, carry) = mac(r2, self.0[2], rhs.0[0], 0);
-        let (r3, carry) = mac(r3, self.0[2], rhs.0[1], carry);
-        let (r4, carry) = mac(r4, self.0[2], rhs.0[2], carry);
-        let (r5, r6) = mac(r5, self.0[2], rhs.0[3], carry);
-
-        let (r3, carry) = mac(r3, self.0[3], rhs.0[0], 0);
-        let (r4, carry) = mac(r4, self.0[3], rhs.0[1], carry);
-        let (r5, carry) = mac(r5, self.0[3], rhs.0[2], carry);
-        let (r6, r7) = mac(r6, self.0[3], rhs.0[3], carry);
-
-        Fp::montgomery_reduce(r0, r1, r2, r3, r4, r5, r6, r7)
+        let u = self.mul_unreduced(rhs);
+        Fp::montgomery_reduce(
+            u.limbs[0], u.limbs[1], u.limbs[2], u.limbs[3], u.limbs[4], u.limbs[5], u.limbs[6],
+            u.limbs[7],
+        )
     }
 
     /// Subtracts `rhs` from `self`, returning the result.
@@ -460,6 +422,82 @@ impl Fp {
         let mask = (((self.0[0] | self.0[1] | self.0[2] | self.0[3]) == 0) as u64).wrapping_sub(1);
 
         Fp([d0 & mask, d1 & mask, d2 & mask, d3 & mask])
+    }
+}
+
+impl sealed::Sealed for Fp {}
+
+impl MontgomeryRepr for Fp {
+    fn mont_reduce(limbs: [u64; 8]) -> Self {
+        Fp::montgomery_reduce(
+            limbs[0], limbs[1], limbs[2], limbs[3], limbs[4], limbs[5], limbs[6], limbs[7],
+        )
+    }
+}
+
+impl Fp {
+    /// Multiplies `rhs` by `self`, returning the unreduced 512-bit Montgomery product.
+    ///
+    /// Use [`MontProduct::reduce`] to obtain the field element. Up to
+    /// [`MontProduct::MAX_NUM_ADD`] products can be summed before reducing.
+    #[cfg_attr(not(feature = "uninline-portable"), inline)]
+    pub const fn mul_unreduced(&self, rhs: &Self) -> MontProduct<Fp> {
+        let (r0, carry) = mac(0, self.0[0], rhs.0[0], 0);
+        let (r1, carry) = mac(0, self.0[0], rhs.0[1], carry);
+        let (r2, carry) = mac(0, self.0[0], rhs.0[2], carry);
+        let (r3, r4) = mac(0, self.0[0], rhs.0[3], carry);
+
+        let (r1, carry) = mac(r1, self.0[1], rhs.0[0], 0);
+        let (r2, carry) = mac(r2, self.0[1], rhs.0[1], carry);
+        let (r3, carry) = mac(r3, self.0[1], rhs.0[2], carry);
+        let (r4, r5) = mac(r4, self.0[1], rhs.0[3], carry);
+
+        let (r2, carry) = mac(r2, self.0[2], rhs.0[0], 0);
+        let (r3, carry) = mac(r3, self.0[2], rhs.0[1], carry);
+        let (r4, carry) = mac(r4, self.0[2], rhs.0[2], carry);
+        let (r5, r6) = mac(r5, self.0[2], rhs.0[3], carry);
+
+        let (r3, carry) = mac(r3, self.0[3], rhs.0[0], 0);
+        let (r4, carry) = mac(r4, self.0[3], rhs.0[1], carry);
+        let (r5, carry) = mac(r5, self.0[3], rhs.0[2], carry);
+        let (r6, r7) = mac(r6, self.0[3], rhs.0[3], carry);
+
+        MontProduct::from_limbs([r0, r1, r2, r3, r4, r5, r6, r7])
+    }
+
+    /// Squares this element, returning the unreduced 512-bit Montgomery product.
+    ///
+    /// Use [`MontProduct::reduce`] to obtain the field element. Up to
+    /// [`MontProduct::MAX_NUM_ADD`] products can be summed before reducing.
+    #[cfg_attr(not(feature = "uninline-portable"), inline)]
+    pub const fn square_unreduced(&self) -> MontProduct<Fp> {
+        let (r1, carry) = mac(0, self.0[0], self.0[1], 0);
+        let (r2, carry) = mac(0, self.0[0], self.0[2], carry);
+        let (r3, r4) = mac(0, self.0[0], self.0[3], carry);
+
+        let (r3, carry) = mac(r3, self.0[1], self.0[2], 0);
+        let (r4, r5) = mac(r4, self.0[1], self.0[3], carry);
+
+        let (r5, r6) = mac(r5, self.0[2], self.0[3], 0);
+
+        let r7 = r6 >> 63;
+        let r6 = (r6 << 1) | (r5 >> 63);
+        let r5 = (r5 << 1) | (r4 >> 63);
+        let r4 = (r4 << 1) | (r3 >> 63);
+        let r3 = (r3 << 1) | (r2 >> 63);
+        let r2 = (r2 << 1) | (r1 >> 63);
+        let r1 = r1 << 1;
+
+        let (r0, carry) = mac(0, self.0[0], self.0[0], 0);
+        let (r1, carry) = adc(0, r1, carry);
+        let (r2, carry) = mac(r2, self.0[1], self.0[1], carry);
+        let (r3, carry) = adc(0, r3, carry);
+        let (r4, carry) = mac(r4, self.0[2], self.0[2], carry);
+        let (r5, carry) = adc(0, r5, carry);
+        let (r6, carry) = mac(r6, self.0[3], self.0[3], carry);
+        let (r7, _) = adc(0, r7, carry);
+
+        MontProduct::from_limbs([r0, r1, r2, r3, r4, r5, r6, r7])
     }
 }
 

--- a/src/fields/fq.rs
+++ b/src/fields/fq.rs
@@ -13,6 +13,8 @@ use ff::{FieldBits, PrimeFieldBits};
 
 use crate::arithmetic::{adc, mac, sbb, SqrtTableHelpers};
 
+use super::mont_product::{sealed, MontProduct, MontgomeryRepr};
+
 #[cfg(feature = "sqrt-table")]
 use crate::arithmetic::SqrtTables;
 
@@ -308,33 +310,11 @@ impl Fq {
     /// Squares this element.
     #[cfg_attr(not(feature = "uninline-portable"), inline)]
     pub const fn square(&self) -> Fq {
-        let (r1, carry) = mac(0, self.0[0], self.0[1], 0);
-        let (r2, carry) = mac(0, self.0[0], self.0[2], carry);
-        let (r3, r4) = mac(0, self.0[0], self.0[3], carry);
-
-        let (r3, carry) = mac(r3, self.0[1], self.0[2], 0);
-        let (r4, r5) = mac(r4, self.0[1], self.0[3], carry);
-
-        let (r5, r6) = mac(r5, self.0[2], self.0[3], 0);
-
-        let r7 = r6 >> 63;
-        let r6 = (r6 << 1) | (r5 >> 63);
-        let r5 = (r5 << 1) | (r4 >> 63);
-        let r4 = (r4 << 1) | (r3 >> 63);
-        let r3 = (r3 << 1) | (r2 >> 63);
-        let r2 = (r2 << 1) | (r1 >> 63);
-        let r1 = r1 << 1;
-
-        let (r0, carry) = mac(0, self.0[0], self.0[0], 0);
-        let (r1, carry) = adc(0, r1, carry);
-        let (r2, carry) = mac(r2, self.0[1], self.0[1], carry);
-        let (r3, carry) = adc(0, r3, carry);
-        let (r4, carry) = mac(r4, self.0[2], self.0[2], carry);
-        let (r5, carry) = adc(0, r5, carry);
-        let (r6, carry) = mac(r6, self.0[3], self.0[3], carry);
-        let (r7, _) = adc(0, r7, carry);
-
-        Fq::montgomery_reduce(r0, r1, r2, r3, r4, r5, r6, r7)
+        let u = self.square_unreduced();
+        Fq::montgomery_reduce(
+            u.limbs[0], u.limbs[1], u.limbs[2], u.limbs[3], u.limbs[4], u.limbs[5], u.limbs[6],
+            u.limbs[7],
+        )
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -388,29 +368,11 @@ impl Fq {
     /// Multiplies `rhs` by `self`, returning the result.
     #[cfg_attr(not(feature = "uninline-portable"), inline)]
     pub const fn mul(&self, rhs: &Self) -> Self {
-        // Schoolbook multiplication
-
-        let (r0, carry) = mac(0, self.0[0], rhs.0[0], 0);
-        let (r1, carry) = mac(0, self.0[0], rhs.0[1], carry);
-        let (r2, carry) = mac(0, self.0[0], rhs.0[2], carry);
-        let (r3, r4) = mac(0, self.0[0], rhs.0[3], carry);
-
-        let (r1, carry) = mac(r1, self.0[1], rhs.0[0], 0);
-        let (r2, carry) = mac(r2, self.0[1], rhs.0[1], carry);
-        let (r3, carry) = mac(r3, self.0[1], rhs.0[2], carry);
-        let (r4, r5) = mac(r4, self.0[1], rhs.0[3], carry);
-
-        let (r2, carry) = mac(r2, self.0[2], rhs.0[0], 0);
-        let (r3, carry) = mac(r3, self.0[2], rhs.0[1], carry);
-        let (r4, carry) = mac(r4, self.0[2], rhs.0[2], carry);
-        let (r5, r6) = mac(r5, self.0[2], rhs.0[3], carry);
-
-        let (r3, carry) = mac(r3, self.0[3], rhs.0[0], 0);
-        let (r4, carry) = mac(r4, self.0[3], rhs.0[1], carry);
-        let (r5, carry) = mac(r5, self.0[3], rhs.0[2], carry);
-        let (r6, r7) = mac(r6, self.0[3], rhs.0[3], carry);
-
-        Fq::montgomery_reduce(r0, r1, r2, r3, r4, r5, r6, r7)
+        let u = self.mul_unreduced(rhs);
+        Fq::montgomery_reduce(
+            u.limbs[0], u.limbs[1], u.limbs[2], u.limbs[3], u.limbs[4], u.limbs[5], u.limbs[6],
+            u.limbs[7],
+        )
     }
 
     /// Subtracts `rhs` from `self`, returning the result.
@@ -460,6 +422,82 @@ impl Fq {
         let mask = (((self.0[0] | self.0[1] | self.0[2] | self.0[3]) == 0) as u64).wrapping_sub(1);
 
         Fq([d0 & mask, d1 & mask, d2 & mask, d3 & mask])
+    }
+}
+
+impl sealed::Sealed for Fq {}
+
+impl MontgomeryRepr for Fq {
+    fn mont_reduce(limbs: [u64; 8]) -> Self {
+        Fq::montgomery_reduce(
+            limbs[0], limbs[1], limbs[2], limbs[3], limbs[4], limbs[5], limbs[6], limbs[7],
+        )
+    }
+}
+
+impl Fq {
+    /// Multiplies `rhs` by `self`, returning the unreduced 512-bit Montgomery product.
+    ///
+    /// Use [`MontProduct::reduce`] to obtain the field element. Up to
+    /// [`MontProduct::MAX_NUM_ADD`] products can be summed before reducing.
+    #[cfg_attr(not(feature = "uninline-portable"), inline)]
+    pub const fn mul_unreduced(&self, rhs: &Self) -> MontProduct<Fq> {
+        let (r0, carry) = mac(0, self.0[0], rhs.0[0], 0);
+        let (r1, carry) = mac(0, self.0[0], rhs.0[1], carry);
+        let (r2, carry) = mac(0, self.0[0], rhs.0[2], carry);
+        let (r3, r4) = mac(0, self.0[0], rhs.0[3], carry);
+
+        let (r1, carry) = mac(r1, self.0[1], rhs.0[0], 0);
+        let (r2, carry) = mac(r2, self.0[1], rhs.0[1], carry);
+        let (r3, carry) = mac(r3, self.0[1], rhs.0[2], carry);
+        let (r4, r5) = mac(r4, self.0[1], rhs.0[3], carry);
+
+        let (r2, carry) = mac(r2, self.0[2], rhs.0[0], 0);
+        let (r3, carry) = mac(r3, self.0[2], rhs.0[1], carry);
+        let (r4, carry) = mac(r4, self.0[2], rhs.0[2], carry);
+        let (r5, r6) = mac(r5, self.0[2], rhs.0[3], carry);
+
+        let (r3, carry) = mac(r3, self.0[3], rhs.0[0], 0);
+        let (r4, carry) = mac(r4, self.0[3], rhs.0[1], carry);
+        let (r5, carry) = mac(r5, self.0[3], rhs.0[2], carry);
+        let (r6, r7) = mac(r6, self.0[3], rhs.0[3], carry);
+
+        MontProduct::from_limbs([r0, r1, r2, r3, r4, r5, r6, r7])
+    }
+
+    /// Squares this element, returning the unreduced 512-bit Montgomery product.
+    ///
+    /// Use [`MontProduct::reduce`] to obtain the field element. Up to
+    /// [`MontProduct::MAX_NUM_ADD`] products can be summed before reducing.
+    #[cfg_attr(not(feature = "uninline-portable"), inline)]
+    pub const fn square_unreduced(&self) -> MontProduct<Fq> {
+        let (r1, carry) = mac(0, self.0[0], self.0[1], 0);
+        let (r2, carry) = mac(0, self.0[0], self.0[2], carry);
+        let (r3, r4) = mac(0, self.0[0], self.0[3], carry);
+
+        let (r3, carry) = mac(r3, self.0[1], self.0[2], 0);
+        let (r4, r5) = mac(r4, self.0[1], self.0[3], carry);
+
+        let (r5, r6) = mac(r5, self.0[2], self.0[3], 0);
+
+        let r7 = r6 >> 63;
+        let r6 = (r6 << 1) | (r5 >> 63);
+        let r5 = (r5 << 1) | (r4 >> 63);
+        let r4 = (r4 << 1) | (r3 >> 63);
+        let r3 = (r3 << 1) | (r2 >> 63);
+        let r2 = (r2 << 1) | (r1 >> 63);
+        let r1 = r1 << 1;
+
+        let (r0, carry) = mac(0, self.0[0], self.0[0], 0);
+        let (r1, carry) = adc(0, r1, carry);
+        let (r2, carry) = mac(r2, self.0[1], self.0[1], carry);
+        let (r3, carry) = adc(0, r3, carry);
+        let (r4, carry) = mac(r4, self.0[2], self.0[2], carry);
+        let (r5, carry) = adc(0, r5, carry);
+        let (r6, carry) = mac(r6, self.0[3], self.0[3], carry);
+        let (r7, _) = adc(0, r7, carry);
+
+        MontProduct::from_limbs([r0, r1, r2, r3, r4, r5, r6, r7])
     }
 }
 

--- a/src/fields/fq.rs
+++ b/src/fields/fq.rs
@@ -433,6 +433,16 @@ impl MontgomeryRepr for Fq {
             limbs[0], limbs[1], limbs[2], limbs[3], limbs[4], limbs[5], limbs[6], limbs[7],
         )
     }
+
+    #[cfg_attr(not(feature = "uninline-portable"), inline)]
+    fn mul_unreduced(&self, rhs: &Self) -> MontProduct<Fq> {
+        Fq::mul_unreduced(self, rhs)
+    }
+
+    #[cfg_attr(not(feature = "uninline-portable"), inline)]
+    fn square_unreduced(&self) -> MontProduct<Fq> {
+        Fq::square_unreduced(self)
+    }
 }
 
 impl Fq {

--- a/src/fields/mont_product.rs
+++ b/src/fields/mont_product.rs
@@ -10,6 +10,12 @@ pub(super) mod sealed {
 pub trait MontgomeryRepr: sealed::Sealed + Sized {
     /// Performs Montgomery reduction on the given 512-bit limbs.
     fn mont_reduce(limbs: [u64; 8]) -> Self;
+
+    /// Multiplies `rhs` by `self`, returning the unreduced 512-bit Montgomery product.
+    fn mul_unreduced(&self, rhs: &Self) -> MontProduct<Self>;
+
+    /// Squares this element, returning the unreduced 512-bit Montgomery product.
+    fn square_unreduced(&self) -> MontProduct<Self>;
 }
 
 /// An unreduced 512-bit Montgomery product over field `F`.
@@ -32,6 +38,17 @@ pub struct MontProduct<F: MontgomeryRepr> {
 }
 
 impl<F: MontgomeryRepr> MontProduct<F> {
+    /// Maximum number of unreduced products that can be safely accumulated
+    /// via addition without overflow. See the [struct-level documentation](Self)
+    /// for the overflow bound derivation.
+    pub const MAX_NUM_ADD: usize = 4;
+
+    /// The zero (additive identity) unreduced product.
+    pub const ZERO: Self = MontProduct {
+        limbs: [0; 8],
+        _marker: core::marker::PhantomData,
+    };
+
     /// Creates a `MontProduct` from raw 512-bit limbs.
     pub(crate) const fn from_limbs(limbs: [u64; 8]) -> Self {
         MontProduct {
@@ -40,21 +57,10 @@ impl<F: MontgomeryRepr> MontProduct<F> {
         }
     }
 
-    /// The zero (additive identity) unreduced product.
-    pub const ZERO: Self = MontProduct {
-        limbs: [0; 8],
-        _marker: core::marker::PhantomData,
-    };
-
     /// Performs Montgomery reduction, returning the field element.
     pub fn reduce(self) -> F {
         F::mont_reduce(self.limbs)
     }
-
-    /// Maximum number of unreduced products that can be safely accumulated
-    /// via addition without overflow. See the [struct-level documentation](Self)
-    /// for the overflow bound derivation.
-    pub const MAX_NUM_ADD: usize = 4;
 }
 
 impl<'a, 'b, F: MontgomeryRepr> Add<&'b MontProduct<F>> for &'a MontProduct<F> {

--- a/src/fields/mont_product.rs
+++ b/src/fields/mont_product.rs
@@ -1,0 +1,213 @@
+use core::ops::{Add, AddAssign};
+
+use crate::arithmetic::adc;
+
+pub(super) mod sealed {
+    pub trait Sealed {}
+}
+
+/// A trait for fields with a Montgomery representation, enabling deferred reduction.
+pub trait MontgomeryRepr: sealed::Sealed + Sized {
+    /// Performs Montgomery reduction on the given 512-bit limbs.
+    fn mont_reduce(limbs: [u64; 8]) -> Self;
+}
+
+/// An unreduced 512-bit Montgomery product over field `F`.
+///
+/// This stores the raw result of a schoolbook multiplication before Montgomery
+/// reduction. Multiple `MontProduct` values can be accumulated via [`Add`] before
+/// performing a single expensive [`reduce`](MontProduct::reduce) call.
+///
+/// # Overflow safety
+///
+/// Each product of two reduced field elements fits in 510 bits (since both
+/// inputs are less than the field modulus $m < 2^{255}$). The 512-bit
+/// representation provides 2 bits of headroom, allowing up to
+/// [`MAX_NUM_ADD`](MontProduct::MAX_NUM_ADD) terms to be summed without
+/// overflow.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct MontProduct<F: MontgomeryRepr> {
+    pub(crate) limbs: [u64; 8],
+    _marker: core::marker::PhantomData<F>,
+}
+
+impl<F: MontgomeryRepr> MontProduct<F> {
+    /// Creates a `MontProduct` from raw 512-bit limbs.
+    pub(crate) const fn from_limbs(limbs: [u64; 8]) -> Self {
+        MontProduct {
+            limbs,
+            _marker: core::marker::PhantomData,
+        }
+    }
+
+    /// The zero (additive identity) unreduced product.
+    pub const ZERO: Self = MontProduct {
+        limbs: [0; 8],
+        _marker: core::marker::PhantomData,
+    };
+
+    /// Performs Montgomery reduction, returning the field element.
+    pub fn reduce(self) -> F {
+        F::mont_reduce(self.limbs)
+    }
+
+    /// Maximum number of unreduced products that can be safely accumulated
+    /// via addition without overflow. See the [struct-level documentation](Self)
+    /// for the overflow bound derivation.
+    pub const MAX_NUM_ADD: usize = 4;
+}
+
+impl<'a, 'b, F: MontgomeryRepr> Add<&'b MontProduct<F>> for &'a MontProduct<F> {
+    type Output = MontProduct<F>;
+
+    #[inline]
+    fn add(self, rhs: &'b MontProduct<F>) -> MontProduct<F> {
+        let (d0, carry) = adc(self.limbs[0], rhs.limbs[0], 0);
+        let (d1, carry) = adc(self.limbs[1], rhs.limbs[1], carry);
+        let (d2, carry) = adc(self.limbs[2], rhs.limbs[2], carry);
+        let (d3, carry) = adc(self.limbs[3], rhs.limbs[3], carry);
+        let (d4, carry) = adc(self.limbs[4], rhs.limbs[4], carry);
+        let (d5, carry) = adc(self.limbs[5], rhs.limbs[5], carry);
+        let (d6, carry) = adc(self.limbs[6], rhs.limbs[6], carry);
+        let (d7, carry) = adc(self.limbs[7], rhs.limbs[7], carry);
+        debug_assert!(carry == 0, "MontProduct addition overflow");
+        MontProduct::from_limbs([d0, d1, d2, d3, d4, d5, d6, d7])
+    }
+}
+
+impl<'b, F: MontgomeryRepr> Add<&'b MontProduct<F>> for MontProduct<F> {
+    type Output = MontProduct<F>;
+
+    #[inline]
+    fn add(self, rhs: &'b MontProduct<F>) -> MontProduct<F> {
+        &self + rhs
+    }
+}
+
+impl<'a, F: MontgomeryRepr> Add<MontProduct<F>> for &'a MontProduct<F> {
+    type Output = MontProduct<F>;
+
+    #[inline]
+    fn add(self, rhs: MontProduct<F>) -> MontProduct<F> {
+        self + &rhs
+    }
+}
+
+impl<F: MontgomeryRepr> Add<MontProduct<F>> for MontProduct<F> {
+    type Output = MontProduct<F>;
+
+    #[inline]
+    fn add(self, rhs: MontProduct<F>) -> MontProduct<F> {
+        &self + &rhs
+    }
+}
+
+impl<F: MontgomeryRepr> AddAssign<MontProduct<F>> for MontProduct<F> {
+    #[inline]
+    fn add_assign(&mut self, rhs: MontProduct<F>) {
+        *self = &*self + &rhs;
+    }
+}
+
+impl<'b, F: MontgomeryRepr> AddAssign<&'b MontProduct<F>> for MontProduct<F> {
+    #[inline]
+    fn add_assign(&mut self, rhs: &'b MontProduct<F>) {
+        *self = &*self + rhs;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::MontProduct;
+    use crate::{Fp, Fq};
+    use ff::Field;
+    use rand::SeedableRng;
+    use rand_xorshift::XorShiftRng;
+    use std::vec::Vec;
+
+    const SEED: [u8; 16] = [
+        0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ];
+
+    macro_rules! mont_product_tests {
+        ($F:ty, $mod:ident) => {
+            mod $mod {
+                use super::*;
+
+                #[test]
+                fn mul_unreduced_roundtrip() {
+                    let mut rng = XorShiftRng::from_seed(SEED);
+                    for _ in 0..100 {
+                        let a = <$F>::random(&mut rng);
+                        let b = <$F>::random(&mut rng);
+                        assert_eq!(a.mul_unreduced(&b).reduce(), a * b);
+                    }
+                }
+
+                #[test]
+                fn square_unreduced_roundtrip() {
+                    let mut rng = XorShiftRng::from_seed(SEED);
+                    for _ in 0..100 {
+                        let a = <$F>::random(&mut rng);
+                        assert_eq!(a.square_unreduced().reduce(), a.square());
+                    }
+                }
+
+                #[test]
+                fn inner_product() {
+                    let mut rng = XorShiftRng::from_seed(SEED);
+                    let n = MontProduct::<$F>::MAX_NUM_ADD;
+                    let a: Vec<$F> = (0..n).map(|_| <$F>::random(&mut rng)).collect();
+                    let b: Vec<$F> = (0..n).map(|_| <$F>::random(&mut rng)).collect();
+
+                    let eager: $F = a.iter().zip(b.iter()).map(|(x, y)| *x * *y).sum();
+
+                    let lazy = a
+                        .iter()
+                        .zip(b.iter())
+                        .fold(MontProduct::<$F>::ZERO, |acc, (x, y)| {
+                            acc + x.mul_unreduced(y)
+                        })
+                        .reduce();
+
+                    assert_eq!(eager, lazy);
+                }
+
+                #[test]
+                fn long_inner_product_chunked() {
+                    let mut rng = XorShiftRng::from_seed(SEED);
+                    let n = MontProduct::<$F>::MAX_NUM_ADD;
+                    let len = 4 * n;
+                    let a: Vec<$F> = (0..len).map(|_| <$F>::random(&mut rng)).collect();
+                    let b: Vec<$F> = (0..len).map(|_| <$F>::random(&mut rng)).collect();
+
+                    let eager: $F = a.iter().zip(b.iter()).map(|(x, y)| *x * *y).sum();
+
+                    let lazy: $F = a
+                        .chunks(n)
+                        .zip(b.chunks(n))
+                        .map(|(ac, bc)| {
+                            ac.iter()
+                                .zip(bc.iter())
+                                .fold(MontProduct::<$F>::ZERO, |acc, (x, y)| {
+                                    acc + x.mul_unreduced(y)
+                                })
+                                .reduce()
+                        })
+                        .sum();
+
+                    assert_eq!(eager, lazy);
+                }
+
+                #[test]
+                fn zero() {
+                    assert_eq!(MontProduct::<$F>::ZERO.reduce(), <$F>::zero());
+                }
+            }
+        };
+    }
+
+    mont_product_tests!(Fp, fp);
+    mont_product_tests!(Fq, fq);
+}

--- a/src/fields/mont_product.rs
+++ b/src/fields/mont_product.rs
@@ -1,5 +1,7 @@
 use core::ops::{Add, AddAssign};
 
+use ff::Field;
+
 use crate::arithmetic::adc;
 
 pub(super) mod sealed {
@@ -7,7 +9,7 @@ pub(super) mod sealed {
 }
 
 /// A trait for fields with a Montgomery representation, enabling deferred reduction.
-pub trait MontgomeryRepr: sealed::Sealed + Sized {
+pub trait MontgomeryRepr: sealed::Sealed + Field {
     /// Performs Montgomery reduction on the given 512-bit limbs.
     fn mont_reduce(limbs: [u64; 8]) -> Self;
 
@@ -16,6 +18,30 @@ pub trait MontgomeryRepr: sealed::Sealed + Sized {
 
     /// Squares this element, returning the unreduced 512-bit Montgomery product.
     fn square_unreduced(&self) -> MontProduct<Self>;
+
+    /// Computes the inner product of two slices, using deferred Montgomery
+    /// reduction internally.
+    ///
+    /// Accumulates unreduced products and reduces only when the 512-bit
+    /// accumulator's headroom is exhausted, minimizing the number of
+    /// expensive Montgomery reductions.
+    ///
+    /// If the slices have different lengths, the extra elements of the longer
+    /// slice are ignored.
+    fn inner_product(a: &[Self], b: &[Self]) -> Self {
+        let mut total = Self::ZERO;
+        let mut acc = MontProduct::<Self>::ZERO;
+
+        for (x, y) in a.iter().zip(b.iter()) {
+            acc += x.mul_unreduced(y);
+            if acc.needs_reduction() {
+                total = total + acc.reduce();
+                acc = MontProduct::<Self>::ZERO;
+            }
+        }
+
+        total + acc.reduce()
+    }
 }
 
 /// An unreduced 512-bit Montgomery product over field `F`.
@@ -60,6 +86,15 @@ impl<F: MontgomeryRepr> MontProduct<F> {
     /// Performs Montgomery reduction, returning the field element.
     pub fn reduce(self) -> F {
         F::mont_reduce(self.limbs)
+    }
+
+    /// Returns `true` if the accumulator's headroom is exhausted and a
+    /// [`reduce`](Self::reduce) is needed before further accumulation.
+    ///
+    /// A single product fits in 510 bits, so the top 2 bits of the
+    /// 512-bit representation serve as overflow indicators.
+    fn needs_reduction(&self) -> bool {
+        self.limbs[7] >> 62 != 0
     }
 }
 
@@ -161,47 +196,28 @@ mod tests {
                 }
 
                 #[test]
-                fn inner_product() {
+                fn inner_product_small() {
+                    use super::super::MontgomeryRepr;
                     let mut rng = XorShiftRng::from_seed(SEED);
-                    let n = MontProduct::<$F>::MAX_NUM_ADD;
-                    let a: Vec<$F> = (0..n).map(|_| <$F>::random(&mut rng)).collect();
-                    let b: Vec<$F> = (0..n).map(|_| <$F>::random(&mut rng)).collect();
+                    let a: Vec<$F> = (0..4).map(|_| <$F>::random(&mut rng)).collect();
+                    let b: Vec<$F> = (0..4).map(|_| <$F>::random(&mut rng)).collect();
 
                     let eager: $F = a.iter().zip(b.iter()).map(|(x, y)| *x * *y).sum();
-
-                    let lazy = a
-                        .iter()
-                        .zip(b.iter())
-                        .fold(MontProduct::<$F>::ZERO, |acc, (x, y)| {
-                            acc + x.mul_unreduced(y)
-                        })
-                        .reduce();
+                    let lazy = <$F>::inner_product(&a, &b);
 
                     assert_eq!(eager, lazy);
                 }
 
                 #[test]
-                fn long_inner_product_chunked() {
+                fn inner_product_large() {
+                    use super::super::MontgomeryRepr;
                     let mut rng = XorShiftRng::from_seed(SEED);
-                    let n = MontProduct::<$F>::MAX_NUM_ADD;
-                    let len = 4 * n;
+                    let len = 100;
                     let a: Vec<$F> = (0..len).map(|_| <$F>::random(&mut rng)).collect();
                     let b: Vec<$F> = (0..len).map(|_| <$F>::random(&mut rng)).collect();
 
                     let eager: $F = a.iter().zip(b.iter()).map(|(x, y)| *x * *y).sum();
-
-                    let lazy: $F = a
-                        .chunks(n)
-                        .zip(b.chunks(n))
-                        .map(|(ac, bc)| {
-                            ac.iter()
-                                .zip(bc.iter())
-                                .fold(MontProduct::<$F>::ZERO, |acc, (x, y)| {
-                                    acc + x.mul_unreduced(y)
-                                })
-                                .reduce()
-                        })
-                        .sum();
+                    let lazy = <$F>::inner_product(&a, &b);
 
                     assert_eq!(eager, lazy);
                 }

--- a/src/fields/mont_product.rs
+++ b/src/fields/mont_product.rs
@@ -35,7 +35,7 @@ pub trait MontgomeryRepr: sealed::Sealed + Field {
         for (x, y) in a.iter().zip(b.iter()) {
             acc += x.mul_unreduced(y);
             if acc.needs_reduction() {
-                total = total + acc.reduce();
+                total += acc.reduce();
                 acc = MontProduct::<Self>::ZERO;
             }
         }

--- a/src/fields/mont_product.rs
+++ b/src/fields/mont_product.rs
@@ -171,8 +171,16 @@ mod tests {
         0xe5,
     ];
 
+    fn fp_from_limbs(limbs: [u64; 4]) -> Fp {
+        Fp(limbs)
+    }
+
+    fn fq_from_limbs(limbs: [u64; 4]) -> Fq {
+        Fq(limbs)
+    }
+
     macro_rules! mont_product_tests {
-        ($F:ty, $mod:ident) => {
+        ($F:ty, $mod:ident, $from_limbs:ident, $a_limbs:expr, $b_limbs:expr) => {
             mod $mod {
                 use super::*;
 
@@ -226,10 +234,81 @@ mod tests {
                 fn zero() {
                     assert_eq!(MontProduct::<$F>::ZERO.reduce(), <$F>::zero());
                 }
+
+                /// Exercises the `needs_reduction` overflow bug.
+                ///
+                /// `needs_reduction` checks `limbs[7] >> 62 != 0`, triggering
+                /// at 2^510. But `R * p > 2^510` by only ~2^353, so when
+                /// products have top limbs slightly below `>> 62`'s per-product
+                /// threshold, 5 products can accumulate before the check fires.
+                /// At that point the accumulator exceeds `R * p`, and
+                /// `montgomery_reduce` (which does a single conditional
+                /// subtraction) returns a non-canonical result off by `p`.
+                #[test]
+                fn inner_product_needs_reduction_overflow() {
+                    use super::super::MontgomeryRepr;
+
+                    // These elements have raw Montgomery limbs with top limb
+                    // ~0x3F, so each product has limbs[7] ~0x0F. This means
+                    // needs_reduction stays false for the first 4 products and
+                    // only fires after the 5th — by which point the 512-bit
+                    // accumulator has overflowed R * p.
+                    let a = $from_limbs($a_limbs);
+                    let b = $from_limbs($b_limbs);
+
+                    let a_arr = [a; 100];
+                    let b_arr = [b; 100];
+
+                    let eager: $F = a_arr.iter().zip(b_arr.iter()).map(|(x, y)| *x * *y).sum();
+                    let lazy = <$F>::inner_product(&a_arr, &b_arr);
+
+                    // Note: Fp's Debug uses to_repr() which canonicalizes,
+                    // so both sides print identically even when limbs differ.
+                    // Compare the raw Montgomery limbs directly.
+                    assert_eq!(
+                        eager, lazy,
+                        "inner_product returned non-canonical result \
+                         (limbs differ by a multiple of the modulus)"
+                    );
+                }
             }
         };
     }
 
-    mont_product_tests!(Fp, fp);
-    mont_product_tests!(Fq, fq);
+    mont_product_tests!(
+        Fp,
+        fp,
+        fp_from_limbs,
+        // Montgomery limbs with top limb ~0x3F, found by searching for pairs whose
+        // product accumulates 5 times before needs_reduction triggers.
+        [
+            0x0361524c2cc0f859u64,
+            0xae68690a78bc7175,
+            0xe66cd36e68ef8f5f,
+            0x3fa6524a713b7e05
+        ],
+        [
+            0x637e0edc5b6e4ae7u64,
+            0xa859890cd670f668,
+            0x27460f22403d1f83,
+            0x3f6208144fbaecc0
+        ]
+    );
+    mont_product_tests!(
+        Fq,
+        fq,
+        fq_from_limbs,
+        [
+            0x31d0b6640589f877u64,
+            0xf87f43fdf6062541,
+            0xb7d6467b2f5a522a,
+            0x3eb025240950fd13
+        ],
+        [
+            0xba26d85135e8579au64,
+            0x0fa34266ccfdba9b,
+            0xade9b2b4efdd35f8,
+            0x3caaf0e81fb797fa
+        ]
+    );
 }


### PR DESCRIPTION
Builds on https://github.com/zcash/pasta_curves/pull/87. See last commit (https://github.com/zcash/pasta_curves/pull/88/changes/ce5e24ceaeb012868d6f2b8adc278d5097b2f3c1) for a regression test that exercises a bug in `needs_reduction`. cc @ebfull, @alxiong.

I was particularly interested in understanding the `needs_reduction` heuristic since it seemed like the crux of the logic that reduction deferral relies on. 

The way I was internalizing it: montgomery reduction will give a correct result when the input is below R * p, and for pasta curves, R * p = 2^256 * p, where p is slightly above 2^254, so that product sits slightly above 2^510. That makes sense to me. In that context, there’s basically two values of interest here: (1) a **reduction trigger threshold**: when accumulator is >= 2^510, and (2) the **safe limit**: R * p = 2^510 + some slack (below which the accumulator must be when reduce is called). There’s an observation here that the trigger is close to the safe limit and there's little headroom. How can we exploit that?

Well basically, we've defined a threshold where you need to perform a montgomery reduction. The actual safe limit is slightly above that threshold, so there's a tiny gap there, and one extra product can presumably happen in that gap before reduction is required. Specifically, the threshold fires at 2^510, and when the accumulator is just below 2^510, one more product can land that exceeds both the threshold and safe limit in the _same_ step. By the time the reduction check fires, the accumulator has _already_ exceed R * p. The reduction fires too late (after the accumulator has already exceeded the safe limit), so the internal limbs shift by some factor of the field modulus.

The side-effect here, as demonstrated below, is you can construct tests where the lazy reduction via `inner_product` doesn’t equal the eager reduction per mul (the internal limbs can differ by some multiple of p). The fix would be to lower the trigger to 2^509 to create more space between the trigger and the safe limit. Another idea: instead of an explicit bit-level heuristic threshold, we can have a simple counter tracking exactly how many products have accumulated and reduce every 3–4 products. Rough math: floor(R/p) = floor(2^256 / p) = 3, so `MAX_UNREDUCED` = 3 means 3 * (p-1)^2 < R * p (no gap between threshold and safe limit). 

**Update:** we discussed OOB an alternatvie approach that would emulate Plonky3's [monty_reduce_u128](https://github.com/Plonky3/Plonky3/blob/main/monty-31/src/utils.rs#L163C21-L163C38) impl in their monty-31 crate. This approach would add an extra limb for accumulating products, and then doing a cheaper partial reduce (subtraction) + full montgomery reduce (full reduction costs ~1 mul) only once at the end instead of say every X muls. 

---------

<img width="912" height="314" alt="Screenshot 2026-03-18 at 11 49 41 AM" src="https://github.com/user-attachments/assets/b6198611-a812-440a-a952-19db66c3549f" />

