### PR TITLE
Add batched same-scalar multiplication hook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,21 @@ jobs:
       - name: Verify working directory is clean
         run: git diff --exit-code
 
+  test-alloc-fallback:
+    name: Test alloc without GLV
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run tests
+        run: >
+          cargo test
+          --verbose
+          --release
+          --no-default-features
+          --features alloc
+      - name: Verify working directory is clean
+        run: git diff --exit-code
+
   no-std:
     name: Check no-std target ${{ matrix.target }}
     runs-on: ubuntu-latest
@@ -123,6 +138,7 @@ jobs:
     needs:
       - test
       - test-32-bit
+      - test-alloc-fallback
       - no-std
       - bitrot
     # `always()` is load-bearing: without it this job is skipped when a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Added
+- `CurveExt::batch_mul_same_scalar_vartime`, for component-wise
+  multiplication of affine points by the same public scalar. Pallas and Vesta
+  use batched GLV multiplication when the `glv` feature is enabled.
+
 ## [0.5.2] - 2026-07-23
 ### Added
 - `pasta_curves::deferred` module, behind the new `deferred` feature flag. This

--- a/benches/glv.rs
+++ b/benches/glv.rs
@@ -1,10 +1,24 @@
 //! Benchmarks for GLV scalar multiplication.
 
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 
 use ff::Field;
 use pasta_curves::glv::{Decomposed, GlvParams, Table};
 use pasta_curves::{pallas, vesta};
+use rand::SeedableRng;
+use rand_xorshift::XorShiftRng;
+
+// A k = 13 Halo generator collapse calls batches from 2^12 down to 2^0.
+const SAME_SCALAR_BATCH_SIZES: [usize; 13] =
+    [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096];
+const SAME_SCALAR_CORPUS_SIZE: usize = 8;
+
+fn same_scalar_corpus<C: GlvParams>() -> Vec<C::ScalarExt> {
+    let mut rng = XorShiftRng::from_seed([0x42; 16]);
+    (0..SAME_SCALAR_CORPUS_SIZE)
+        .map(|_| C::ScalarExt::random(&mut rng))
+        .collect()
+}
 
 fn criterion_benchmark(c: &mut Criterion) {
     glv_bench::<pallas::Point>(c, "Pallas");
@@ -38,6 +52,43 @@ fn glv_bench<C: GlvParams>(c: &mut Criterion, name: &str) {
         b.iter(|| table.mul_decomposed(&decomposed));
     });
 
+    group.finish();
+
+    let mut group = c.benchmark_group(format!("{name}/same-scalar batch"));
+    group.sample_size(10);
+    // This measures the multiplication kernel. The caller's addition and
+    // final batch normalization are common to both implementations.
+    let scalars = same_scalar_corpus::<C>();
+    for size in SAME_SCALAR_BATCH_SIZES {
+        group.throughput(Throughput::Elements((size * scalars.len()) as u64));
+        let points: Vec<C::AffineExt> = (0..size)
+            .map(|i| C::AffineExt::from(C::generator() * (k + C::ScalarExt::from(i as u64 + 1))))
+            .collect();
+        let mut output = vec![C::identity(); size];
+
+        group.bench_with_input(BenchmarkId::new("native loop", size), &size, |b, _| {
+            b.iter(|| {
+                let points = black_box(points.as_slice());
+                let scalars = black_box(scalars.as_slice());
+                for scalar in scalars {
+                    for (point, output) in points.iter().zip(output.iter_mut()) {
+                        *output = *point * scalar;
+                    }
+                    black_box(output.as_slice());
+                }
+            });
+        });
+        group.bench_with_input(BenchmarkId::new("batch hook", size), &size, |b, _| {
+            b.iter(|| {
+                let points = black_box(points.as_slice());
+                let scalars = black_box(scalars.as_slice());
+                for scalar in scalars {
+                    C::batch_mul_same_scalar_vartime(points, scalar, &mut output);
+                    black_box(output.as_slice());
+                }
+            });
+        });
+    }
     group.finish();
 }
 

--- a/src/arithmetic/curves.rs
+++ b/src/arithmetic/curves.rs
@@ -80,6 +80,33 @@ pub trait CurveExt:
     /// Obtains a point given Jacobian coordinates $X : Y : Z$, failing
     /// if the coordinates are not on the curve.
     fn new_jacobian(x: Self::Base, y: Self::Base, z: Self::Base) -> CtOption<Self>;
+
+    /// Multiplies every point in `points` by the same `scalar`, writing the
+    /// corresponding products to `output`.
+    ///
+    /// The default implementation performs the native scalar multiplication
+    /// independently for each point. Implementations may batch work shared by
+    /// these component-wise scalar multiplications.
+    ///
+    /// # Security
+    ///
+    /// This method may run in variable time with respect to `scalar`. **The
+    /// scalar must be public.** Do not use this method with secret scalar
+    /// material.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `points` and `output` have different lengths.
+    fn batch_mul_same_scalar_vartime(
+        points: &[Self::AffineExt],
+        scalar: &Self::ScalarExt,
+        output: &mut [Self],
+    ) {
+        assert_eq!(points.len(), output.len());
+        for (point, output) in points.iter().zip(output.iter_mut()) {
+            *output = *point * scalar;
+        }
+    }
 }
 
 /// This trait is the affine counterpart to `Curve` and is used for
@@ -178,5 +205,78 @@ impl<C: CurveAffine> ConditionallySelectable for Coordinates<C> {
             x: C::Base::conditional_select(&a.x, &b.x, choice),
             y: C::Base::conditional_select(&a.y, &b.y, choice),
         }
+    }
+}
+
+#[cfg(all(test, feature = "alloc"))]
+mod tests {
+    use super::*;
+    use crate::{pallas, vesta};
+    use ff::{Field, PrimeField, WithSmallOrderMulGroup};
+
+    const BATCH_SIZES: [usize; 15] = [0, 1, 2, 3, 7, 8, 15, 16, 17, 63, 64, 65, 127, 128, 129];
+
+    fn batch_mul_same_scalar_matches_native<C: CurveExt>() {
+        let full_width = (C::ScalarExt::from(0x9E37_79B9_7F4A_7C15u64).square()
+            + C::ScalarExt::from(0x0123_4567_89AB_CDEFu64))
+        .square();
+        let scalars = [
+            C::ScalarExt::ZERO,
+            C::ScalarExt::ONE,
+            -C::ScalarExt::ONE,
+            C::ScalarExt::from(2),
+            C::ScalarExt::ZETA,
+            -C::ScalarExt::ZETA,
+            C::ScalarExt::ZETA + C::ScalarExt::ONE,
+            C::ScalarExt::from(u64::MAX),
+            C::ScalarExt::from_u128((1u128 << 127) - 1),
+            C::ScalarExt::from_u128(1u128 << 127),
+            full_width,
+        ];
+
+        for size in BATCH_SIZES {
+            let projective: alloc::vec::Vec<C> = (0..size)
+                .map(|i| {
+                    if size > 2 && i == size / 2 {
+                        C::identity()
+                    } else {
+                        C::generator()
+                            * (C::ScalarExt::from(i as u64 + 1).square()
+                                + C::ScalarExt::from(0xDEAD_BEEFu64))
+                    }
+                })
+                .collect();
+            let points: alloc::vec::Vec<C::AffineExt> =
+                projective.iter().copied().map(C::AffineExt::from).collect();
+            let mut output = alloc::vec![C::identity(); size];
+
+            for scalar in scalars {
+                C::batch_mul_same_scalar_vartime(&points, &scalar, &mut output);
+                for ((point, output), expected) in
+                    points.iter().zip(output.iter()).zip(projective.iter())
+                {
+                    assert_eq!(*output, *point * scalar);
+                    assert_eq!(*output, *expected * scalar);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn batch_mul_same_scalar_pallas() {
+        batch_mul_same_scalar_matches_native::<pallas::Point>();
+    }
+
+    #[test]
+    fn batch_mul_same_scalar_vesta() {
+        batch_mul_same_scalar_matches_native::<vesta::Point>();
+    }
+
+    #[test]
+    #[should_panic]
+    fn batch_mul_same_scalar_length_mismatch_panics() {
+        let points = [pallas::Affine::generator()];
+        let mut output = [];
+        pallas::Point::batch_mul_same_scalar_vartime(&points, &pallas::Scalar::ONE, &mut output);
     }
 }

--- a/src/curves.rs
+++ b/src/curves.rs
@@ -26,9 +26,35 @@ use super::{Fp, Fq};
 #[cfg(feature = "alloc")]
 use crate::arithmetic::{Coordinates, CurveAffine, CurveExt};
 
+#[cfg(feature = "alloc")]
+macro_rules! impl_batch_mul_same_scalar_vartime {
+    (glv, $name:ident) => {
+        #[cfg(feature = "glv")]
+        fn batch_mul_same_scalar_vartime(
+            points: &[Self::AffineExt],
+            scalar: &Self::ScalarExt,
+            output: &mut [Self],
+        ) {
+            assert_eq!(points.len(), output.len());
+            if points.is_empty() {
+                return;
+            }
+            for (point, output) in points.iter().zip(output.iter_mut()) {
+                *output = PrimeCurveAffine::to_curve(point);
+            }
+            let scalar = crate::glv::Decomposed::<$name>::new(scalar);
+            let tables = crate::glv::Table::batch(output);
+            for (output, table) in output.iter_mut().zip(tables) {
+                *output = table.mul_decomposed(&scalar);
+            }
+        }
+    };
+    (native, $name:ident) => {};
+}
+
 macro_rules! new_curve_impl {
     (($($privacy:tt)*), $name:ident, $name_affine:ident, $iso:ident, $base:ident, $scalar:ident,
-     $curve_id:literal, $a_raw:expr, $b_raw:expr, $curve_type:ident) => {
+     $curve_id:literal, $a_raw:expr, $b_raw:expr, $curve_type:ident, $same_scalar_mul:ident) => {
         /// Represents a point in the projective coordinate space.
         #[derive(Copy, Clone, Debug)]
         #[cfg_attr(feature = "repr-c", repr(C))]
@@ -165,6 +191,8 @@ macro_rules! new_curve_impl {
                     .ct_eq(&(z6 * $name::curve_constant_b()))
                     | self.z.is_zero()
             }
+
+            impl_batch_mul_same_scalar_vartime!($same_scalar_mul, $name);
         }
 
         impl group::Curve for $name {
@@ -955,7 +983,8 @@ new_curve_impl!(
     "pallas",
     [0, 0, 0, 0],
     [5, 0, 0, 0],
-    special_a0_b5
+    special_a0_b5,
+    glv
 );
 new_curve_impl!(
     (pub),
@@ -967,7 +996,8 @@ new_curve_impl!(
     "vesta",
     [0, 0, 0, 0],
     [5, 0, 0, 0],
-    special_a0_b5
+    special_a0_b5,
+    glv
 );
 new_curve_impl!(
     (pub(crate)),
@@ -984,7 +1014,8 @@ new_curve_impl!(
         0x18354a2eb0ea8c9c,
     ],
     [1265, 0, 0, 0],
-    general
+    general,
+    native
 );
 new_curve_impl!(
     (pub(crate)),
@@ -1001,7 +1032,8 @@ new_curve_impl!(
         0x267f9b2ee592271a,
     ],
     [1265, 0, 0, 0],
-    general
+    general,
+    native
 );
 
 impl Ep {


### PR DESCRIPTION
## Summary

Adds a provided `CurveExt::batch_mul_same_scalar_vartime` method for
component-wise multiplication of affine points by one public scalar.

The default implementation preserves the existing per-point behavior. With
the `glv` feature enabled, Pallas and Vesta instead decompose the scalar once,
build their GLV tables as a batch, and reuse the caller's output buffer as
scratch space.

This is the generic hook needed by Halo 2's IPA prover to accelerate generator
collapse without specialization or Pasta-specific bounds in generic proving
code. The dependent integration is
[zcash/halo2#927](https://github.com/zcash/halo2/pull/927).

## Security

This API is deliberately named and documented as variable-time. Callers must
only pass public scalars. The motivating Halo 2 inputs are public
Fiat-Shamir challenges and public generators.

## Performance

Criterion measurements on arm64 use eight fixed, full-width scalars per
sample. The table reports the total time for all eight calls:

| Points per call | Native loop | Batch hook | Throughput speedup |
| ---: | ---: | ---: | ---: |
| 128 | 142.90 ms | 49.55 ms | 2.88x |
| 1,024 | 1.143 s | 395.38 ms | 2.89x |
| 2,048 | 2.287 s | 789.81 ms | 2.90x |
| 4,096 | 4.565 s | 1.579 s | 2.89x |

The benchmark covers every power-of-two batch size from 1 through 4,096,
matching the batches used by a k = 13 Halo generator collapse. It isolates the
multiplication kernel; the caller's additions and final batch normalization
are common to both implementations.

Single-thread end-to-end measurements from the dependent PR are:

| Workload | Native | Batched GLV | Latency reduction | Throughput |
| --- | ---: | ---: | ---: | ---: |
| Real Orchard proof, one action, protocol k = 11 | 3.925 s | 3.779 s | 3.73% | 1.039x |
| Synthetic Halo proof, k = 13 | 2.554 s | 1.804 s | 29.36% | 1.416x |

The Orchard row uses ABBA means; one GLV run had a severe high outlier outside
generator collapse. Its median aggregate gives a 3.98% latency reduction, and
the collapse phase itself is stable at a 65.15% reduction. The k = 11 and
k = 13 rows are different circuits, so their absolute timings are not directly
comparable.

## API surface

This PR adds exactly one public API item: the provided
`CurveExt::batch_mul_same_scalar_vartime` trait method. It does not add a new
required method, feature, dependency, visibility change, type, constant, or
enum variant. Existing and external `CurveExt` implementations inherit the
native default.

## Validation

- Rust 1.63 formatting check
- all-features release test suite and doctests
- `alloc`-only fallback tests and doctests
- no-default-features tests
- default and `alloc`-only Clippy with warnings denied
- all-features private documentation build
- focused Pallas and Vesta tests across empty, boundary, identity, and scalar
  edge cases
- a CI lane for the `alloc` fallback without `glv`
