### PR TITLE
Add an opt-in Apple AArch64 Pasta field backend

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,6 +168,9 @@ Defined in `Cargo.toml`; `default = ["bits", "sqrt-table"]`.
 - `bits` — enables the `ff/bits` integration (`PrimeFieldBits`). *(default)*
 - `sqrt-table` — large precomputed tables (on the heap) that speed up square roots;
   implies `alloc`, pulls in `lazy_static`. *(default)*
+- `aarch64-asm` — uses an assembly backend for runtime `Fp` and `Fq`
+  multiplication and squaring on Apple AArch64 targets; pulls in `cc` as a
+  build dependency.
 - `glv` — variable-time GLV scalar multiplication for non-secret scalars (implies `alloc`).
 - `deferred` — the `deferred` module: `DeferredField` and a wide `Product` accumulator
   for batching many field multiplications behind a single Montgomery reduction.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,8 +169,8 @@ Defined in `Cargo.toml`; `default = ["bits", "sqrt-table"]`.
 - `sqrt-table` — large precomputed tables (on the heap) that speed up square roots;
   implies `alloc`, pulls in `lazy_static`. *(default)*
 - `aarch64-asm` — uses an assembly backend for runtime `Fp` and `Fq`
-  multiplication and squaring on Apple AArch64 targets; pulls in `cc` as a
-  build dependency.
+  multiplication, squaring, and canonical-representation conversion on Apple
+  AArch64 targets; pulls in `cc` as a build dependency.
 - `glv` — variable-time GLV scalar multiplication for non-secret scalars (implies `alloc`).
 - `deferred` — the `deferred` module: `DeferredField` and a wide `Product` accumulator
   for batching many field multiplications behind a single Montgomery reduction.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to Rust's notion of
 
 ### Added
 - `aarch64-asm` feature flag, which enables an assembly backend for runtime
-  `Fp` and `Fq` multiplication and squaring on Apple AArch64 targets.
+  `Fp` and `Fq` multiplication, squaring, and canonical-representation
+  conversion on Apple AArch64 targets.
 
 ## [0.5.2] - 2026-07-23
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Added
+- `aarch64-asm` feature flag, which enables an assembly backend for runtime
+  `Fp` and `Fq` multiplication and squaring on Apple AArch64 targets.
+
 ## [0.5.2] - 2026-07-23
 ### Added
 - `pasta_curves::deferred` module, behind the new `deferred` feature flag. This

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
+name = "cc"
+version = "1.0.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -415,6 +424,7 @@ version = "0.5.2"
 dependencies = [
  "bincode",
  "blake2b_simd",
+ "cc",
  "criterion",
  "ec-gpu",
  "ff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,8 +71,13 @@ ec-gpu = { version = "0.2.0", optional = true }
 serde_crate = { version = "1.0.16", optional = true, default-features = false, features = ["alloc"], package = "serde" }
 hex = { version = "0.4", optional = true, default-features = false, features = ["alloc", "serde"] }
 
+[build-dependencies]
+# Held at a release that builds on the pinned MSRV toolchain.
+cc = { version = "=1.0.83", optional = true }
+
 [features]
 default = ["bits", "sqrt-table"]
+aarch64-asm = ["dep:cc"]
 alloc = ["group/alloc", "blake2b_simd"]
 bits = ["ff/bits"]
 glv = ["alloc"]

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,21 @@
+#[cfg(feature = "aarch64-asm")]
+use std::env;
+
+fn main() {
+    println!("cargo:rerun-if-changed=src/asm/pasta_mul-armv8.S");
+
+    #[cfg(feature = "aarch64-asm")]
+    build_aarch64_asm();
+}
+
+#[cfg(feature = "aarch64-asm")]
+fn build_aarch64_asm() {
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+    let target_vendor = env::var("CARGO_CFG_TARGET_VENDOR").unwrap();
+
+    if target_arch == "aarch64" && target_vendor == "apple" {
+        cc::Build::new()
+            .file("src/asm/pasta_mul-armv8.S")
+            .compile("pasta_curves_aarch64");
+    }
+}

--- a/src/asm/pasta_mul-armv8.S
+++ b/src/asm/pasta_mul-armv8.S
@@ -1,0 +1,395 @@
+// Copyright Supranational LLC
+// Licensed under the Apache License, Version 2.0, see LICENSE-APACHE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Adapted from the pre-generated Mach-O assembly in Semolina v0.1.4:
+// https://github.com/supranational/semolina/blob/v0.1.4/src/mach-o/pasta_mul-armv8.S
+//
+// Only Montgomery multiplication, squaring, and the squaring reduction helper
+// are retained. Symbols are renamed for this crate. The implementation relies
+// on both Pasta moduli having limb 2 equal to zero and limb 3 equal to 2^62.
+
+.text
+
+.globl _pasta_curves_mul_mont_pasta
+.private_extern _pasta_curves_mul_mont_pasta
+
+.align 5
+_pasta_curves_mul_mont_pasta:
+    stp x29,x30,[sp,#-64]!
+    add x29,sp,#0
+    stp x19,x20,[sp,#16]
+    stp x21,x22,[sp,#32]
+    stp x23,x24,[sp,#48]
+
+    ldp x10,x11,[x1]
+    ldr x9,        [x2]
+    ldp x12,x13,[x1,#16]
+
+    mul x19,x10,x9
+    ldp x5,x6,[x3]
+    mul x20,x11,x9
+    ldp x7,x8,[x3,#16]
+    mul x21,x12,x9
+    mul x22,x13,x9
+
+    umulh x14,x10,x9
+    umulh x15,x11,x9
+    mul x3,x4,x19
+    umulh x16,x12,x9
+    umulh x17,x13,x9
+    adds x20,x20,x14
+    //mul x14,x5,x3
+    adcs x21,x21,x15
+    mul x15,x6,x3
+    adcs x22,x22,x16
+    //mul x16,x7,x3 //x7==0
+    adc x23,xzr,    x17
+    lsl x17,x3,#62      //mul x17,x8,x3
+    ldr x9,[x2,8*1]
+    subs xzr,x19,#1     //adds x19,x19,x14
+    umulh x14,x5,x3
+    adcs x20,x20,x15
+    umulh x15,x6,x3
+    adcs x21,x21,xzr    //x16
+    //umulh x16,x7,x3   //x7==0
+    adcs x22,x22,x17
+    lsr x17,x3,#2       //umulh x17,x8,x3
+    adc x23,x23,xzr
+
+    adds x19,x20,x14
+    mul x14,x10,x9
+    adcs x20,x21,x15
+    mul x15,x11,x9
+    adcs x21,x22,xzr    //x16
+    mul x16,x12,x9
+    adcs x22,x23,x17
+    mul x17,x13,x9
+    adc x23,xzr,xzr
+
+    adds x19,x19,x14
+    umulh x14,x10,x9
+    adcs x20,x20,x15
+    umulh x15,x11,x9
+    adcs x21,x21,x16
+    mul x3,x4,x19
+    umulh x16,x12,x9
+    adcs x22,x22,x17
+    umulh x17,x13,x9
+    adc x23,x23,xzr
+
+    adds x20,x20,x14
+    //mul x14,x5,x3
+    adcs x21,x21,x15
+    mul x15,x6,x3
+    adcs x22,x22,x16
+    //mul x16,x7,x3 //x7==0
+    adc x23,x23,x17
+    lsl x17,x3,#62      //mul x17,x8,x3
+    ldr x9,[x2,8*2]
+    subs xzr,x19,#1     //adds x19,x19,x14
+    umulh x14,x5,x3
+    adcs x20,x20,x15
+    umulh x15,x6,x3
+    adcs x21,x21,xzr    //x16
+    //umulh x16,x7,x3   //x7==0
+    adcs x22,x22,x17
+    lsr x17,x3,#2       //umulh x17,x8,x3
+    adc x23,x23,xzr
+
+    adds x19,x20,x14
+    mul x14,x10,x9
+    adcs x20,x21,x15
+    mul x15,x11,x9
+    adcs x21,x22,xzr    //x16
+    mul x16,x12,x9
+    adcs x22,x23,x17
+    mul x17,x13,x9
+    adc x23,xzr,xzr
+
+    adds x19,x19,x14
+    umulh x14,x10,x9
+    adcs x20,x20,x15
+    umulh x15,x11,x9
+    adcs x21,x21,x16
+    mul x3,x4,x19
+    umulh x16,x12,x9
+    adcs x22,x22,x17
+    umulh x17,x13,x9
+    adc x23,x23,xzr
+
+    adds x20,x20,x14
+    //mul x14,x5,x3
+    adcs x21,x21,x15
+    mul x15,x6,x3
+    adcs x22,x22,x16
+    //mul x16,x7,x3 //x7==0
+    adc x23,x23,x17
+    lsl x17,x3,#62      //mul x17,x8,x3
+    ldr x9,[x2,8*3]
+    subs xzr,x19,#1     //adds x19,x19,x14
+    umulh x14,x5,x3
+    adcs x20,x20,x15
+    umulh x15,x6,x3
+    adcs x21,x21,xzr    //x16
+    //umulh x16,x7,x3   //x7==0
+    adcs x22,x22,x17
+    lsr x17,x3,#2       //umulh x17,x8,x3
+    adc x23,x23,xzr
+
+    adds x19,x20,x14
+    mul x14,x10,x9
+    adcs x20,x21,x15
+    mul x15,x11,x9
+    adcs x21,x22,xzr    //x16
+    mul x16,x12,x9
+    adcs x22,x23,x17
+    mul x17,x13,x9
+    adc x23,xzr,xzr
+
+    adds x19,x19,x14
+    umulh x14,x10,x9
+    adcs x20,x20,x15
+    umulh x15,x11,x9
+    adcs x21,x21,x16
+    mul x3,x4,x19
+    umulh x16,x12,x9
+    adcs x22,x22,x17
+    umulh x17,x13,x9
+    adc x23,x23,xzr
+
+    adds x20,x20,x14
+    //mul x14,x5,x3
+    adcs x21,x21,x15
+    mul x15,x6,x3
+    adcs x22,x22,x16
+    //mul x16,x7,x3 //x7==0
+    adc x23,x23,x17
+    lsl x17,x3,#62      //mul x17,x8,x3
+    subs xzr,x19,#1     //adds x19,x19,x14
+    umulh x14,x5,x3
+    adcs x20,x20,x15
+    umulh x15,x6,x3
+    adcs x21,x21,xzr    //x16
+    //umulh x16,x7,x3   //x7==0
+    adcs x22,x22,x17
+    lsr x17,x3,#2       //umulh x17,x8,x3
+    adc x23,x23,xzr
+
+    adds x19,x20,x14
+    adcs x20,x21,x15
+    adcs x21,x22,xzr    //x16
+    adcs x22,x23,x17
+    adc x23,xzr,xzr
+
+    subs x14,x19,x5
+    sbcs x15,x20,x6
+    sbcs x16,x21,xzr    //x7
+    sbcs x17,x22,x8
+    sbcs xzr,    x23,xzr
+
+    csel x19,x19,x14,lo
+    csel x20,x20,x15,lo
+    csel x21,x21,x16,lo
+    csel x22,x22,x17,lo
+
+    stp x19,x20,[x0]
+    stp x21,x22,[x0,#16]
+
+    ldp x19,x20,[x29,#16]
+    ldp x21,x22,[x29,#32]
+    ldp x23,x24,[x29,#48]
+    ldr x29,[sp],#64
+    ret
+
+.globl _pasta_curves_sqr_mont_pasta
+.private_extern _pasta_curves_sqr_mont_pasta
+
+.align 5
+_pasta_curves_sqr_mont_pasta:
+    .long 3573752639
+    stp x29,x30,[sp,#-48]!
+    add x29,sp,#0
+    stp x19,x20,[sp,#16]
+    stp x21,x22,[sp,#32]
+
+    ldp x5,x6,[x1]
+    ldp x7,x8,[x1,#16]
+    mov x4,x3
+
+    ////////////////////////////////////////////////////////////////
+    //  |  |  |  |  |  |a1*a0|  |
+    //  |  |  |  |  |a2*a0|  |  |
+    //  |  |a3*a2|a3*a0|  |  |  |
+    //  |  |  |  |a2*a1|  |  |  |
+    //  |  |  |a3*a1|  |  |  |  |
+    // *|  |  |  |  |  |  |  | 2|
+    // +|a3*a3|a2*a2|a1*a1|a0*a0|
+    //  |--+--+--+--+--+--+--+--|
+    //  |A7|A6|A5|A4|A3|A2|A1|A0|, where Ax is x10
+    //
+    //  "can't overflow" below mark carrying into high part of
+    //  multiplication result, which can't overflow, because it
+    //  can never be all ones.
+
+    mul x11,x6,x5        // a[1]*a[0]
+    umulh x15,x6,x5
+    mul x12,x7,x5        // a[2]*a[0]
+    umulh x16,x7,x5
+    mul x13,x8,x5        // a[3]*a[0]
+    umulh x19,x8,x5
+
+    adds x12,x12,x15     // accumulate high parts of multiplication
+    mul x14,x7,x6        // a[2]*a[1]
+    umulh x15,x7,x6
+    adcs x13,x13,x16
+    mul x16,x8,x6        // a[3]*a[1]
+    umulh x17,x8,x6
+    adc x19,x19,xzr      // can't overflow
+
+    mul x20,x8,x7        // a[3]*a[2]
+    umulh x21,x8,x7
+
+    adds x15,x15,x16     // accumulate high parts of multiplication
+    mul x10,x5,x5        // a[0]*a[0]
+    adc x16,x17,xzr      // can't overflow
+
+    adds x13,x13,x14     // accumulate low parts of multiplication
+    umulh x5,x5,x5
+    adcs x19,x19,x15
+    mul x15,x6,x6        // a[1]*a[1]
+    adcs x20,x20,x16
+    umulh x6,x6,x6
+    adc x21,x21,xzr      // can't overflow
+
+    adds x11,x11,x11     // acc[1-6]*=2
+    mul x16,x7,x7        // a[2]*a[2]
+    adcs x12,x12,x12
+    umulh x7,x7,x7
+    adcs x13,x13,x13
+    mul x17,x8,x8        // a[3]*a[3]
+    adcs x19,x19,x19
+    umulh x8,x8,x8
+    adcs x20,x20,x20
+    adcs x21,x21,x21
+    adc x22,xzr,xzr
+
+    adds x11,x11,x5      // +a[i]*a[i]
+    adcs x12,x12,x15
+    adcs x13,x13,x6
+    adcs x19,x19,x16
+    adcs x20,x20,x7
+    adcs x21,x21,x17
+    adc x22,x22,x8
+
+    bl L$pasta_curves_mul_by_1_mont_pasta
+    ldr x30,[x29,#8]
+
+    adds x10,x10,x19     // accumulate upper half
+    adcs x11,x11,x20
+    adcs x12,x12,x21
+    adcs x13,x13,x22
+    adc x19,xzr,xzr
+
+    subs x14,x10,x5
+    sbcs x15,x11,x6
+    sbcs x16,x12,x7
+    sbcs x17,x13,x8
+    sbcs xzr,    x19,xzr
+
+    csel x10,x10,x14,lo
+    csel x11,x11,x15,lo
+    csel x12,x12,x16,lo
+    csel x13,x13,x17,lo
+
+    stp x10,x11,[x0]
+    stp x12,x13,[x0,#16]
+
+    ldp x19,x20,[x29,#16]
+    ldp x21,x22,[x29,#32]
+    ldr x29,[sp],#48
+    .long 3573752767
+    ret
+
+.align 5
+L$pasta_curves_mul_by_1_mont_pasta:
+    mul x3,x4,x10
+    ldp x5,x6,[x2]
+    ldp x7,x8,[x2,#16]
+    //mul x14,x5,x3
+    mul x15,x6,x3
+    //mul x16,x7,x3 //mod[2]==0
+    lsl x17,x3,#62      //mul x17,x8,x3
+    subs xzr,x10,#1     //adds x10,x10,x14
+    umulh x14,x5,x3
+    adcs x11,x11,x15
+    umulh x15,x6,x3
+    adcs x12,x12,xzr    //x16
+    //umulh x16,x7,x3   //x7==0
+    adcs x13,x13,x17
+    lsr x17,x3,#2       //umulh x17,x8,x3
+    adc x9,xzr,xzr
+
+    adds x10,x11,x14
+    adcs x11,x12,x15
+    adcs x12,x13,xzr    //x16
+    mul x3,x4,x10
+    adc x13,x9,x17
+    //mul x14,x5,x3
+    mul x15,x6,x3
+    //mul x16,x7,x3 //mod[2]==0
+    lsl x17,x3,#62      //mul x17,x8,x3
+    subs xzr,x10,#1     //adds x10,x10,x14
+    umulh x14,x5,x3
+    adcs x11,x11,x15
+    umulh x15,x6,x3
+    adcs x12,x12,xzr    //x16
+    //umulh x16,x7,x3   //x7==0
+    adcs x13,x13,x17
+    lsr x17,x3,#2       //umulh x17,x8,x3
+    adc x9,xzr,xzr
+
+    adds x10,x11,x14
+    adcs x11,x12,x15
+    adcs x12,x13,xzr    //x16
+    mul x3,x4,x10
+    adc x13,x9,x17
+    //mul x14,x5,x3
+    mul x15,x6,x3
+    //mul x16,x7,x3 //mod[2]==0
+    lsl x17,x3,#62      //mul x17,x8,x3
+    subs xzr,x10,#1     //adds x10,x10,x14
+    umulh x14,x5,x3
+    adcs x11,x11,x15
+    umulh x15,x6,x3
+    adcs x12,x12,xzr    //x16
+    //umulh x16,x7,x3   //x7==0
+    adcs x13,x13,x17
+    lsr x17,x3,#2       //umulh x17,x8,x3
+    adc x9,xzr,xzr
+
+    adds x10,x11,x14
+    adcs x11,x12,x15
+    adcs x12,x13,xzr    //x16
+    mul x3,x4,x10
+    adc x13,x9,x17
+    //mul x14,x5,x3
+    mul x15,x6,x3
+    //mul x16,x7,x3 //mod[2]==0
+    lsl x17,x3,#62      //mul x17,x8,x3
+    subs xzr,x10,#1     //adds x10,x10,x14
+    umulh x14,x5,x3
+    adcs x11,x11,x15
+    umulh x15,x6,x3
+    adcs x12,x12,xzr    //x16
+    //umulh x16,x7,x3   //x7==0
+    adcs x13,x13,x17
+    lsr x17,x3,#2       //umulh x17,x8,x3
+    adc x9,xzr,xzr
+
+    adds x10,x11,x14
+    adcs x11,x12,x15
+    adcs x12,x13,xzr    //x16
+    adc x13,x9,x17
+
+    ret

--- a/src/asm/pasta_mul-armv8.S
+++ b/src/asm/pasta_mul-armv8.S
@@ -5,9 +5,10 @@
 // Adapted from the pre-generated Mach-O assembly in Semolina v0.1.4:
 // https://github.com/supranational/semolina/blob/v0.1.4/src/mach-o/pasta_mul-armv8.S
 //
-// Only Montgomery multiplication, squaring, and the squaring reduction helper
-// are retained. Symbols are renamed for this crate. The implementation relies
-// on both Pasta moduli having limb 2 equal to zero and limb 3 equal to 2^62.
+// Only Montgomery multiplication, squaring, conversion, and their shared
+// reduction helper are retained. Symbols are renamed for this crate. The
+// implementation relies on both Pasta moduli having limb 2 equal to zero and
+// limb 3 equal to 2^62.
 
 .text
 
@@ -308,6 +309,39 @@ _pasta_curves_sqr_mont_pasta:
     ldp x19,x20,[x29,#16]
     ldp x21,x22,[x29,#32]
     ldr x29,[sp],#48
+    .long 3573752767
+    ret
+
+.globl _pasta_curves_from_mont_pasta
+.private_extern _pasta_curves_from_mont_pasta
+
+.align 5
+_pasta_curves_from_mont_pasta:
+    .long 3573752639
+    stp x29,x30,[sp,#-16]!
+    add x29,sp,#0
+
+    mov x4,x3
+    ldp x10,x11,[x1]
+    ldp x12,x13,[x1,#16]
+
+    bl L$pasta_curves_mul_by_1_mont_pasta
+    ldr x30,[x29,#8]
+
+    subs x14,x10,x5
+    sbcs x15,x11,x6
+    sbcs x16,x12,x7
+    sbcs x17,x13,x8
+
+    csel x10,x10,x14,lo
+    csel x11,x11,x15,lo
+    csel x12,x12,x16,lo
+    csel x13,x13,x17,lo
+
+    stp x10,x11,[x0]
+    stp x12,x13,[x0,#16]
+
+    ldr x29,[sp],#16
     .long 3573752767
     ret
 

--- a/src/curves.rs
+++ b/src/curves.rs
@@ -197,7 +197,7 @@ macro_rules! new_curve_impl {
                     acc = $base::conditional_select(&(acc * p.z), &acc, skip);
 
                     // Set the coordinates to the correct value
-                    let tmp2 = tmp.square();
+                    let tmp2 = Field::square(&tmp);
                     let tmp3 = tmp2 * tmp;
 
                     q.x = p.x * tmp2;
@@ -209,7 +209,7 @@ macro_rules! new_curve_impl {
 
             fn to_affine(&self) -> Self::AffineRepr {
                 let zinv = self.z.invert().unwrap_or($base::zero());
-                let zinv2 = zinv.square();
+                let zinv2 = Field::square(&zinv);
                 let x = self.x * zinv2;
                 let zinv3 = zinv2 * zinv;
                 let y = self.y * zinv3;
@@ -368,8 +368,8 @@ macro_rules! new_curve_impl {
                 } else if bool::from(rhs.is_identity()) {
                     *self
                 } else {
-                    let z1z1 = self.z.square();
-                    let z2z2 = rhs.z.square();
+                    let z1z1 = Field::square(&self.z);
+                    let z2z2 = Field::square(&rhs.z);
                     let u1 = self.x * z2z2;
                     let u2 = rhs.x * z1z1;
                     let s1 = self.y * z2z2 * rhs.z;
@@ -383,16 +383,16 @@ macro_rules! new_curve_impl {
                         }
                     } else {
                         let h = u2 - u1;
-                        let i = (h + h).square();
+                        let i = Field::square(&(h + h));
                         let j = h * i;
                         let r = s2 - s1;
                         let r = r + r;
                         let v = u1 * i;
-                        let x3 = r.square() - j - v - v;
+                        let x3 = Field::square(&r) - j - v - v;
                         let s1 = s1 * j;
                         let s1 = s1 + s1;
                         let y3 = r * (v - x3) - s1;
-                        let z3 = (self.z + rhs.z).square() - z1z1 - z2z2;
+                        let z3 = Field::square(&(self.z + rhs.z)) - z1z1 - z2z2;
                         let z3 = z3 * h;
 
                         $name {
@@ -412,7 +412,7 @@ macro_rules! new_curve_impl {
                 } else if bool::from(rhs.is_identity()) {
                     *self
                 } else {
-                    let z1z1 = self.z.square();
+                    let z1z1 = Field::square(&self.z);
                     let u2 = rhs.x * z1z1;
                     let s2 = rhs.y * z1z1 * self.z;
 
@@ -424,18 +424,18 @@ macro_rules! new_curve_impl {
                         }
                     } else {
                         let h = u2 - self.x;
-                        let hh = h.square();
+                        let hh = Field::square(&h);
                         let i = hh + hh;
                         let i = i + i;
                         let j = h * i;
                         let r = s2 - self.y;
                         let r = r + r;
                         let v = self.x * i;
-                        let x3 = r.square() - j - v - v;
+                        let x3 = Field::square(&r) - j - v - v;
                         let j = self.y * j;
                         let j = j + j;
                         let y3 = r * (v - x3) - j;
-                        let z3 = (self.z + h).square() - z1z1 - hh;
+                        let z3 = Field::square(&(self.z + h)) - z1z1 - hh;
 
                         $name {
                             x: x3, y: y3, z: z3
@@ -539,14 +539,14 @@ macro_rules! new_curve_impl {
                         }
                     } else {
                         let h = rhs.x - self.x;
-                        let hh = h.square();
+                        let hh = Field::square(&h);
                         let i = hh + hh;
                         let i = i + i;
                         let j = h * i;
                         let r = rhs.y - self.y;
                         let r = r + r;
                         let v = self.x * i;
-                        let x3 = r.square() - j - v - v;
+                        let x3 = Field::square(&r) - j - v - v;
                         let j = self.y * j;
                         let j = j + j;
                         let y3 = r * (v - x3) - j;
@@ -814,15 +814,15 @@ macro_rules! impl_projective_curve_specific {
             //
             // There are no points of order 2.
 
-            let a = self.x.square();
-            let b = self.y.square();
-            let c = b.square();
+            let a = Field::square(&self.x);
+            let b = Field::square(&self.y);
+            let c = Field::square(&b);
             let d = self.x + b;
-            let d = d.square();
+            let d = Field::square(&d);
             let d = d - a - c;
             let d = d + d;
             let e = a + a + a;
-            let f = e.square();
+            let f = Field::square(&e);
             let z3 = self.z * self.y;
             let z3 = z3 + z3;
             let x3 = f - (d + d);

--- a/src/fields.rs
+++ b/src/fields.rs
@@ -4,6 +4,16 @@
 mod fp;
 mod fq;
 
+// Keep the assembly FFI exception contained within a private module whose
+// public interface consists only of safe wrappers.
+#[allow(unsafe_code)]
+#[cfg(all(
+    feature = "aarch64-asm",
+    target_arch = "aarch64",
+    target_vendor = "apple"
+))]
+mod aarch64_asm;
+
 pub use fp::*;
 pub use fq::*;
 

--- a/src/fields/aarch64_asm.rs
+++ b/src/fields/aarch64_asm.rs
@@ -1,0 +1,43 @@
+//! Private bindings to the Apple AArch64 Pasta field backend.
+
+type Limbs = [u64; 4];
+
+extern "C" {
+    fn pasta_curves_mul_mont_pasta(
+        out: *mut Limbs,
+        lhs: *const Limbs,
+        rhs: *const Limbs,
+        modulus: *const Limbs,
+        inv: u64,
+    );
+    fn pasta_curves_sqr_mont_pasta(
+        out: *mut Limbs,
+        value: *const Limbs,
+        modulus: *const Limbs,
+        inv: u64,
+    );
+}
+
+/// Multiplies two canonical Montgomery residues for a Pasta modulus.
+#[inline]
+pub(super) fn mul(lhs: &Limbs, rhs: &Limbs, modulus: &Limbs, inv: u64) -> Limbs {
+    let mut out = Limbs::default();
+    // SAFETY: All pointers refer to four initialized `u64` limbs for the
+    // duration of the call. The backend writes exactly four limbs to `out`.
+    unsafe {
+        pasta_curves_mul_mont_pasta(&mut out, lhs, rhs, modulus, inv);
+    }
+    out
+}
+
+/// Squares a canonical Montgomery residue for a Pasta modulus.
+#[inline]
+pub(super) fn square(value: &Limbs, modulus: &Limbs, inv: u64) -> Limbs {
+    let mut out = Limbs::default();
+    // SAFETY: All pointers refer to four initialized `u64` limbs for the
+    // duration of the call. The backend writes exactly four limbs to `out`.
+    unsafe {
+        pasta_curves_sqr_mont_pasta(&mut out, value, modulus, inv);
+    }
+    out
+}

--- a/src/fields/aarch64_asm.rs
+++ b/src/fields/aarch64_asm.rs
@@ -16,6 +16,12 @@ extern "C" {
         modulus: *const Limbs,
         inv: u64,
     );
+    fn pasta_curves_from_mont_pasta(
+        out: *mut Limbs,
+        value: *const Limbs,
+        modulus: *const Limbs,
+        inv: u64,
+    );
 }
 
 /// Multiplies two canonical Montgomery residues for a Pasta modulus.
@@ -38,6 +44,18 @@ pub(super) fn square(value: &Limbs, modulus: &Limbs, inv: u64) -> Limbs {
     // duration of the call. The backend writes exactly four limbs to `out`.
     unsafe {
         pasta_curves_sqr_mont_pasta(&mut out, value, modulus, inv);
+    }
+    out
+}
+
+/// Converts a canonical Montgomery residue into its canonical integer.
+#[inline]
+pub(super) fn from_mont(value: &Limbs, modulus: &Limbs, inv: u64) -> Limbs {
+    let mut out = Limbs::default();
+    // SAFETY: All pointers refer to four initialized `u64` limbs for the
+    // duration of the call. The backend writes exactly four limbs to `out`.
+    unsafe {
+        pasta_curves_from_mont_pasta(&mut out, value, modulus, inv);
     }
     out
 }

--- a/src/fields/fp.rs
+++ b/src/fields/fp.rs
@@ -168,7 +168,7 @@ impl<'a, 'b> Mul<&'b Fp> for &'a Fp {
 
     #[inline]
     fn mul(self, rhs: &'b Fp) -> Fp {
-        self.mul(rhs)
+        self.mul_runtime(rhs)
     }
 }
 
@@ -369,6 +369,48 @@ impl Fp {
         Fp::montgomery_reduce(u[0], u[1], u[2], u[3], u[4], u[5], u[6], u[7])
     }
 
+    #[inline]
+    fn mul_runtime(&self, rhs: &Self) -> Self {
+        #[cfg(all(
+            feature = "aarch64-asm",
+            target_arch = "aarch64",
+            target_vendor = "apple"
+        ))]
+        {
+            Fp(super::aarch64_asm::mul(&self.0, &rhs.0, &MODULUS.0, INV))
+        }
+
+        #[cfg(not(all(
+            feature = "aarch64-asm",
+            target_arch = "aarch64",
+            target_vendor = "apple"
+        )))]
+        {
+            self.mul(rhs)
+        }
+    }
+
+    #[inline]
+    fn square_runtime(&self) -> Self {
+        #[cfg(all(
+            feature = "aarch64-asm",
+            target_arch = "aarch64",
+            target_vendor = "apple"
+        ))]
+        {
+            Fp(super::aarch64_asm::square(&self.0, &MODULUS.0, INV))
+        }
+
+        #[cfg(not(all(
+            feature = "aarch64-asm",
+            target_arch = "aarch64",
+            target_vendor = "apple"
+        )))]
+        {
+            self.square()
+        }
+    }
+
     /// Subtracts `rhs` from `self`, returning the result.
     #[cfg_attr(not(feature = "uninline-portable"), inline)]
     pub const fn sub(&self, rhs: &Self) -> Self {
@@ -544,7 +586,7 @@ impl ff::Field for Fp {
 
     #[inline(always)]
     fn square(&self) -> Self {
-        self.square()
+        self.square_runtime()
     }
 
     fn sqrt_ratio(num: &Self, div: &Self) -> (Choice, Self) {
@@ -819,6 +861,54 @@ impl ec_gpu::GpuField for Fp {
 
     fn modulus() -> alloc::vec::Vec<u32> {
         crate::fields::u64_to_u32(&MODULUS.0[..])
+    }
+}
+
+#[cfg(all(
+    test,
+    feature = "aarch64-asm",
+    target_arch = "aarch64",
+    target_vendor = "apple"
+))]
+#[test]
+fn aarch64_asm_matches_portable_arithmetic() {
+    use rand::SeedableRng;
+
+    let modulus_minus_one =
+        Fp::from_raw([MODULUS.0[0] - 1, MODULUS.0[1], MODULUS.0[2], MODULUS.0[3]]);
+    let boundaries = [
+        Fp::zero(),
+        Fp::one(),
+        -Fp::one(),
+        Fp::from_raw([1, 0, 0, 0]),
+        modulus_minus_one,
+        Fp::from_raw([u64::MAX; 4]),
+    ];
+
+    for lhs in boundaries {
+        assert_eq!(<Fp as Field>::square(&lhs), Fp::square(&lhs));
+        for rhs in boundaries {
+            assert_eq!(&lhs * &rhs, Fp::mul(&lhs, &rhs));
+        }
+    }
+
+    let mut rng = rand_xorshift::XorShiftRng::from_seed([0x5a; 16]);
+    for _ in 0..1024 {
+        let lhs = Fp::from_raw([
+            rng.next_u64(),
+            rng.next_u64(),
+            rng.next_u64(),
+            rng.next_u64(),
+        ]);
+        let rhs = Fp::from_raw([
+            rng.next_u64(),
+            rng.next_u64(),
+            rng.next_u64(),
+            rng.next_u64(),
+        ]);
+
+        assert_eq!(&lhs * &rhs, Fp::mul(&lhs, &rhs));
+        assert_eq!(<Fp as Field>::square(&lhs), Fp::square(&lhs));
     }
 }
 

--- a/src/fields/fp.rs
+++ b/src/fields/fp.rs
@@ -705,6 +705,18 @@ impl ff::PrimeField for Fp {
     fn to_repr(&self) -> Self::Repr {
         // Turn into canonical form by computing
         // (a.R) / R = a
+        #[cfg(all(
+            feature = "aarch64-asm",
+            target_arch = "aarch64",
+            target_vendor = "apple"
+        ))]
+        let tmp = Fp(super::aarch64_asm::from_mont(&self.0, &MODULUS.0, INV));
+
+        #[cfg(not(all(
+            feature = "aarch64-asm",
+            target_arch = "aarch64",
+            target_vendor = "apple"
+        )))]
         let tmp = Fp::montgomery_reduce(self.0[0], self.0[1], self.0[2], self.0[3], 0, 0, 0, 0);
 
         let mut res = [0; 32];
@@ -870,24 +882,71 @@ impl ec_gpu::GpuField for Fp {
     target_arch = "aarch64",
     target_vendor = "apple"
 ))]
+fn aarch64_asm_portable_repr(value: Fp) -> [u8; 32] {
+    let value = Fp::montgomery_reduce(value.0[0], value.0[1], value.0[2], value.0[3], 0, 0, 0, 0);
+    let mut repr = [0; 32];
+    for (bytes, limb) in repr.chunks_exact_mut(8).zip(value.0) {
+        bytes.copy_from_slice(&limb.to_le_bytes());
+    }
+    repr
+}
+
+#[cfg(all(
+    test,
+    feature = "aarch64-asm",
+    target_arch = "aarch64",
+    target_vendor = "apple"
+))]
+fn aarch64_asm_check_repr(value: Fp) {
+    let portable = aarch64_asm_portable_repr(value);
+    assert_eq!(value.to_repr(), portable);
+    assert_eq!(Fp::from_repr(portable).unwrap(), value);
+    assert_eq!(value.is_odd().unwrap_u8(), portable[0] & 1);
+}
+
+#[cfg(all(
+    test,
+    feature = "aarch64-asm",
+    target_arch = "aarch64",
+    target_vendor = "apple"
+))]
+fn aarch64_asm_portable_cmp(lhs: Fp, rhs: Fp) -> core::cmp::Ordering {
+    aarch64_asm_portable_repr(lhs)
+        .iter()
+        .zip(aarch64_asm_portable_repr(rhs).iter())
+        .rev()
+        .find_map(|(lhs, rhs)| match lhs.cmp(rhs) {
+            core::cmp::Ordering::Equal => None,
+            ordering => Some(ordering),
+        })
+        .unwrap_or(core::cmp::Ordering::Equal)
+}
+
+#[cfg(all(
+    test,
+    feature = "aarch64-asm",
+    target_arch = "aarch64",
+    target_vendor = "apple"
+))]
 #[test]
 fn aarch64_asm_matches_portable_arithmetic() {
     use rand::SeedableRng;
 
-    let modulus_minus_one =
-        Fp::from_raw([MODULUS.0[0] - 1, MODULUS.0[1], MODULUS.0[2], MODULUS.0[3]]);
+    let max_montgomery_residue = Fp([MODULUS.0[0] - 1, MODULUS.0[1], MODULUS.0[2], MODULUS.0[3]]);
     let boundaries = [
         Fp::zero(),
         Fp::one(),
         -Fp::one(),
         Fp::from_raw([1, 0, 0, 0]),
-        modulus_minus_one,
+        max_montgomery_residue,
         Fp::from_raw([u64::MAX; 4]),
     ];
 
     for lhs in boundaries {
+        aarch64_asm_check_repr(lhs);
         assert_eq!(<Fp as Field>::square(&lhs), Fp::square(&lhs));
         for rhs in boundaries {
+            assert_eq!(lhs.cmp(&rhs), aarch64_asm_portable_cmp(lhs, rhs));
             assert_eq!(&lhs * &rhs, Fp::mul(&lhs, &rhs));
         }
     }
@@ -907,6 +966,8 @@ fn aarch64_asm_matches_portable_arithmetic() {
             rng.next_u64(),
         ]);
 
+        aarch64_asm_check_repr(lhs);
+        assert_eq!(lhs.cmp(&rhs), aarch64_asm_portable_cmp(lhs, rhs));
         assert_eq!(&lhs * &rhs, Fp::mul(&lhs, &rhs));
         assert_eq!(<Fp as Field>::square(&lhs), Fp::square(&lhs));
     }

--- a/src/fields/fq.rs
+++ b/src/fields/fq.rs
@@ -705,6 +705,18 @@ impl ff::PrimeField for Fq {
     fn to_repr(&self) -> Self::Repr {
         // Turn into canonical form by computing
         // (a.R) / R = a
+        #[cfg(all(
+            feature = "aarch64-asm",
+            target_arch = "aarch64",
+            target_vendor = "apple"
+        ))]
+        let tmp = Fq(super::aarch64_asm::from_mont(&self.0, &MODULUS.0, INV));
+
+        #[cfg(not(all(
+            feature = "aarch64-asm",
+            target_arch = "aarch64",
+            target_vendor = "apple"
+        )))]
         let tmp = Fq::montgomery_reduce(self.0[0], self.0[1], self.0[2], self.0[3], 0, 0, 0, 0);
 
         let mut res = [0; 32];
@@ -869,24 +881,71 @@ impl ec_gpu::GpuField for Fq {
     target_arch = "aarch64",
     target_vendor = "apple"
 ))]
+fn aarch64_asm_portable_repr(value: Fq) -> [u8; 32] {
+    let value = Fq::montgomery_reduce(value.0[0], value.0[1], value.0[2], value.0[3], 0, 0, 0, 0);
+    let mut repr = [0; 32];
+    for (bytes, limb) in repr.chunks_exact_mut(8).zip(value.0) {
+        bytes.copy_from_slice(&limb.to_le_bytes());
+    }
+    repr
+}
+
+#[cfg(all(
+    test,
+    feature = "aarch64-asm",
+    target_arch = "aarch64",
+    target_vendor = "apple"
+))]
+fn aarch64_asm_check_repr(value: Fq) {
+    let portable = aarch64_asm_portable_repr(value);
+    assert_eq!(value.to_repr(), portable);
+    assert_eq!(Fq::from_repr(portable).unwrap(), value);
+    assert_eq!(value.is_odd().unwrap_u8(), portable[0] & 1);
+}
+
+#[cfg(all(
+    test,
+    feature = "aarch64-asm",
+    target_arch = "aarch64",
+    target_vendor = "apple"
+))]
+fn aarch64_asm_portable_cmp(lhs: Fq, rhs: Fq) -> core::cmp::Ordering {
+    aarch64_asm_portable_repr(lhs)
+        .iter()
+        .zip(aarch64_asm_portable_repr(rhs).iter())
+        .rev()
+        .find_map(|(lhs, rhs)| match lhs.cmp(rhs) {
+            core::cmp::Ordering::Equal => None,
+            ordering => Some(ordering),
+        })
+        .unwrap_or(core::cmp::Ordering::Equal)
+}
+
+#[cfg(all(
+    test,
+    feature = "aarch64-asm",
+    target_arch = "aarch64",
+    target_vendor = "apple"
+))]
 #[test]
 fn aarch64_asm_matches_portable_arithmetic() {
     use rand::SeedableRng;
 
-    let modulus_minus_one =
-        Fq::from_raw([MODULUS.0[0] - 1, MODULUS.0[1], MODULUS.0[2], MODULUS.0[3]]);
+    let max_montgomery_residue = Fq([MODULUS.0[0] - 1, MODULUS.0[1], MODULUS.0[2], MODULUS.0[3]]);
     let boundaries = [
         Fq::zero(),
         Fq::one(),
         -Fq::one(),
         Fq::from_raw([1, 0, 0, 0]),
-        modulus_minus_one,
+        max_montgomery_residue,
         Fq::from_raw([u64::MAX; 4]),
     ];
 
     for lhs in boundaries {
+        aarch64_asm_check_repr(lhs);
         assert_eq!(<Fq as Field>::square(&lhs), Fq::square(&lhs));
         for rhs in boundaries {
+            assert_eq!(lhs.cmp(&rhs), aarch64_asm_portable_cmp(lhs, rhs));
             assert_eq!(&lhs * &rhs, Fq::mul(&lhs, &rhs));
         }
     }
@@ -906,6 +965,8 @@ fn aarch64_asm_matches_portable_arithmetic() {
             rng.next_u64(),
         ]);
 
+        aarch64_asm_check_repr(lhs);
+        assert_eq!(lhs.cmp(&rhs), aarch64_asm_portable_cmp(lhs, rhs));
         assert_eq!(&lhs * &rhs, Fq::mul(&lhs, &rhs));
         assert_eq!(<Fq as Field>::square(&lhs), Fq::square(&lhs));
     }

--- a/src/fields/fq.rs
+++ b/src/fields/fq.rs
@@ -168,7 +168,7 @@ impl<'a, 'b> Mul<&'b Fq> for &'a Fq {
 
     #[inline]
     fn mul(self, rhs: &'b Fq) -> Fq {
-        self.mul(rhs)
+        self.mul_runtime(rhs)
     }
 }
 
@@ -369,6 +369,48 @@ impl Fq {
         Fq::montgomery_reduce(u[0], u[1], u[2], u[3], u[4], u[5], u[6], u[7])
     }
 
+    #[inline]
+    fn mul_runtime(&self, rhs: &Self) -> Self {
+        #[cfg(all(
+            feature = "aarch64-asm",
+            target_arch = "aarch64",
+            target_vendor = "apple"
+        ))]
+        {
+            Fq(super::aarch64_asm::mul(&self.0, &rhs.0, &MODULUS.0, INV))
+        }
+
+        #[cfg(not(all(
+            feature = "aarch64-asm",
+            target_arch = "aarch64",
+            target_vendor = "apple"
+        )))]
+        {
+            self.mul(rhs)
+        }
+    }
+
+    #[inline]
+    fn square_runtime(&self) -> Self {
+        #[cfg(all(
+            feature = "aarch64-asm",
+            target_arch = "aarch64",
+            target_vendor = "apple"
+        ))]
+        {
+            Fq(super::aarch64_asm::square(&self.0, &MODULUS.0, INV))
+        }
+
+        #[cfg(not(all(
+            feature = "aarch64-asm",
+            target_arch = "aarch64",
+            target_vendor = "apple"
+        )))]
+        {
+            self.square()
+        }
+    }
+
     /// Subtracts `rhs` from `self`, returning the result.
     #[cfg_attr(not(feature = "uninline-portable"), inline)]
     pub const fn sub(&self, rhs: &Self) -> Self {
@@ -544,7 +586,7 @@ impl ff::Field for Fq {
 
     #[inline(always)]
     fn square(&self) -> Self {
-        self.square()
+        self.square_runtime()
     }
 
     fn sqrt_ratio(num: &Self, div: &Self) -> (Choice, Self) {
@@ -818,6 +860,54 @@ impl ec_gpu::GpuField for Fq {
 
     fn modulus() -> alloc::vec::Vec<u32> {
         crate::fields::u64_to_u32(&MODULUS.0[..])
+    }
+}
+
+#[cfg(all(
+    test,
+    feature = "aarch64-asm",
+    target_arch = "aarch64",
+    target_vendor = "apple"
+))]
+#[test]
+fn aarch64_asm_matches_portable_arithmetic() {
+    use rand::SeedableRng;
+
+    let modulus_minus_one =
+        Fq::from_raw([MODULUS.0[0] - 1, MODULUS.0[1], MODULUS.0[2], MODULUS.0[3]]);
+    let boundaries = [
+        Fq::zero(),
+        Fq::one(),
+        -Fq::one(),
+        Fq::from_raw([1, 0, 0, 0]),
+        modulus_minus_one,
+        Fq::from_raw([u64::MAX; 4]),
+    ];
+
+    for lhs in boundaries {
+        assert_eq!(<Fq as Field>::square(&lhs), Fq::square(&lhs));
+        for rhs in boundaries {
+            assert_eq!(&lhs * &rhs, Fq::mul(&lhs, &rhs));
+        }
+    }
+
+    let mut rng = rand_xorshift::XorShiftRng::from_seed([0xa5; 16]);
+    for _ in 0..1024 {
+        let lhs = Fq::from_raw([
+            rng.next_u64(),
+            rng.next_u64(),
+            rng.next_u64(),
+            rng.next_u64(),
+        ]);
+        let rhs = Fq::from_raw([
+            rng.next_u64(),
+            rng.next_u64(),
+            rng.next_u64(),
+            rng.next_u64(),
+        ]);
+
+        assert_eq!(&lhs * &rhs, Fq::mul(&lhs, &rhs));
+        assert_eq!(<Fq as Field>::square(&lhs), Fq::square(&lhs));
     }
 }
 


### PR DESCRIPTION
## Summary

This adds an `aarch64-asm` feature that uses Pasta-specific Montgomery
multiplication, squaring, and conversion assembly on Apple AArch64 targets.
The assembly is adapted from Semolina v0.1.4, with the original copyright and
Apache-2.0 attribution retained.

The commits are intentionally separated so their effects remain measurable:

1. Add the feature-gated backend and route field operator and
   `ff::Field::square` calls through it.
2. Route the concrete curve implementation's hot squaring operations through
   `ff::Field::square`.
3. Route `PrimeField::to_repr` through Semolina's dedicated sparse
   Montgomery-to-canonical reducer.

Portable arithmetic remains the default. Enabling the feature on a target
other than Apple AArch64 continues to use the portable implementation.

The backend executes fixed instruction sequences with no secret-dependent
branches or memory accesses. Conditional modular subtraction uses AArch64
conditional selection rather than control flow.

## Performance

Single-threaded genuine one-action Orchard proving at $k = 11$, measured as a
source-identical feature delta on the then-current optimization stack:

| Configuration | Median | Change vs portable |
| --- | ---: | ---: |
| Portable | 1,476.24 ms | baseline |
| Assembly multiplication and trait squaring | about 1,273.89 ms | 13.7% less |
| Plus concrete curve-square routing | 1,257.33 ms | 14.83% less / 1.174x |

On the single-threaded verifier stack, the same backend reduced genuine
one-action batch-verifier medians by 11.22%, 11.07%, 8.99%, and 7.62% at batch
sizes 1, 2, 16, and 64 respectively.

The `to_repr` change was measured separately with strictly sequential
Criterion runs, 100 samples, a five-second warm-up, and a 15-second
measurement window. Times are nanoseconds per call:

| Field | Portable runs | Full asm multiply by raw one | Dedicated reducer runs | Balanced geomean change |
| --- | ---: | ---: | ---: | ---: |
| `Fp` | 10.516 / 10.379 | 12.160 | 10.076 / 10.092 | 10.4473 -> 10.0840, 3.477% less / 1.0360x |
| `Fq` | 10.544 / 10.373 | 12.131 | 10.055 / 10.130 | 10.4582 -> 10.0924, 3.497% less / 1.0362x |

Calling the full assembly multiplier with raw one was deliberately tested
first and rejected: it regressed `Fp` by 15.63% and `Fq` by 15.05% relative to
the first portable runs. That prototype is not included. The retained path is
Semolina's dedicated `from_mont_pasta` wrapper, which invokes only the sparse
four-round reducer.

This is a generic serialization micro-optimization rather than a material
addition to the Orchard proving result above. The large `pasta-msm` path
receives Montgomery scalars directly, so this does not speed up its internal
work. It helps Rust MSM fallback, GLV decomposition, transcripts, encodings,
ordering, and parity checks.

## Validation

- `cargo fmt --all -- --check`
- `cargo +stable test --locked --offline --features aarch64-asm`
- `cargo +stable test --locked --offline --no-default-features --features aarch64-asm`
- `cargo +stable test --locked --offline --all-features`
- `cargo +stable test --release --locked --offline --all-features`
- `cargo +stable test --release --locked --offline --no-default-features`
- `cargo +stable test --release --locked --offline --no-default-features --features aarch64-asm`
- `cargo +1.63 check --locked --features aarch64-asm --lib`
- `cargo +1.63 clippy --locked --all-features --all-targets -- -D warnings`
- Dedicated-reducer validation on stable:
  - default features plus `aarch64-asm`: 31 unit tests and one doc-test
  - no default features plus `aarch64-asm`: 24 unit tests
  - all features: 83 unit tests and one doc-test
- Dedicated-reducer validation on Rust 1.63:
  - no default features plus `aarch64-asm`: 24 unit tests
  - all features: 83 unit tests and one doc-test
- `cargo clippy --all-targets --all-features -- -D warnings`

Differential `Fp` and `Fq` tests cover boundary values and 1,024 seeded random
values per field against the portable reducer. They also check
`from_repr(to_repr(value))`, `is_odd`, and field ordering against the portable
representation.

## API and dependencies

- Adds one public Cargo feature: `aarch64-asm`.
- Adds optional build dependency `cc = 1.0.83`, held at an MSRV-compatible
  release.
- Adds a private, narrowly-scoped unsafe FFI module with safe wrappers.
- Adds three `pub(super)` safe wrappers inside that private module: field
  multiplication, squaring, and Montgomery-to-canonical conversion.
- Adds one private-external assembly symbol for the conversion routine.
- Does not add or change any downstream-public or `pub(crate)` Rust item,
  function signature, trait method, or visibility.

The third commit adds one private FFI declaration and call inside the existing
contained unsafe module. Its safe wrapper supplies non-aliasing, initialized
four-limb inputs and output for the duration of the call; the field type's
canonical-residue invariant and the Pasta modulus constants satisfy the
assembly preconditions.

## Licensing

The vendored assembly is Apache-2.0 and retains the Supranational copyright,
SPDX identifier, source version, and source URL. The crate is already licensed
`MIT OR Apache-2.0`; the assembly is distributed under the Apache-2.0 option.
The conversion routine is copied from the same already-attributed Semolina
v0.1.4 source, so it introduces no additional license or provenance.
