### PR TITLE
Apple AArch64 assembly backend for the Pasta fields

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,38 @@ jobs:
           --target ${{ matrix.target }}
           --no-default-features
 
+  aarch64-asm:
+    name: Apple AArch64 assembly backend
+    # macos-latest is Apple silicon, which is the only target the
+    # `aarch64-asm` feature actually compiles assembly for. The `test`
+    # matrix reaches this code through `--all-features`; this job pins the
+    # feature on its own, so a break is attributed rather than buried in a
+    # combined run, and so the backend's tests are known to have run.
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Confirm the runner is Apple AArch64
+        # If GitHub ever moves macos-latest back to x86_64, the feature would
+        # compile out and every check below would pass vacuously.
+        run: test "$(uname -sm)" = "Darwin arm64"
+      - name: Build with the assembly backend
+        run: cargo build --verbose --features aarch64-asm
+      - name: Run tests with the assembly backend
+        run: cargo test --verbose --release --features aarch64-asm
+      - name: Confirm the backend's own tests ran
+        # A cfg-gated test that silently compiles out still reports success,
+        # so assert that both differential tests were actually executed.
+        run: |
+          out=$(cargo test --release --features aarch64-asm -- --exact \
+            fields::fp::aarch64_asm_matches_portable_arithmetic \
+            fields::fq::aarch64_asm_matches_portable_arithmetic)
+          echo "$out"
+          echo "$out" | grep -q '2 passed'
+      - name: Verify working directory is clean
+        run: git diff --exit-code
+
   bitrot:
     name: Bitrot check
     runs-on: ubuntu-latest
@@ -140,6 +172,7 @@ jobs:
       - test
       - test-32-bit
       - no-std
+      - aarch64-asm
       - bitrot
     # `always()` is load-bearing: without it this job is skipped when a
     # needed job fails, and GitHub treats a skipped required check as

--- a/.github/workflows/lints-stable.yml
+++ b/.github/workflows/lints-stable.yml
@@ -24,3 +24,19 @@ jobs:
           # go in `deny`/`warn` (the action places them after the `--`).
           check-args: --all-features --all-targets
           deny: warnings
+
+  clippy-aarch64-asm:
+    name: Clippy (Apple AArch64 assembly backend)
+    timeout-minutes: 30
+    # The gated backend is compiled out everywhere else, so the ubuntu clippy
+    # job above never lints a line of it.
+    runs-on: macos-latest
+    permissions:
+      contents: read # check out the repository
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Run clippy
+        run: cargo clippy --all-targets --features aarch64-asm -- -D warnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- An assembly implementation of Pallas and Vesta base and scalar field
+  multiplication, squaring and Montgomery reduction for Apple AArch64, behind
+  the new `aarch64-asm` feature flag. The feature is opt-in and has no effect
+  on other targets; with it disabled the existing portable implementation is
+  used unchanged.
+
 ### Changed
 - MSRV is now 1.88.0.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,28 @@ and this project adheres to Rust's notion of
   the new `aarch64-asm` feature flag. The feature is opt-in and has no effect
   on other targets; with it disabled the existing portable implementation is
   used unchanged.
+- The `aarch64-asm` backend's exponentiation chains (`invert`, `pow_vartime`,
+  and the square-root chains) use a fused "square `n` times, then multiply"
+  assembly routine that keeps the accumulator in registers for the whole run.
 
 ### Changed
+- `Fp::pow_vartime` and `Fq::pow_vartime` now fuse each run of squarings with
+  the following multiplication. The sequence of field operations (and thus
+  the variable-time profile, which depends only on the exponent) is
+  unchanged. This applies on every target, not only Apple AArch64; without
+  the assembly backend the fused helper falls back to the portable
+  square-and-multiply loop.
+- The `aarch64-asm` backend now implements runtime multiplication and
+  squaring as inline assembly with register operands instead of calls into
+  the assembly file. This removes the per-operation call and memory
+  round-trip, which speeds up all composed arithmetic, notably curve point
+  operations (`double`, mixed addition) and everything built on them.
+- The `aarch64-asm` Montgomery multiplication no longer captures and compares
+  a provably-zero fifth output limb. Direct `Fp` and `Fq` multiplication
+  benchmarks are approximately 1.7% faster on Apple M4. The bound that makes
+  the limb provably zero needs a canonical `rhs` (which every caller already
+  supplies); the assembly wrappers now debug-assert it, since a violation
+  would yield an incorrect residue rather than a merely non-canonical one.
 - MSRV is now 1.88.0.
 
 ## [0.5.2] - 2026-07-23

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
+name = "cc"
+version = "1.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -251,6 +261,12 @@ dependencies = [
  "rand_core",
  "subtle",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "funty"
@@ -415,6 +431,7 @@ version = "0.5.2"
 dependencies = [
  "bincode",
  "blake2b_simd",
+ "cc",
  "criterion",
  "ec-gpu",
  "ff",
@@ -654,6 +671,12 @@ dependencies = [
  "ryu",
  "serde",
 ]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "spin"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/zcash/pasta_curves"
 documentation = "https://docs.rs/pasta_curves"
 readme = "README.md"
+build = "build.rs"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -72,6 +73,7 @@ serde_crate = { version = "1.0.16", optional = true, default-features = false, f
 hex = { version = "0.4", optional = true, default-features = false, features = ["alloc", "serde"] }
 
 [features]
+aarch64-asm = ["dep:cc"]
 default = ["bits", "sqrt-table"]
 alloc = ["group/alloc", "blake2b_simd"]
 bits = ["ff/bits"]
@@ -82,3 +84,7 @@ repr-c = []
 uninline-portable = []
 deferred = []
 serde = ["hex", "serde_crate"]
+
+[build-dependencies]
+# Latest release compatible with the MSRV.
+cc = { version = "1", optional = true }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,21 @@
+#[cfg(feature = "aarch64-asm")]
+use std::env;
+
+fn main() {
+    println!("cargo:rerun-if-changed=src/asm/pasta_mul-armv8.S");
+
+    #[cfg(feature = "aarch64-asm")]
+    build_aarch64_asm();
+}
+
+#[cfg(feature = "aarch64-asm")]
+fn build_aarch64_asm() {
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+    let target_vendor = env::var("CARGO_CFG_TARGET_VENDOR").unwrap();
+
+    if target_arch == "aarch64" && target_vendor == "apple" {
+        cc::Build::new()
+            .file("src/asm/pasta_mul-armv8.S")
+            .compile("pasta_curves_aarch64");
+    }
+}

--- a/src/asm/pasta_mul-armv8.S
+++ b/src/asm/pasta_mul-armv8.S
@@ -1,0 +1,395 @@
+// Copyright Supranational LLC
+// Licensed under the Apache License, Version 2.0, see LICENSE-APACHE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Adapted from the pre-generated Mach-O assembly in Semolina v0.1.4:
+// https://github.com/supranational/semolina/blob/v0.1.4/src/mach-o/pasta_mul-armv8.S
+//
+// Only Montgomery multiplication, squaring, and the squaring reduction helper
+// are retained. Symbols are renamed for this crate. The implementation relies
+// on both Pasta moduli having limb 2 equal to zero and limb 3 equal to 2^62.
+
+.text
+
+.globl _pasta_curves_mul_mont_pasta
+.private_extern _pasta_curves_mul_mont_pasta
+
+.align 5
+_pasta_curves_mul_mont_pasta:
+    stp x29,x30,[sp,#-64]!
+    add x29,sp,#0
+    stp x19,x20,[sp,#16]
+    stp x21,x22,[sp,#32]
+    stp x23,x24,[sp,#48]
+
+    ldp x10,x11,[x1]
+    ldr x9,        [x2]
+    ldp x12,x13,[x1,#16]
+
+    mul x19,x10,x9
+    ldp x5,x6,[x3]
+    mul x20,x11,x9
+    ldp x7,x8,[x3,#16]
+    mul x21,x12,x9
+    mul x22,x13,x9
+
+    umulh x14,x10,x9
+    umulh x15,x11,x9
+    mul x3,x4,x19
+    umulh x16,x12,x9
+    umulh x17,x13,x9
+    adds x20,x20,x14
+    //mul x14,x5,x3
+    adcs x21,x21,x15
+    mul x15,x6,x3
+    adcs x22,x22,x16
+    //mul x16,x7,x3 //x7==0
+    adc x23,xzr,    x17
+    lsl x17,x3,#62      //mul x17,x8,x3
+    ldr x9,[x2,8*1]
+    subs xzr,x19,#1     //adds x19,x19,x14
+    umulh x14,x5,x3
+    adcs x20,x20,x15
+    umulh x15,x6,x3
+    adcs x21,x21,xzr    //x16
+    //umulh x16,x7,x3   //x7==0
+    adcs x22,x22,x17
+    lsr x17,x3,#2       //umulh x17,x8,x3
+    adc x23,x23,xzr
+
+    adds x19,x20,x14
+    mul x14,x10,x9
+    adcs x20,x21,x15
+    mul x15,x11,x9
+    adcs x21,x22,xzr    //x16
+    mul x16,x12,x9
+    adcs x22,x23,x17
+    mul x17,x13,x9
+    adc x23,xzr,xzr
+
+    adds x19,x19,x14
+    umulh x14,x10,x9
+    adcs x20,x20,x15
+    umulh x15,x11,x9
+    adcs x21,x21,x16
+    mul x3,x4,x19
+    umulh x16,x12,x9
+    adcs x22,x22,x17
+    umulh x17,x13,x9
+    adc x23,x23,xzr
+
+    adds x20,x20,x14
+    //mul x14,x5,x3
+    adcs x21,x21,x15
+    mul x15,x6,x3
+    adcs x22,x22,x16
+    //mul x16,x7,x3 //x7==0
+    adc x23,x23,x17
+    lsl x17,x3,#62      //mul x17,x8,x3
+    ldr x9,[x2,8*2]
+    subs xzr,x19,#1     //adds x19,x19,x14
+    umulh x14,x5,x3
+    adcs x20,x20,x15
+    umulh x15,x6,x3
+    adcs x21,x21,xzr    //x16
+    //umulh x16,x7,x3   //x7==0
+    adcs x22,x22,x17
+    lsr x17,x3,#2       //umulh x17,x8,x3
+    adc x23,x23,xzr
+
+    adds x19,x20,x14
+    mul x14,x10,x9
+    adcs x20,x21,x15
+    mul x15,x11,x9
+    adcs x21,x22,xzr    //x16
+    mul x16,x12,x9
+    adcs x22,x23,x17
+    mul x17,x13,x9
+    adc x23,xzr,xzr
+
+    adds x19,x19,x14
+    umulh x14,x10,x9
+    adcs x20,x20,x15
+    umulh x15,x11,x9
+    adcs x21,x21,x16
+    mul x3,x4,x19
+    umulh x16,x12,x9
+    adcs x22,x22,x17
+    umulh x17,x13,x9
+    adc x23,x23,xzr
+
+    adds x20,x20,x14
+    //mul x14,x5,x3
+    adcs x21,x21,x15
+    mul x15,x6,x3
+    adcs x22,x22,x16
+    //mul x16,x7,x3 //x7==0
+    adc x23,x23,x17
+    lsl x17,x3,#62      //mul x17,x8,x3
+    ldr x9,[x2,8*3]
+    subs xzr,x19,#1     //adds x19,x19,x14
+    umulh x14,x5,x3
+    adcs x20,x20,x15
+    umulh x15,x6,x3
+    adcs x21,x21,xzr    //x16
+    //umulh x16,x7,x3   //x7==0
+    adcs x22,x22,x17
+    lsr x17,x3,#2       //umulh x17,x8,x3
+    adc x23,x23,xzr
+
+    adds x19,x20,x14
+    mul x14,x10,x9
+    adcs x20,x21,x15
+    mul x15,x11,x9
+    adcs x21,x22,xzr    //x16
+    mul x16,x12,x9
+    adcs x22,x23,x17
+    mul x17,x13,x9
+    adc x23,xzr,xzr
+
+    adds x19,x19,x14
+    umulh x14,x10,x9
+    adcs x20,x20,x15
+    umulh x15,x11,x9
+    adcs x21,x21,x16
+    mul x3,x4,x19
+    umulh x16,x12,x9
+    adcs x22,x22,x17
+    umulh x17,x13,x9
+    adc x23,x23,xzr
+
+    adds x20,x20,x14
+    //mul x14,x5,x3
+    adcs x21,x21,x15
+    mul x15,x6,x3
+    adcs x22,x22,x16
+    //mul x16,x7,x3 //x7==0
+    adc x23,x23,x17
+    lsl x17,x3,#62      //mul x17,x8,x3
+    subs xzr,x19,#1     //adds x19,x19,x14
+    umulh x14,x5,x3
+    adcs x20,x20,x15
+    umulh x15,x6,x3
+    adcs x21,x21,xzr    //x16
+    //umulh x16,x7,x3   //x7==0
+    adcs x22,x22,x17
+    lsr x17,x3,#2       //umulh x17,x8,x3
+    adc x23,x23,xzr
+
+    adds x19,x20,x14
+    adcs x20,x21,x15
+    adcs x21,x22,xzr    //x16
+    adcs x22,x23,x17
+    adc x23,xzr,xzr
+
+    subs x14,x19,x5
+    sbcs x15,x20,x6
+    sbcs x16,x21,xzr    //x7
+    sbcs x17,x22,x8
+    sbcs xzr,    x23,xzr
+
+    csel x19,x19,x14,lo
+    csel x20,x20,x15,lo
+    csel x21,x21,x16,lo
+    csel x22,x22,x17,lo
+
+    stp x19,x20,[x0]
+    stp x21,x22,[x0,#16]
+
+    ldp x19,x20,[x29,#16]
+    ldp x21,x22,[x29,#32]
+    ldp x23,x24,[x29,#48]
+    ldr x29,[sp],#64
+    ret
+
+.globl _pasta_curves_sqr_mont_pasta
+.private_extern _pasta_curves_sqr_mont_pasta
+
+.align 5
+_pasta_curves_sqr_mont_pasta:
+    .long 3573752639
+    stp x29,x30,[sp,#-48]!
+    add x29,sp,#0
+    stp x19,x20,[sp,#16]
+    stp x21,x22,[sp,#32]
+
+    ldp x5,x6,[x1]
+    ldp x7,x8,[x1,#16]
+    mov x4,x3
+
+    ////////////////////////////////////////////////////////////////
+    //  |  |  |  |  |  |a1*a0|  |
+    //  |  |  |  |  |a2*a0|  |  |
+    //  |  |a3*a2|a3*a0|  |  |  |
+    //  |  |  |  |a2*a1|  |  |  |
+    //  |  |  |a3*a1|  |  |  |  |
+    // *|  |  |  |  |  |  |  | 2|
+    // +|a3*a3|a2*a2|a1*a1|a0*a0|
+    //  |--+--+--+--+--+--+--+--|
+    //  |A7|A6|A5|A4|A3|A2|A1|A0|, where Ax is x10
+    //
+    //  "can't overflow" below mark carrying into high part of
+    //  multiplication result, which can't overflow, because it
+    //  can never be all ones.
+
+    mul x11,x6,x5        // a[1]*a[0]
+    umulh x15,x6,x5
+    mul x12,x7,x5        // a[2]*a[0]
+    umulh x16,x7,x5
+    mul x13,x8,x5        // a[3]*a[0]
+    umulh x19,x8,x5
+
+    adds x12,x12,x15     // accumulate high parts of multiplication
+    mul x14,x7,x6        // a[2]*a[1]
+    umulh x15,x7,x6
+    adcs x13,x13,x16
+    mul x16,x8,x6        // a[3]*a[1]
+    umulh x17,x8,x6
+    adc x19,x19,xzr      // can't overflow
+
+    mul x20,x8,x7        // a[3]*a[2]
+    umulh x21,x8,x7
+
+    adds x15,x15,x16     // accumulate high parts of multiplication
+    mul x10,x5,x5        // a[0]*a[0]
+    adc x16,x17,xzr      // can't overflow
+
+    adds x13,x13,x14     // accumulate low parts of multiplication
+    umulh x5,x5,x5
+    adcs x19,x19,x15
+    mul x15,x6,x6        // a[1]*a[1]
+    adcs x20,x20,x16
+    umulh x6,x6,x6
+    adc x21,x21,xzr      // can't overflow
+
+    adds x11,x11,x11     // acc[1-6]*=2
+    mul x16,x7,x7        // a[2]*a[2]
+    adcs x12,x12,x12
+    umulh x7,x7,x7
+    adcs x13,x13,x13
+    mul x17,x8,x8        // a[3]*a[3]
+    adcs x19,x19,x19
+    umulh x8,x8,x8
+    adcs x20,x20,x20
+    adcs x21,x21,x21
+    adc x22,xzr,xzr
+
+    adds x11,x11,x5      // +a[i]*a[i]
+    adcs x12,x12,x15
+    adcs x13,x13,x6
+    adcs x19,x19,x16
+    adcs x20,x20,x7
+    adcs x21,x21,x17
+    adc x22,x22,x8
+
+    bl L$pasta_curves_mul_by_1_mont_pasta
+    ldr x30,[x29,#8]
+
+    adds x10,x10,x19     // accumulate upper half
+    adcs x11,x11,x20
+    adcs x12,x12,x21
+    adcs x13,x13,x22
+    adc x19,xzr,xzr
+
+    subs x14,x10,x5
+    sbcs x15,x11,x6
+    sbcs x16,x12,x7
+    sbcs x17,x13,x8
+    sbcs xzr,    x19,xzr
+
+    csel x10,x10,x14,lo
+    csel x11,x11,x15,lo
+    csel x12,x12,x16,lo
+    csel x13,x13,x17,lo
+
+    stp x10,x11,[x0]
+    stp x12,x13,[x0,#16]
+
+    ldp x19,x20,[x29,#16]
+    ldp x21,x22,[x29,#32]
+    ldr x29,[sp],#48
+    .long 3573752767
+    ret
+
+.align 5
+L$pasta_curves_mul_by_1_mont_pasta:
+    mul x3,x4,x10
+    ldp x5,x6,[x2]
+    ldp x7,x8,[x2,#16]
+    //mul x14,x5,x3
+    mul x15,x6,x3
+    //mul x16,x7,x3 //mod[2]==0
+    lsl x17,x3,#62      //mul x17,x8,x3
+    subs xzr,x10,#1     //adds x10,x10,x14
+    umulh x14,x5,x3
+    adcs x11,x11,x15
+    umulh x15,x6,x3
+    adcs x12,x12,xzr    //x16
+    //umulh x16,x7,x3   //x7==0
+    adcs x13,x13,x17
+    lsr x17,x3,#2       //umulh x17,x8,x3
+    adc x9,xzr,xzr
+
+    adds x10,x11,x14
+    adcs x11,x12,x15
+    adcs x12,x13,xzr    //x16
+    mul x3,x4,x10
+    adc x13,x9,x17
+    //mul x14,x5,x3
+    mul x15,x6,x3
+    //mul x16,x7,x3 //mod[2]==0
+    lsl x17,x3,#62      //mul x17,x8,x3
+    subs xzr,x10,#1     //adds x10,x10,x14
+    umulh x14,x5,x3
+    adcs x11,x11,x15
+    umulh x15,x6,x3
+    adcs x12,x12,xzr    //x16
+    //umulh x16,x7,x3   //x7==0
+    adcs x13,x13,x17
+    lsr x17,x3,#2       //umulh x17,x8,x3
+    adc x9,xzr,xzr
+
+    adds x10,x11,x14
+    adcs x11,x12,x15
+    adcs x12,x13,xzr    //x16
+    mul x3,x4,x10
+    adc x13,x9,x17
+    //mul x14,x5,x3
+    mul x15,x6,x3
+    //mul x16,x7,x3 //mod[2]==0
+    lsl x17,x3,#62      //mul x17,x8,x3
+    subs xzr,x10,#1     //adds x10,x10,x14
+    umulh x14,x5,x3
+    adcs x11,x11,x15
+    umulh x15,x6,x3
+    adcs x12,x12,xzr    //x16
+    //umulh x16,x7,x3   //x7==0
+    adcs x13,x13,x17
+    lsr x17,x3,#2       //umulh x17,x8,x3
+    adc x9,xzr,xzr
+
+    adds x10,x11,x14
+    adcs x11,x12,x15
+    adcs x12,x13,xzr    //x16
+    mul x3,x4,x10
+    adc x13,x9,x17
+    //mul x14,x5,x3
+    mul x15,x6,x3
+    //mul x16,x7,x3 //mod[2]==0
+    lsl x17,x3,#62      //mul x17,x8,x3
+    subs xzr,x10,#1     //adds x10,x10,x14
+    umulh x14,x5,x3
+    adcs x11,x11,x15
+    umulh x15,x6,x3
+    adcs x12,x12,xzr    //x16
+    //umulh x16,x7,x3   //x7==0
+    adcs x13,x13,x17
+    lsr x17,x3,#2       //umulh x17,x8,x3
+    adc x9,xzr,xzr
+
+    adds x10,x11,x14
+    adcs x11,x12,x15
+    adcs x12,x13,xzr    //x16
+    adc x13,x9,x17
+
+    ret

--- a/src/asm/pasta_mul-armv8.S
+++ b/src/asm/pasta_mul-armv8.S
@@ -5,9 +5,10 @@
 // Adapted from the pre-generated Mach-O assembly in Semolina v0.1.4:
 // https://github.com/supranational/semolina/blob/v0.1.4/src/mach-o/pasta_mul-armv8.S
 //
-// Only Montgomery multiplication, squaring, and the squaring reduction helper
-// are retained. Symbols are renamed for this crate. The implementation relies
-// on both Pasta moduli having limb 2 equal to zero and limb 3 equal to 2^62.
+// Only Montgomery multiplication, squaring, conversion, and their shared
+// reduction helper are retained. Symbols are renamed for this crate. The
+// implementation relies on both Pasta moduli having limb 2 equal to zero and
+// limb 3 equal to 2^62.
 
 .text
 
@@ -308,6 +309,39 @@ _pasta_curves_sqr_mont_pasta:
     ldp x19,x20,[x29,#16]
     ldp x21,x22,[x29,#32]
     ldr x29,[sp],#48
+    .long 3573752767
+    ret
+
+.globl _pasta_curves_from_mont_pasta
+.private_extern _pasta_curves_from_mont_pasta
+
+.align 5
+_pasta_curves_from_mont_pasta:
+    .long 3573752639
+    stp x29,x30,[sp,#-16]!
+    add x29,sp,#0
+
+    mov x4,x3
+    ldp x10,x11,[x1]
+    ldp x12,x13,[x1,#16]
+
+    bl L$pasta_curves_mul_by_1_mont_pasta
+    ldr x30,[x29,#8]
+
+    subs x14,x10,x5
+    sbcs x15,x11,x6
+    sbcs x16,x12,x7
+    sbcs x17,x13,x8
+
+    csel x10,x10,x14,lo
+    csel x11,x11,x15,lo
+    csel x12,x12,x16,lo
+    csel x13,x13,x17,lo
+
+    stp x10,x11,[x0]
+    stp x12,x13,[x0,#16]
+
+    ldr x29,[sp],#16
     .long 3573752767
     ret
 

--- a/src/asm/pasta_mul-armv8.S
+++ b/src/asm/pasta_mul-armv8.S
@@ -10,6 +10,20 @@
 // implementation relies on both Pasta moduli having limb 2 equal to zero and
 // limb 3 equal to 2^62.
 
+// All field elements and moduli are four little-endian 64-bit limbs. `inv` is
+// -modulus[0]^-1 mod 2^64. The routines implement Montgomery reduction with
+// R = 2^256. Registers named as limbs below always list the least-significant
+// limb first.
+//
+// Apple AArch64 argument registers:
+//
+// - mul:       x0 = out, x1 = lhs, x2 = rhs, x3 = modulus, x4 = inv
+// - square:    x0 = out, x1 = value, x2 = modulus, x3 = inv
+// - from_mont: x0 = out, x1 = value, x2 = modulus, x3 = inv
+//
+// The code has no secret-dependent branches or memory accesses. Conditional
+// reductions use `csel` after a full-width subtraction.
+
 .text
 
 .globl _pasta_curves_mul_mont_pasta
@@ -17,206 +31,217 @@
 
 .align 5
 _pasta_curves_mul_mont_pasta:
-    stp x29,x30,[sp,#-64]!
-    add x29,sp,#0
-    stp x19,x20,[sp,#16]
-    stp x21,x22,[sp,#32]
-    stp x23,x24,[sp,#48]
+    stp x29,x30,[sp,#-64]! // Allocate frame; save frame pointer and LR.
+    add x29,sp,#0           // Set the frame pointer to the new stack top.
+    stp x19,x20,[sp,#16]    // Preserve callee-saved accumulator limbs 0-1.
+    stp x21,x22,[sp,#32]    // Preserve callee-saved accumulator limbs 2-3.
+    stp x23,x24,[sp,#48]    // Preserve the carry limb and paired x24.
 
-    ldp x10,x11,[x1]
-    ldr x9,        [x2]
-    ldp x12,x13,[x1,#16]
+    ldp x10,x11,[x1]        // Load lhs limbs a[0] and a[1].
+    ldr x9,[x2]             // Load rhs limb b[0].
+    ldp x12,x13,[x1,#16]    // Load lhs limbs a[2] and a[3].
 
-    mul x19,x10,x9
-    ldp x5,x6,[x3]
-    mul x20,x11,x9
-    ldp x7,x8,[x3,#16]
-    mul x21,x12,x9
-    mul x22,x13,x9
+    // Form the five-limb product a * b[0] in x19..x23.
+    mul x19,x10,x9          // x19 = low(a[0] * b[0]).
+    ldp x5,x6,[x3]          // Load modulus limbs p[0] and p[1].
+    mul x20,x11,x9          // x20 = low(a[1] * b[0]).
+    ldp x7,x8,[x3,#16]      // Load p[2] = 0 and p[3] = 2^62.
+    mul x21,x12,x9          // x21 = low(a[2] * b[0]).
+    mul x22,x13,x9          // x22 = low(a[3] * b[0]).
 
-    umulh x14,x10,x9
-    umulh x15,x11,x9
-    mul x3,x4,x19
-    umulh x16,x12,x9
-    umulh x17,x13,x9
-    adds x20,x20,x14
-    //mul x14,x5,x3
-    adcs x21,x21,x15
-    mul x15,x6,x3
-    adcs x22,x22,x16
-    //mul x16,x7,x3 //x7==0
-    adc x23,xzr,    x17
-    lsl x17,x3,#62      //mul x17,x8,x3
-    ldr x9,[x2,8*1]
-    subs xzr,x19,#1     //adds x19,x19,x14
-    umulh x14,x5,x3
-    adcs x20,x20,x15
-    umulh x15,x6,x3
-    adcs x21,x21,xzr    //x16
-    //umulh x16,x7,x3   //x7==0
-    adcs x22,x22,x17
-    lsr x17,x3,#2       //umulh x17,x8,x3
-    adc x23,x23,xzr
+    umulh x14,x10,x9        // x14 = high(a[0] * b[0]).
+    umulh x15,x11,x9        // x15 = high(a[1] * b[0]).
+    mul x3,x4,x19           // q = x19 * inv mod 2^64.
+    umulh x16,x12,x9        // x16 = high(a[2] * b[0]).
+    umulh x17,x13,x9        // x17 = high(a[3] * b[0]).
+    adds x20,x20,x14        // Add high(a[0] * b[0]) into limb 1.
+    // low(q * p[0]) cancels x19 and is discarded by the limb shift.
+    adcs x21,x21,x15        // Add high(a[1] * b[0]) and carry.
+    mul x15,x6,x3           // x15 = low(q * p[1]).
+    adcs x22,x22,x16        // Add high(a[2] * b[0]) and carry.
+    // q * p[2] is zero because p[2] = 0.
+    adc x23,xzr,x17         // Finish a * b[0] with its fifth limb.
+    lsl x17,x3,#62          // x17 = low(q * p[3]).
+    ldr x9,[x2,8*1]         // Load rhs limb b[1] for the next round.
+    // Carry from x19 + low(q*p[0]) is one exactly when x19 is nonzero.
+    subs xzr,x19,#1         // Set that carry without computing the zero sum.
+    umulh x14,x5,x3         // x14 = high(q * p[0]).
+    adcs x20,x20,x15        // Add low(q * p[1]) and cancellation carry.
+    umulh x15,x6,x3         // x15 = high(q * p[1]).
+    adcs x21,x21,xzr        // Propagate carry; p[2]'s product is zero.
+    // high(q * p[2]) is zero.
+    adcs x22,x22,x17        // Add low(q * p[3]) and carry.
+    lsr x17,x3,#2           // x17 = high(q * p[3]).
+    adc x23,x23,xzr         // Propagate carry into the fifth limb.
 
-    adds x19,x20,x14
-    mul x14,x10,x9
-    adcs x20,x21,x15
-    mul x15,x11,x9
-    adcs x21,x22,xzr    //x16
-    mul x16,x12,x9
-    adcs x22,x23,x17
-    mul x17,x13,x9
-    adc x23,xzr,xzr
+    // Drop the cancelled low limb: (a*b[0] + q*p) / 2^64.
+    adds x19,x20,x14        // New limb 0 includes high(q * p[0]).
+    mul x14,x10,x9          // x14 = low(a[0] * b[1]).
+    adcs x20,x21,x15        // New limb 1 includes high(q * p[1]).
+    mul x15,x11,x9          // x15 = low(a[1] * b[1]).
+    adcs x21,x22,xzr        // New limb 2; p[2] contributes zero.
+    mul x16,x12,x9          // x16 = low(a[2] * b[1]).
+    adcs x22,x23,x17        // New limb 3 includes high(q * p[3]).
+    mul x17,x13,x9          // x17 = low(a[3] * b[1]).
+    adc x23,xzr,xzr         // Capture the reduction carry as limb 4.
 
-    adds x19,x19,x14
-    umulh x14,x10,x9
-    adcs x20,x20,x15
-    umulh x15,x11,x9
-    adcs x21,x21,x16
-    mul x3,x4,x19
-    umulh x16,x12,x9
-    adcs x22,x22,x17
-    umulh x17,x13,x9
-    adc x23,x23,xzr
+    // Round 1: add a * b[1] to the reduced accumulator.
+    adds x19,x19,x14        // Add low(a[0] * b[1]) to limb 0.
+    umulh x14,x10,x9        // x14 = high(a[0] * b[1]).
+    adcs x20,x20,x15        // Add low(a[1] * b[1]) and carry.
+    umulh x15,x11,x9        // x15 = high(a[1] * b[1]).
+    adcs x21,x21,x16        // Add low(a[2] * b[1]) and carry.
+    mul x3,x4,x19           // q = current limb 0 * inv mod 2^64.
+    umulh x16,x12,x9        // x16 = high(a[2] * b[1]).
+    adcs x22,x22,x17        // Add low(a[3] * b[1]) and carry.
+    umulh x17,x13,x9        // x17 = high(a[3] * b[1]).
+    adc x23,x23,xzr         // Propagate multiplication carry to limb 4.
 
-    adds x20,x20,x14
-    //mul x14,x5,x3
-    adcs x21,x21,x15
-    mul x15,x6,x3
-    adcs x22,x22,x16
-    //mul x16,x7,x3 //x7==0
-    adc x23,x23,x17
-    lsl x17,x3,#62      //mul x17,x8,x3
-    ldr x9,[x2,8*2]
-    subs xzr,x19,#1     //adds x19,x19,x14
-    umulh x14,x5,x3
-    adcs x20,x20,x15
-    umulh x15,x6,x3
-    adcs x21,x21,xzr    //x16
-    //umulh x16,x7,x3   //x7==0
-    adcs x22,x22,x17
-    lsr x17,x3,#2       //umulh x17,x8,x3
-    adc x23,x23,xzr
+    adds x20,x20,x14        // Add high(a[0] * b[1]) to limb 1.
+    // low(q * p[0]) cancels x19.
+    adcs x21,x21,x15        // Add high(a[1] * b[1]) and carry.
+    mul x15,x6,x3           // x15 = low(q * p[1]).
+    adcs x22,x22,x16        // Add high(a[2] * b[1]) and carry.
+    // low(q * p[2]) is zero.
+    adc x23,x23,x17         // Add high(a[3] * b[1]) and final carry.
+    lsl x17,x3,#62          // x17 = low(q * p[3]).
+    ldr x9,[x2,8*2]         // Load rhs limb b[2] for the next round.
+    subs xzr,x19,#1         // Set the low-limb cancellation carry.
+    umulh x14,x5,x3         // x14 = high(q * p[0]).
+    adcs x20,x20,x15        // Add low(q * p[1]) and cancellation carry.
+    umulh x15,x6,x3         // x15 = high(q * p[1]).
+    adcs x21,x21,xzr        // Propagate carry across zero p[2].
+    // high(q * p[2]) is zero.
+    adcs x22,x22,x17        // Add low(q * p[3]) and carry.
+    lsr x17,x3,#2           // x17 = high(q * p[3]).
+    adc x23,x23,xzr         // Propagate carry to limb 4.
 
-    adds x19,x20,x14
-    mul x14,x10,x9
-    adcs x20,x21,x15
-    mul x15,x11,x9
-    adcs x21,x22,xzr    //x16
-    mul x16,x12,x9
-    adcs x22,x23,x17
-    mul x17,x13,x9
-    adc x23,xzr,xzr
+    // Shift after round 1 while starting a * b[2].
+    adds x19,x20,x14        // New limb 0 includes high(q * p[0]).
+    mul x14,x10,x9          // x14 = low(a[0] * b[2]).
+    adcs x20,x21,x15        // New limb 1 includes high(q * p[1]).
+    mul x15,x11,x9          // x15 = low(a[1] * b[2]).
+    adcs x21,x22,xzr        // New limb 2; p[2] contributes zero.
+    mul x16,x12,x9          // x16 = low(a[2] * b[2]).
+    adcs x22,x23,x17        // New limb 3 includes high(q * p[3]).
+    mul x17,x13,x9          // x17 = low(a[3] * b[2]).
+    adc x23,xzr,xzr         // Capture the reduction carry as limb 4.
 
-    adds x19,x19,x14
-    umulh x14,x10,x9
-    adcs x20,x20,x15
-    umulh x15,x11,x9
-    adcs x21,x21,x16
-    mul x3,x4,x19
-    umulh x16,x12,x9
-    adcs x22,x22,x17
-    umulh x17,x13,x9
-    adc x23,x23,xzr
+    // Round 2: add a * b[2] and cancel the resulting low limb.
+    adds x19,x19,x14        // Add low(a[0] * b[2]) to limb 0.
+    umulh x14,x10,x9        // x14 = high(a[0] * b[2]).
+    adcs x20,x20,x15        // Add low(a[1] * b[2]) and carry.
+    umulh x15,x11,x9        // x15 = high(a[1] * b[2]).
+    adcs x21,x21,x16        // Add low(a[2] * b[2]) and carry.
+    mul x3,x4,x19           // q = current limb 0 * inv mod 2^64.
+    umulh x16,x12,x9        // x16 = high(a[2] * b[2]).
+    adcs x22,x22,x17        // Add low(a[3] * b[2]) and carry.
+    umulh x17,x13,x9        // x17 = high(a[3] * b[2]).
+    adc x23,x23,xzr         // Propagate multiplication carry to limb 4.
 
-    adds x20,x20,x14
-    //mul x14,x5,x3
-    adcs x21,x21,x15
-    mul x15,x6,x3
-    adcs x22,x22,x16
-    //mul x16,x7,x3 //x7==0
-    adc x23,x23,x17
-    lsl x17,x3,#62      //mul x17,x8,x3
-    ldr x9,[x2,8*3]
-    subs xzr,x19,#1     //adds x19,x19,x14
-    umulh x14,x5,x3
-    adcs x20,x20,x15
-    umulh x15,x6,x3
-    adcs x21,x21,xzr    //x16
-    //umulh x16,x7,x3   //x7==0
-    adcs x22,x22,x17
-    lsr x17,x3,#2       //umulh x17,x8,x3
-    adc x23,x23,xzr
+    adds x20,x20,x14        // Add high(a[0] * b[2]) to limb 1.
+    // low(q * p[0]) cancels x19.
+    adcs x21,x21,x15        // Add high(a[1] * b[2]) and carry.
+    mul x15,x6,x3           // x15 = low(q * p[1]).
+    adcs x22,x22,x16        // Add high(a[2] * b[2]) and carry.
+    // low(q * p[2]) is zero.
+    adc x23,x23,x17         // Add high(a[3] * b[2]) and final carry.
+    lsl x17,x3,#62          // x17 = low(q * p[3]).
+    ldr x9,[x2,8*3]         // Load rhs limb b[3] for the last round.
+    subs xzr,x19,#1         // Set the low-limb cancellation carry.
+    umulh x14,x5,x3         // x14 = high(q * p[0]).
+    adcs x20,x20,x15        // Add low(q * p[1]) and cancellation carry.
+    umulh x15,x6,x3         // x15 = high(q * p[1]).
+    adcs x21,x21,xzr        // Propagate carry across zero p[2].
+    // high(q * p[2]) is zero.
+    adcs x22,x22,x17        // Add low(q * p[3]) and carry.
+    lsr x17,x3,#2           // x17 = high(q * p[3]).
+    adc x23,x23,xzr         // Propagate carry to limb 4.
 
-    adds x19,x20,x14
-    mul x14,x10,x9
-    adcs x20,x21,x15
-    mul x15,x11,x9
-    adcs x21,x22,xzr    //x16
-    mul x16,x12,x9
-    adcs x22,x23,x17
-    mul x17,x13,x9
-    adc x23,xzr,xzr
+    // Shift after round 2 while starting a * b[3].
+    adds x19,x20,x14        // New limb 0 includes high(q * p[0]).
+    mul x14,x10,x9          // x14 = low(a[0] * b[3]).
+    adcs x20,x21,x15        // New limb 1 includes high(q * p[1]).
+    mul x15,x11,x9          // x15 = low(a[1] * b[3]).
+    adcs x21,x22,xzr        // New limb 2; p[2] contributes zero.
+    mul x16,x12,x9          // x16 = low(a[2] * b[3]).
+    adcs x22,x23,x17        // New limb 3 includes high(q * p[3]).
+    mul x17,x13,x9          // x17 = low(a[3] * b[3]).
+    adc x23,xzr,xzr         // Capture the reduction carry as limb 4.
 
-    adds x19,x19,x14
-    umulh x14,x10,x9
-    adcs x20,x20,x15
-    umulh x15,x11,x9
-    adcs x21,x21,x16
-    mul x3,x4,x19
-    umulh x16,x12,x9
-    adcs x22,x22,x17
-    umulh x17,x13,x9
-    adc x23,x23,xzr
+    // Round 3: add a * b[3] and perform the last Montgomery cancellation.
+    adds x19,x19,x14        // Add low(a[0] * b[3]) to limb 0.
+    umulh x14,x10,x9        // x14 = high(a[0] * b[3]).
+    adcs x20,x20,x15        // Add low(a[1] * b[3]) and carry.
+    umulh x15,x11,x9        // x15 = high(a[1] * b[3]).
+    adcs x21,x21,x16        // Add low(a[2] * b[3]) and carry.
+    mul x3,x4,x19           // q = current limb 0 * inv mod 2^64.
+    umulh x16,x12,x9        // x16 = high(a[2] * b[3]).
+    adcs x22,x22,x17        // Add low(a[3] * b[3]) and carry.
+    umulh x17,x13,x9        // x17 = high(a[3] * b[3]).
+    adc x23,x23,xzr         // Propagate multiplication carry to limb 4.
 
-    adds x20,x20,x14
-    //mul x14,x5,x3
-    adcs x21,x21,x15
-    mul x15,x6,x3
-    adcs x22,x22,x16
-    //mul x16,x7,x3 //x7==0
-    adc x23,x23,x17
-    lsl x17,x3,#62      //mul x17,x8,x3
-    subs xzr,x19,#1     //adds x19,x19,x14
-    umulh x14,x5,x3
-    adcs x20,x20,x15
-    umulh x15,x6,x3
-    adcs x21,x21,xzr    //x16
-    //umulh x16,x7,x3   //x7==0
-    adcs x22,x22,x17
-    lsr x17,x3,#2       //umulh x17,x8,x3
-    adc x23,x23,xzr
+    adds x20,x20,x14        // Add high(a[0] * b[3]) to limb 1.
+    // low(q * p[0]) cancels x19.
+    adcs x21,x21,x15        // Add high(a[1] * b[3]) and carry.
+    mul x15,x6,x3           // x15 = low(q * p[1]).
+    adcs x22,x22,x16        // Add high(a[2] * b[3]) and carry.
+    // low(q * p[2]) is zero.
+    adc x23,x23,x17         // Add high(a[3] * b[3]) and final carry.
+    lsl x17,x3,#62          // x17 = low(q * p[3]).
+    subs xzr,x19,#1         // Set the low-limb cancellation carry.
+    umulh x14,x5,x3         // x14 = high(q * p[0]).
+    adcs x20,x20,x15        // Add low(q * p[1]) and cancellation carry.
+    umulh x15,x6,x3         // x15 = high(q * p[1]).
+    adcs x21,x21,xzr        // Propagate carry across zero p[2].
+    // high(q * p[2]) is zero.
+    adcs x22,x22,x17        // Add low(q * p[3]) and carry.
+    lsr x17,x3,#2           // x17 = high(q * p[3]).
+    adc x23,x23,xzr         // Propagate carry to limb 4.
 
-    adds x19,x20,x14
-    adcs x20,x21,x15
-    adcs x21,x22,xzr    //x16
-    adcs x22,x23,x17
-    adc x23,xzr,xzr
+    // Shift out the fourth cancelled limb. x23 records any 257th bit.
+    adds x19,x20,x14        // Final candidate limb 0.
+    adcs x20,x21,x15        // Final candidate limb 1.
+    adcs x21,x22,xzr        // Final candidate limb 2.
+    adcs x22,x23,x17        // Final candidate limb 3.
+    adc x23,xzr,xzr         // Final candidate carry limb.
 
-    subs x14,x19,x5
-    sbcs x15,x20,x6
-    sbcs x16,x21,xzr    //x7
-    sbcs x17,x22,x8
-    sbcs xzr,    x23,xzr
+    // Subtract the five-limb value p = [p0,p1,0,p3,0].
+    subs x14,x19,x5         // Tentative result limb 0 = candidate - p[0].
+    sbcs x15,x20,x6         // Tentative result limb 1 minus p[1].
+    sbcs x16,x21,xzr        // Tentative result limb 2; p[2] is zero.
+    sbcs x17,x22,x8         // Tentative result limb 3 minus p[3].
+    sbcs xzr,x23,xzr        // Include the carry limb in the comparison.
 
-    csel x19,x19,x14,lo
-    csel x20,x20,x15,lo
-    csel x21,x21,x16,lo
-    csel x22,x22,x17,lo
+    // `lo` means subtraction borrowed, so retain the original candidate.
+    csel x19,x19,x14,lo     // Select canonical output limb 0.
+    csel x20,x20,x15,lo     // Select canonical output limb 1.
+    csel x21,x21,x16,lo     // Select canonical output limb 2.
+    csel x22,x22,x17,lo     // Select canonical output limb 3.
 
-    stp x19,x20,[x0]
-    stp x21,x22,[x0,#16]
+    stp x19,x20,[x0]        // Store output limbs 0 and 1.
+    stp x21,x22,[x0,#16]    // Store output limbs 2 and 3.
 
-    ldp x19,x20,[x29,#16]
-    ldp x21,x22,[x29,#32]
-    ldp x23,x24,[x29,#48]
-    ldr x29,[sp],#64
-    ret
+    ldp x19,x20,[x29,#16]   // Restore callee-saved x19 and x20.
+    ldp x21,x22,[x29,#32]   // Restore callee-saved x21 and x22.
+    ldp x23,x24,[x29,#48]   // Restore callee-saved x23 and x24.
+    ldr x29,[sp],#64        // Restore frame pointer and release the frame.
+    ret                     // Return; x30 still holds the caller's address.
 
 .globl _pasta_curves_sqr_mont_pasta
 .private_extern _pasta_curves_sqr_mont_pasta
 
 .align 5
 _pasta_curves_sqr_mont_pasta:
-    .long 3573752639
-    stp x29,x30,[sp,#-48]!
-    add x29,sp,#0
-    stp x19,x20,[sp,#16]
-    stp x21,x22,[sp,#32]
+    .long 3573752639        // `paciasp`: sign LR with the entry stack pointer.
+    stp x29,x30,[sp,#-48]! // Allocate frame; save frame pointer and signed LR.
+    add x29,sp,#0           // Set the frame pointer to the new stack top.
+    stp x19,x20,[sp,#16]    // Preserve callee-saved product limbs 4 and 5.
+    stp x21,x22,[sp,#32]    // Preserve callee-saved product limbs 6 and 7.
 
-    ldp x5,x6,[x1]
-    ldp x7,x8,[x1,#16]
-    mov x4,x3
+    ldp x5,x6,[x1]          // Load value limbs a[0] and a[1].
+    ldp x7,x8,[x1,#16]      // Load value limbs a[2] and a[3].
+    mov x4,x3               // Move inv into the helper's expected register.
 
     ////////////////////////////////////////////////////////////////
     //  |  |  |  |  |  |a1*a0|  |
@@ -227,203 +252,223 @@ _pasta_curves_sqr_mont_pasta:
     // *|  |  |  |  |  |  |  | 2|
     // +|a3*a3|a2*a2|a1*a1|a0*a0|
     //  |--+--+--+--+--+--+--+--|
-    //  |A7|A6|A5|A4|A3|A2|A1|A0|, where Ax is x10
+    //  |A7|A6|A5|A4|A3|A2|A1|A0|
+    // A0..A7 map to x10,x11,x12,x13,x19,x20,x21,x22.
     //
     //  "can't overflow" below mark carrying into high part of
     //  multiplication result, which can't overflow, because it
     //  can never be all ones.
 
-    mul x11,x6,x5        // a[1]*a[0]
-    umulh x15,x6,x5
-    mul x12,x7,x5        // a[2]*a[0]
-    umulh x16,x7,x5
-    mul x13,x8,x5        // a[3]*a[0]
-    umulh x19,x8,x5
+    mul x11,x6,x5           // x11 = low(a[1] * a[0]).
+    umulh x15,x6,x5         // x15 = high(a[1] * a[0]).
+    mul x12,x7,x5           // x12 = low(a[2] * a[0]).
+    umulh x16,x7,x5         // x16 = high(a[2] * a[0]).
+    mul x13,x8,x5           // x13 = low(a[3] * a[0]).
+    umulh x19,x8,x5         // x19 = high(a[3] * a[0]).
 
-    adds x12,x12,x15     // accumulate high parts of multiplication
-    mul x14,x7,x6        // a[2]*a[1]
-    umulh x15,x7,x6
-    adcs x13,x13,x16
-    mul x16,x8,x6        // a[3]*a[1]
-    umulh x17,x8,x6
-    adc x19,x19,xzr      // can't overflow
+    adds x12,x12,x15        // Fold high(a[1] * a[0]) into product limb 2.
+    mul x14,x7,x6           // x14 = low(a[2] * a[1]).
+    umulh x15,x7,x6         // x15 = high(a[2] * a[1]).
+    adcs x13,x13,x16        // Fold high(a[2] * a[0]) into product limb 3.
+    mul x16,x8,x6           // x16 = low(a[3] * a[1]).
+    umulh x17,x8,x6         // x17 = high(a[3] * a[1]).
+    adc x19,x19,xzr         // Propagate carry into product limb 4.
 
-    mul x20,x8,x7        // a[3]*a[2]
-    umulh x21,x8,x7
+    mul x20,x8,x7           // x20 = low(a[3] * a[2]).
+    umulh x21,x8,x7         // x21 = high(a[3] * a[2]).
 
-    adds x15,x15,x16     // accumulate high parts of multiplication
-    mul x10,x5,x5        // a[0]*a[0]
-    adc x16,x17,xzr      // can't overflow
+    adds x15,x15,x16        // Combine terms contributing to product limb 4.
+    mul x10,x5,x5           // x10 = low(a[0]^2), product limb 0.
+    adc x16,x17,xzr         // Combine terms contributing to product limb 5.
 
-    adds x13,x13,x14     // accumulate low parts of multiplication
-    umulh x5,x5,x5
-    adcs x19,x19,x15
-    mul x15,x6,x6        // a[1]*a[1]
-    adcs x20,x20,x16
-    umulh x6,x6,x6
-    adc x21,x21,xzr      // can't overflow
+    adds x13,x13,x14        // Add low(a[2] * a[1]) into product limb 3.
+    umulh x5,x5,x5          // x5 = high(a[0]^2).
+    adcs x19,x19,x15        // Accumulate cross terms into product limb 4.
+    mul x15,x6,x6           // x15 = low(a[1]^2).
+    adcs x20,x20,x16        // Accumulate cross terms into product limb 5.
+    umulh x6,x6,x6          // x6 = high(a[1]^2).
+    adc x21,x21,xzr         // Propagate carry into product limb 6.
 
-    adds x11,x11,x11     // acc[1-6]*=2
-    mul x16,x7,x7        // a[2]*a[2]
-    adcs x12,x12,x12
-    umulh x7,x7,x7
-    adcs x13,x13,x13
-    mul x17,x8,x8        // a[3]*a[3]
-    adcs x19,x19,x19
-    umulh x8,x8,x8
-    adcs x20,x20,x20
-    adcs x21,x21,x21
-    adc x22,xzr,xzr
+    adds x11,x11,x11        // Double cross-term product limb 1.
+    mul x16,x7,x7           // x16 = low(a[2]^2).
+    adcs x12,x12,x12        // Double cross-term product limb 2.
+    umulh x7,x7,x7          // x7 = high(a[2]^2).
+    adcs x13,x13,x13        // Double cross-term product limb 3.
+    mul x17,x8,x8           // x17 = low(a[3]^2).
+    adcs x19,x19,x19        // Double cross-term product limb 4.
+    umulh x8,x8,x8          // x8 = high(a[3]^2).
+    adcs x20,x20,x20        // Double cross-term product limb 5.
+    adcs x21,x21,x21        // Double cross-term product limb 6.
+    adc x22,xzr,xzr         // Capture the doubled cross-term carry in limb 7.
 
-    adds x11,x11,x5      // +a[i]*a[i]
-    adcs x12,x12,x15
-    adcs x13,x13,x6
-    adcs x19,x19,x16
-    adcs x20,x20,x7
-    adcs x21,x21,x17
-    adc x22,x22,x8
+    // Add diagonal squares to obtain a^2 in x10,x11,x12,x13,x19..x22.
+    adds x11,x11,x5         // Add high(a[0]^2) to product limb 1.
+    adcs x12,x12,x15        // Add low(a[1]^2) to product limb 2.
+    adcs x13,x13,x6         // Add high(a[1]^2) to product limb 3.
+    adcs x19,x19,x16        // Add low(a[2]^2) to product limb 4.
+    adcs x20,x20,x7         // Add high(a[2]^2) to product limb 5.
+    adcs x21,x21,x17        // Add low(a[3]^2) to product limb 6.
+    adc x22,x22,x8          // Add high(a[3]^2) to product limb 7.
 
-    bl L$pasta_curves_mul_by_1_mont_pasta
-    ldr x30,[x29,#8]
+    // Reduce the lower four limbs; upper limbs remain in callee-saved regs.
+    bl L$pasta_curves_mul_by_1_mont_pasta // Reduce x10..x13 by R.
+    ldr x30,[x29,#8]        // Restore signed LR clobbered by `bl`.
 
-    adds x10,x10,x19     // accumulate upper half
-    adcs x11,x11,x20
-    adcs x12,x12,x21
-    adcs x13,x13,x22
-    adc x19,xzr,xzr
+    // Add the untouched upper half, completing reduction of the 512-bit square.
+    adds x10,x10,x19        // Add original product limb 4 to result limb 0.
+    adcs x11,x11,x20        // Add original product limb 5 and carry.
+    adcs x12,x12,x21        // Add original product limb 6 and carry.
+    adcs x13,x13,x22        // Add original product limb 7 and carry.
+    adc x19,xzr,xzr         // Capture a possible 257th candidate bit.
 
-    subs x14,x10,x5
-    sbcs x15,x11,x6
-    sbcs x16,x12,x7
-    sbcs x17,x13,x8
-    sbcs xzr,    x19,xzr
+    // Tentatively subtract p as a five-limb value.
+    subs x14,x10,x5         // Tentative result limb 0 = candidate - p[0].
+    sbcs x15,x11,x6         // Tentative result limb 1 minus p[1].
+    sbcs x16,x12,x7         // Tentative result limb 2 minus p[2] = 0.
+    sbcs x17,x13,x8         // Tentative result limb 3 minus p[3].
+    sbcs xzr,x19,xzr        // Include the candidate carry in the comparison.
 
-    csel x10,x10,x14,lo
-    csel x11,x11,x15,lo
-    csel x12,x12,x16,lo
-    csel x13,x13,x17,lo
+    // If subtraction borrowed (`lo`), keep the original candidate.
+    csel x10,x10,x14,lo     // Select canonical output limb 0.
+    csel x11,x11,x15,lo     // Select canonical output limb 1.
+    csel x12,x12,x16,lo     // Select canonical output limb 2.
+    csel x13,x13,x17,lo     // Select canonical output limb 3.
 
-    stp x10,x11,[x0]
-    stp x12,x13,[x0,#16]
+    stp x10,x11,[x0]        // Store output limbs 0 and 1.
+    stp x12,x13,[x0,#16]    // Store output limbs 2 and 3.
 
-    ldp x19,x20,[x29,#16]
-    ldp x21,x22,[x29,#32]
-    ldr x29,[sp],#48
-    .long 3573752767
-    ret
+    ldp x19,x20,[x29,#16]   // Restore callee-saved x19 and x20.
+    ldp x21,x22,[x29,#32]   // Restore callee-saved x21 and x22.
+    ldr x29,[sp],#48        // Restore frame pointer and entry stack pointer.
+    .long 3573752767        // `autiasp`: authenticate LR with entry SP.
+    ret                     // Return through the authenticated address.
 
 .globl _pasta_curves_from_mont_pasta
 .private_extern _pasta_curves_from_mont_pasta
 
 .align 5
 _pasta_curves_from_mont_pasta:
-    .long 3573752639
-    stp x29,x30,[sp,#-16]!
-    add x29,sp,#0
+    .long 3573752639        // `paciasp`: sign LR with the entry stack pointer.
+    stp x29,x30,[sp,#-16]! // Allocate frame; save frame pointer and signed LR.
+    add x29,sp,#0           // Set the frame pointer to the new stack top.
 
-    mov x4,x3
-    ldp x10,x11,[x1]
-    ldp x12,x13,[x1,#16]
+    mov x4,x3               // Move inv into the helper's expected register.
+    ldp x10,x11,[x1]        // Load Montgomery residue limbs 0 and 1.
+    ldp x12,x13,[x1,#16]    // Load Montgomery residue limbs 2 and 3.
 
-    bl L$pasta_curves_mul_by_1_mont_pasta
-    ldr x30,[x29,#8]
+    // Montgomery-reduce an implicit zero upper half: value * R^-1 mod p.
+    bl L$pasta_curves_mul_by_1_mont_pasta // Reduce x10..x13 by R.
+    ldr x30,[x29,#8]        // Restore signed LR clobbered by `bl`.
 
-    subs x14,x10,x5
-    sbcs x15,x11,x6
-    sbcs x16,x12,x7
-    sbcs x17,x13,x8
+    // The helper leaves p in x5..x8; one subtraction canonicalizes the result.
+    subs x14,x10,x5         // Tentative result limb 0 = candidate - p[0].
+    sbcs x15,x11,x6         // Tentative result limb 1 minus p[1].
+    sbcs x16,x12,x7         // Tentative result limb 2 minus p[2] = 0.
+    sbcs x17,x13,x8         // Tentative result limb 3 minus p[3].
 
-    csel x10,x10,x14,lo
-    csel x11,x11,x15,lo
-    csel x12,x12,x16,lo
-    csel x13,x13,x17,lo
+    // If subtraction borrowed (`lo`), keep the original candidate.
+    csel x10,x10,x14,lo     // Select canonical integer limb 0.
+    csel x11,x11,x15,lo     // Select canonical integer limb 1.
+    csel x12,x12,x16,lo     // Select canonical integer limb 2.
+    csel x13,x13,x17,lo     // Select canonical integer limb 3.
 
-    stp x10,x11,[x0]
-    stp x12,x13,[x0,#16]
+    stp x10,x11,[x0]        // Store canonical integer limbs 0 and 1.
+    stp x12,x13,[x0,#16]    // Store canonical integer limbs 2 and 3.
 
-    ldr x29,[sp],#16
-    .long 3573752767
-    ret
+    ldr x29,[sp],#16        // Restore frame pointer and entry stack pointer.
+    .long 3573752767        // `autiasp`: authenticate LR with entry SP.
+    ret                     // Return through the authenticated address.
 
 .align 5
 L$pasta_curves_mul_by_1_mont_pasta:
-    mul x3,x4,x10
-    ldp x5,x6,[x2]
-    ldp x7,x8,[x2,#16]
-    //mul x14,x5,x3
-    mul x15,x6,x3
-    //mul x16,x7,x3 //mod[2]==0
-    lsl x17,x3,#62      //mul x17,x8,x3
-    subs xzr,x10,#1     //adds x10,x10,x14
-    umulh x14,x5,x3
-    adcs x11,x11,x15
-    umulh x15,x6,x3
-    adcs x12,x12,xzr    //x16
-    //umulh x16,x7,x3   //x7==0
-    adcs x13,x13,x17
-    lsr x17,x3,#2       //umulh x17,x8,x3
-    adc x9,xzr,xzr
+    // Entry: x10..x13 = t, x2 = p, x4 = inv. Each iteration chooses q_i
+    // so the current low limb plus q_i*p[0] is zero modulo 2^64, adds
+    // q_i*p, and discards that zero limb. On exit, x10..x13 contain
+    // (t + Q*p) / R, where Q has the four q_i as little-endian limbs.
 
-    adds x10,x11,x14
-    adcs x11,x12,x15
-    adcs x12,x13,xzr    //x16
-    mul x3,x4,x10
-    adc x13,x9,x17
-    //mul x14,x5,x3
-    mul x15,x6,x3
-    //mul x16,x7,x3 //mod[2]==0
-    lsl x17,x3,#62      //mul x17,x8,x3
-    subs xzr,x10,#1     //adds x10,x10,x14
-    umulh x14,x5,x3
-    adcs x11,x11,x15
-    umulh x15,x6,x3
-    adcs x12,x12,xzr    //x16
-    //umulh x16,x7,x3   //x7==0
-    adcs x13,x13,x17
-    lsr x17,x3,#2       //umulh x17,x8,x3
-    adc x9,xzr,xzr
+    // Montgomery cancellation 0.
+    mul x3,x4,x10           // q = t[0] * inv mod 2^64.
+    ldp x5,x6,[x2]          // Load modulus limbs p[0] and p[1].
+    ldp x7,x8,[x2,#16]      // Load p[2] = 0 and p[3] = 2^62.
+    // low(q * p[0]) cancels x10 and is discarded.
+    mul x15,x6,x3           // x15 = low(q * p[1]).
+    // q * p[2] is zero because p[2] = 0.
+    lsl x17,x3,#62          // x17 = low(q * p[3]).
+    // Carry from x10 + low(q*p[0]) is one exactly when x10 is nonzero.
+    subs xzr,x10,#1         // Set that cancellation carry.
+    umulh x14,x5,x3         // x14 = high(q * p[0]).
+    adcs x11,x11,x15        // Add low(q * p[1]) and cancellation carry.
+    umulh x15,x6,x3         // x15 = high(q * p[1]).
+    adcs x12,x12,xzr        // Propagate carry across zero p[2].
+    // high(q * p[2]) is zero.
+    adcs x13,x13,x17        // Add low(q * p[3]) and carry.
+    lsr x17,x3,#2           // x17 = high(q * p[3]).
+    adc x9,xzr,xzr          // Save the carry above limb 3.
 
-    adds x10,x11,x14
-    adcs x11,x12,x15
-    adcs x12,x13,xzr    //x16
-    mul x3,x4,x10
-    adc x13,x9,x17
-    //mul x14,x5,x3
-    mul x15,x6,x3
-    //mul x16,x7,x3 //mod[2]==0
-    lsl x17,x3,#62      //mul x17,x8,x3
-    subs xzr,x10,#1     //adds x10,x10,x14
-    umulh x14,x5,x3
-    adcs x11,x11,x15
-    umulh x15,x6,x3
-    adcs x12,x12,xzr    //x16
-    //umulh x16,x7,x3   //x7==0
-    adcs x13,x13,x17
-    lsr x17,x3,#2       //umulh x17,x8,x3
-    adc x9,xzr,xzr
+    // Shift out cancelled limb 0 and start cancellation 1.
+    adds x10,x11,x14        // New limb 0 includes high(q * p[0]).
+    adcs x11,x12,x15        // New limb 1 includes high(q * p[1]).
+    adcs x12,x13,xzr        // New limb 2; p[2] contributes zero.
+    mul x3,x4,x10           // Next q = new limb 0 * inv mod 2^64.
+    adc x13,x9,x17          // New limb 3 includes high(q * p[3]).
+    // low(q * p[0]) cancels x10 and is discarded.
+    mul x15,x6,x3           // x15 = low(next q * p[1]).
+    // next q * p[2] is zero.
+    lsl x17,x3,#62          // x17 = low(next q * p[3]).
+    subs xzr,x10,#1         // Set the low-limb cancellation carry.
+    umulh x14,x5,x3         // x14 = high(next q * p[0]).
+    adcs x11,x11,x15        // Add low(next q * p[1]) and carry.
+    umulh x15,x6,x3         // x15 = high(next q * p[1]).
+    adcs x12,x12,xzr        // Propagate carry across zero p[2].
+    // high(next q * p[2]) is zero.
+    adcs x13,x13,x17        // Add low(next q * p[3]) and carry.
+    lsr x17,x3,#2           // x17 = high(next q * p[3]).
+    adc x9,xzr,xzr          // Save the carry above limb 3.
 
-    adds x10,x11,x14
-    adcs x11,x12,x15
-    adcs x12,x13,xzr    //x16
-    mul x3,x4,x10
-    adc x13,x9,x17
-    //mul x14,x5,x3
-    mul x15,x6,x3
-    //mul x16,x7,x3 //mod[2]==0
-    lsl x17,x3,#62      //mul x17,x8,x3
-    subs xzr,x10,#1     //adds x10,x10,x14
-    umulh x14,x5,x3
-    adcs x11,x11,x15
-    umulh x15,x6,x3
-    adcs x12,x12,xzr    //x16
-    //umulh x16,x7,x3   //x7==0
-    adcs x13,x13,x17
-    lsr x17,x3,#2       //umulh x17,x8,x3
-    adc x9,xzr,xzr
+    // Shift out cancelled limb 1 and start cancellation 2.
+    adds x10,x11,x14        // New limb 0 includes high(q * p[0]).
+    adcs x11,x12,x15        // New limb 1 includes high(q * p[1]).
+    adcs x12,x13,xzr        // New limb 2; p[2] contributes zero.
+    mul x3,x4,x10           // Next q = new limb 0 * inv mod 2^64.
+    adc x13,x9,x17          // New limb 3 includes high(q * p[3]).
+    // low(q * p[0]) cancels x10 and is discarded.
+    mul x15,x6,x3           // x15 = low(next q * p[1]).
+    // next q * p[2] is zero.
+    lsl x17,x3,#62          // x17 = low(next q * p[3]).
+    subs xzr,x10,#1         // Set the low-limb cancellation carry.
+    umulh x14,x5,x3         // x14 = high(next q * p[0]).
+    adcs x11,x11,x15        // Add low(next q * p[1]) and carry.
+    umulh x15,x6,x3         // x15 = high(next q * p[1]).
+    adcs x12,x12,xzr        // Propagate carry across zero p[2].
+    // high(next q * p[2]) is zero.
+    adcs x13,x13,x17        // Add low(next q * p[3]) and carry.
+    lsr x17,x3,#2           // x17 = high(next q * p[3]).
+    adc x9,xzr,xzr          // Save the carry above limb 3.
 
-    adds x10,x11,x14
-    adcs x11,x12,x15
-    adcs x12,x13,xzr    //x16
-    adc x13,x9,x17
+    // Shift out cancelled limb 2 and start cancellation 3.
+    adds x10,x11,x14        // New limb 0 includes high(q * p[0]).
+    adcs x11,x12,x15        // New limb 1 includes high(q * p[1]).
+    adcs x12,x13,xzr        // New limb 2; p[2] contributes zero.
+    mul x3,x4,x10           // Final q = new limb 0 * inv mod 2^64.
+    adc x13,x9,x17          // New limb 3 includes high(q * p[3]).
+    // low(q * p[0]) cancels x10 and is discarded.
+    mul x15,x6,x3           // x15 = low(final q * p[1]).
+    // final q * p[2] is zero.
+    lsl x17,x3,#62          // x17 = low(final q * p[3]).
+    subs xzr,x10,#1         // Set the low-limb cancellation carry.
+    umulh x14,x5,x3         // x14 = high(final q * p[0]).
+    adcs x11,x11,x15        // Add low(final q * p[1]) and carry.
+    umulh x15,x6,x3         // x15 = high(final q * p[1]).
+    adcs x12,x12,xzr        // Propagate carry across zero p[2].
+    // high(final q * p[2]) is zero.
+    adcs x13,x13,x17        // Add low(final q * p[3]) and carry.
+    lsr x17,x3,#2           // x17 = high(final q * p[3]).
+    adc x9,xzr,xzr          // Save the carry above limb 3.
 
-    ret
+    // Shift out cancelled limb 3 to finish division by R = 2^256.
+    adds x10,x11,x14        // Output limb 0 includes high(q * p[0]).
+    adcs x11,x12,x15        // Output limb 1 includes high(q * p[1]).
+    adcs x12,x13,xzr        // Output limb 2; p[2] contributes zero.
+    adc x13,x9,x17          // Output limb 3 includes high(q * p[3]).
+
+    ret                     // Return to square or from_mont through x30.

--- a/src/asm/pasta_mul-armv8.S
+++ b/src/asm/pasta_mul-armv8.S
@@ -5,10 +5,10 @@
 // Adapted from the pre-generated Mach-O assembly in Semolina v0.1.4:
 // https://github.com/supranational/semolina/blob/v0.1.4/src/mach-o/pasta_mul-armv8.S
 //
-// Only Montgomery multiplication, squaring, conversion, and their shared
-// reduction helper are retained. Symbols are renamed for this crate. The
-// implementation relies on both Pasta moduli having limb 2 equal to zero and
-// limb 3 equal to 2^62.
+// Only Montgomery multiplication, squaring, fused repeated-squaring
+// multiplication, conversion, and their shared reduction helper are retained.
+// Symbols are renamed for this crate. The implementation relies on both Pasta
+// moduli having limb 2 equal to zero and limb 3 equal to 2^62.
 
 // All field elements and moduli are four little-endian 64-bit limbs. `inv` is
 // -modulus[0]^-1 mod 2^64. The routines implement Montgomery reduction with
@@ -17,9 +17,11 @@
 //
 // Apple AArch64 argument registers:
 //
-// - mul:       x0 = out, x1 = lhs, x2 = rhs, x3 = modulus, x4 = inv
-// - square:    x0 = out, x1 = value, x2 = modulus, x3 = inv
-// - from_mont: x0 = out, x1 = value, x2 = modulus, x3 = inv
+// - mul:        x0 = out, x1 = lhs, x2 = rhs, x3 = modulus, x4 = inv
+// - square:     x0 = out, x1 = value, x2 = modulus, x3 = inv
+// - sqr_n_mul:  x0 = out, x1 = value, x2 = count, x3 = rhs, x4 = modulus,
+//               x5 = inv
+// - from_mont:  x0 = out, x1 = value, x2 = modulus, x3 = inv
 //
 // The code has no secret-dependent branches or memory accesses. Conditional
 // reductions use `csel` after a full-width subtraction.
@@ -472,3 +474,368 @@ L$pasta_curves_mul_by_1_mont_pasta:
     adc x13,x9,x17          // Output limb 3 includes high(q * p[3]).
 
     ret                     // Return to square or from_mont through x30.
+
+.globl _pasta_curves_sqr_n_mul_mont_pasta
+.private_extern _pasta_curves_sqr_n_mul_mont_pasta
+
+// Squares the input `count` times (count must be at least 1), then multiplies
+// by `rhs`, keeping the accumulator in registers throughout. Intermediate
+// squarings skip the final conditional subtraction, so mid-loop residues may
+// exceed the modulus; they stay below 2p (the map t -> p + t^2/2^256 keeps
+// [0, 2p) essentially invariant since 4p exceeds 2^256 by only ~2^-129 * 4p),
+// so no limb-4 carry can be lost. The closing multiplication by a canonical
+// `rhs` yields a value below rhs/2 + p < 2p, which one conditional
+// subtraction (with no fifth limb, as the sum fits 256 bits) canonicalizes.
+//
+// The loop count is consumed with a decrement-then-test, so `count` = 0 would
+// wrap; callers must pass at least 1.
+
+.align 5
+_pasta_curves_sqr_n_mul_mont_pasta:
+    stp x29,x30,[sp,#-80]! // Allocate frame; save frame pointer and LR.
+    add x29,sp,#0           // Set the frame pointer to the new stack top.
+    stp x19,x20,[sp,#16]    // Preserve callee-saved scratch x19 and x20.
+    stp x21,x22,[sp,#32]    // Preserve callee-saved scratch x21 and x22.
+    stp x23,x24,[sp,#48]    // Preserve callee-saved modulus limbs 0 and 1.
+
+    ldp x6,x7,[x1]          // Load value limbs a[0] and a[1].
+    ldp x8,x9,[x1,#16]      // Load value limbs a[2] and a[3].
+
+    ldp x23,x24,[x4]        // Keep p[0] and p[1] resident across the loop.
+    // p[2] = 0 and p[3] = 2^62 are implicit throughout.
+
+L$pasta_curves_sqr_n_mul_loop:
+    sub x2,x2,#1            // Consume one squaring from the count.
+
+    // Square a (in x6..x9) exactly as in sqr_mont above; the 512-bit
+    // product limbs A0..A7 map to x10,x11,x12,x13,x14,x15,x16,x17.
+
+    mul x11,x7,x6           // x11 = low(a[1] * a[0]).
+    umulh x20,x7,x6         // x20 = high(a[1] * a[0]).
+    mul x12,x8,x6           // x12 = low(a[2] * a[0]).
+    umulh x21,x8,x6         // x21 = high(a[2] * a[0]).
+    mul x13,x9,x6           // x13 = low(a[3] * a[0]).
+    umulh x14,x9,x6         // x14 = high(a[3] * a[0]).
+
+    adds x12,x12,x20        // Fold high(a[1] * a[0]) into product limb 2.
+    mul x19,x8,x7           // x19 = low(a[2] * a[1]).
+    umulh x20,x8,x7         // x20 = high(a[2] * a[1]).
+    adcs x13,x13,x21        // Fold high(a[2] * a[0]) into product limb 3.
+    mul x21,x9,x7           // x21 = low(a[3] * a[1]).
+    umulh x22,x9,x7         // x22 = high(a[3] * a[1]).
+    adc x14,x14,xzr         // Propagate carry into product limb 4.
+
+    mul x15,x9,x8           // x15 = low(a[3] * a[2]).
+    umulh x16,x9,x8         // x16 = high(a[3] * a[2]).
+
+    adds x20,x20,x21        // Combine terms contributing to product limb 4.
+    mul x10,x6,x6           // x10 = low(a[0]^2), product limb 0.
+    adc x21,x22,xzr         // Combine terms contributing to product limb 5.
+
+    adds x13,x13,x19        // Add low(a[2] * a[1]) into product limb 3.
+    umulh x6,x6,x6          // x6 = high(a[0]^2).
+    adcs x14,x14,x20        // Accumulate cross terms into product limb 4.
+    mul x20,x7,x7           // x20 = low(a[1]^2).
+    adcs x15,x15,x21        // Accumulate cross terms into product limb 5.
+    umulh x7,x7,x7          // x7 = high(a[1]^2).
+    adc x16,x16,xzr         // Propagate carry into product limb 6.
+
+    adds x11,x11,x11        // Double cross-term product limb 1.
+    mul x21,x8,x8           // x21 = low(a[2]^2).
+    adcs x12,x12,x12        // Double cross-term product limb 2.
+    umulh x8,x8,x8          // x8 = high(a[2]^2).
+    adcs x13,x13,x13        // Double cross-term product limb 3.
+    mul x22,x9,x9           // x22 = low(a[3]^2).
+    adcs x14,x14,x14        // Double cross-term product limb 4.
+    umulh x9,x9,x9          // x9 = high(a[3]^2).
+    adcs x15,x15,x15        // Double cross-term product limb 5.
+    adcs x16,x16,x16        // Double cross-term product limb 6.
+    adc x17,xzr,xzr         // Capture the doubled cross-term carry in limb 7.
+
+    mul x4,x5,x10           // q = product limb 0 * inv mod 2^64.
+
+    // Add diagonal squares to obtain a^2 in x10..x17.
+    adds x11,x11,x6         // Add high(a[0]^2) to product limb 1.
+    adcs x12,x12,x20        // Add low(a[1]^2) to product limb 2.
+    adcs x13,x13,x7         // Add high(a[1]^2) to product limb 3.
+    adcs x14,x14,x21        // Add low(a[2]^2) to product limb 4.
+    adcs x15,x15,x8         // Add high(a[2]^2) to product limb 5.
+    adcs x16,x16,x22        // Add low(a[3]^2) to product limb 6.
+    adc x17,x17,x9          // Add high(a[3]^2) to product limb 7.
+
+    // Montgomery cancellation 0 on the low half, as in the shared helper.
+    // low(q * p[0]) cancels x10 and is discarded by the limb shift.
+    mul x20,x24,x4          // x20 = low(q * p[1]).
+    // q * p[2] is zero because p[2] = 0.
+    lsl x22,x4,#62          // x22 = low(q * p[3]).
+    // Carry from x10 + low(q*p[0]) is one exactly when x10 is nonzero.
+    subs xzr,x10,#1         // Set that cancellation carry.
+    umulh x19,x23,x4        // x19 = high(q * p[0]).
+    adcs x11,x11,x20        // Add low(q * p[1]) and cancellation carry.
+    umulh x20,x24,x4        // x20 = high(q * p[1]).
+    adcs x12,x12,xzr        // Propagate carry across zero p[2].
+    // high(q * p[2]) is zero.
+    adcs x13,x13,x22        // Add low(q * p[3]) and carry.
+    lsr x22,x4,#2           // x22 = high(q * p[3]).
+    adc x1,xzr,xzr          // Save the carry above limb 3.
+
+    // Shift out cancelled limb 0 and start cancellation 1.
+    adds x10,x11,x19        // New limb 0 includes high(q * p[0]).
+    adcs x11,x12,x20        // New limb 1 includes high(q * p[1]).
+    adcs x12,x13,xzr        // New limb 2; p[2] contributes zero.
+    mul x4,x5,x10           // Next q = new limb 0 * inv mod 2^64.
+    adc x13,x1,x22          // New limb 3 includes high(q * p[3]).
+    // low(q * p[0]) cancels x10 and is discarded.
+    mul x20,x24,x4          // x20 = low(next q * p[1]).
+    // next q * p[2] is zero.
+    lsl x22,x4,#62          // x22 = low(next q * p[3]).
+    subs xzr,x10,#1         // Set the low-limb cancellation carry.
+    umulh x19,x23,x4        // x19 = high(next q * p[0]).
+    adcs x11,x11,x20        // Add low(next q * p[1]) and carry.
+    umulh x20,x24,x4        // x20 = high(next q * p[1]).
+    adcs x12,x12,xzr        // Propagate carry across zero p[2].
+    // high(next q * p[2]) is zero.
+    adcs x13,x13,x22        // Add low(next q * p[3]) and carry.
+    lsr x22,x4,#2           // x22 = high(next q * p[3]).
+    adc x1,xzr,xzr          // Save the carry above limb 3.
+
+    // Shift out cancelled limb 1 and start cancellation 2.
+    adds x10,x11,x19        // New limb 0 includes high(q * p[0]).
+    adcs x11,x12,x20        // New limb 1 includes high(q * p[1]).
+    adcs x12,x13,xzr        // New limb 2; p[2] contributes zero.
+    mul x4,x5,x10           // Next q = new limb 0 * inv mod 2^64.
+    adc x13,x1,x22          // New limb 3 includes high(q * p[3]).
+    // low(q * p[0]) cancels x10 and is discarded.
+    mul x20,x24,x4          // x20 = low(next q * p[1]).
+    // next q * p[2] is zero.
+    lsl x22,x4,#62          // x22 = low(next q * p[3]).
+    subs xzr,x10,#1         // Set the low-limb cancellation carry.
+    umulh x19,x23,x4        // x19 = high(next q * p[0]).
+    adcs x11,x11,x20        // Add low(next q * p[1]) and carry.
+    umulh x20,x24,x4        // x20 = high(next q * p[1]).
+    adcs x12,x12,xzr        // Propagate carry across zero p[2].
+    // high(next q * p[2]) is zero.
+    adcs x13,x13,x22        // Add low(next q * p[3]) and carry.
+    lsr x22,x4,#2           // x22 = high(next q * p[3]).
+    adc x1,xzr,xzr          // Save the carry above limb 3.
+
+    // Shift out cancelled limb 2 and start cancellation 3.
+    adds x10,x11,x19        // New limb 0 includes high(q * p[0]).
+    adcs x11,x12,x20        // New limb 1 includes high(q * p[1]).
+    adcs x12,x13,xzr        // New limb 2; p[2] contributes zero.
+    mul x4,x5,x10           // Final q = new limb 0 * inv mod 2^64.
+    adc x13,x1,x22          // New limb 3 includes high(q * p[3]).
+    // low(q * p[0]) cancels x10 and is discarded.
+    mul x20,x24,x4          // x20 = low(final q * p[1]).
+    // final q * p[2] is zero.
+    lsl x22,x4,#62          // x22 = low(final q * p[3]).
+    subs xzr,x10,#1         // Set the low-limb cancellation carry.
+    umulh x19,x23,x4        // x19 = high(final q * p[0]).
+    adcs x11,x11,x20        // Add low(final q * p[1]) and carry.
+    umulh x20,x24,x4        // x20 = high(final q * p[1]).
+    adcs x12,x12,xzr        // Propagate carry across zero p[2].
+    // high(final q * p[2]) is zero.
+    adcs x13,x13,x22        // Add low(final q * p[3]) and carry.
+    lsr x22,x4,#2           // x22 = high(final q * p[3]).
+    adc x1,xzr,xzr          // Save the carry above limb 3.
+
+    // Shift out cancelled limb 3 to finish dividing the low half by R.
+    adds x10,x11,x19        // Reduced limb 0 includes high(q * p[0]).
+    adcs x11,x12,x20        // Reduced limb 1 includes high(q * p[1]).
+    adcs x12,x13,xzr        // Reduced limb 2; p[2] contributes zero.
+    adc x13,x1,x22          // Reduced limb 3 includes high(q * p[3]).
+    // Add the upper product half; the sum stays below 2p (see above), so no
+    // carry escapes and no conditional subtraction is needed mid-loop.
+    adds x6,x10,x14         // Next-iteration a[0].
+    adcs x7,x11,x15         // Next-iteration a[1].
+    adcs x8,x12,x16         // Next-iteration a[2].
+    adc x9,x13,x17          // Next-iteration a[3].
+
+    cbnz x2,L$pasta_curves_sqr_n_mul_loop // Square again if count remains.
+
+    // Multiply the accumulator (x6..x9) by rhs, as in mul_mont above but
+    // with the five-limb product in x10..x14 and temporaries in x19..x22.
+    ldr x1,[x3]             // Load rhs limb b[0].
+
+    mul x10,x6,x1           // x10 = low(a[0] * b[0]).
+    mul x11,x7,x1           // x11 = low(a[1] * b[0]).
+    mul x12,x8,x1           // x12 = low(a[2] * b[0]).
+    mul x13,x9,x1           // x13 = low(a[3] * b[0]).
+
+    umulh x19,x6,x1         // x19 = high(a[0] * b[0]).
+    umulh x20,x7,x1         // x20 = high(a[1] * b[0]).
+    mul x4,x5,x10           // q = x10 * inv mod 2^64.
+    umulh x21,x8,x1         // x21 = high(a[2] * b[0]).
+    umulh x22,x9,x1         // x22 = high(a[3] * b[0]).
+    adds x11,x11,x19        // Add high(a[0] * b[0]) into limb 1.
+    // low(q * p[0]) cancels x10 and is discarded by the limb shift.
+    adcs x12,x12,x20        // Add high(a[1] * b[0]) and carry.
+    mul x20,x24,x4          // x20 = low(q * p[1]).
+    adcs x13,x13,x21        // Add high(a[2] * b[0]) and carry.
+    // q * p[2] is zero because p[2] = 0.
+    adc x14,xzr,x22         // Finish a * b[0] with its fifth limb.
+    lsl x22,x4,#62          // x22 = low(q * p[3]).
+    ldr x1,[x3,8*1]         // Load rhs limb b[1] for the next round.
+    // Carry from x10 + low(q*p[0]) is one exactly when x10 is nonzero.
+    subs xzr,x10,#1         // Set that carry without computing the zero sum.
+    umulh x19,x23,x4        // x19 = high(q * p[0]).
+    adcs x11,x11,x20        // Add low(q * p[1]) and cancellation carry.
+    umulh x20,x24,x4        // x20 = high(q * p[1]).
+    adcs x12,x12,xzr        // Propagate carry; p[2]'s product is zero.
+    // high(q * p[2]) is zero.
+    adcs x13,x13,x22        // Add low(q * p[3]) and carry.
+    lsr x22,x4,#2           // x22 = high(q * p[3]).
+    adc x14,x14,xzr         // Propagate carry into the fifth limb.
+
+    // Drop the cancelled low limb: (a*b[0] + q*p) / 2^64.
+    adds x10,x11,x19        // New limb 0 includes high(q * p[0]).
+    mul x19,x6,x1           // x19 = low(a[0] * b[1]).
+    adcs x11,x12,x20        // New limb 1 includes high(q * p[1]).
+    mul x20,x7,x1           // x20 = low(a[1] * b[1]).
+    adcs x12,x13,xzr        // New limb 2; p[2] contributes zero.
+    mul x21,x8,x1           // x21 = low(a[2] * b[1]).
+    adcs x13,x14,x22        // New limb 3 includes high(q * p[3]).
+    mul x22,x9,x1           // x22 = low(a[3] * b[1]).
+    adc x14,xzr,xzr         // Capture the reduction carry as limb 4.
+
+    // Round 1: add a * b[1] to the reduced accumulator.
+    adds x10,x10,x19        // Add low(a[0] * b[1]) to limb 0.
+    umulh x19,x6,x1         // x19 = high(a[0] * b[1]).
+    adcs x11,x11,x20        // Add low(a[1] * b[1]) and carry.
+    umulh x20,x7,x1         // x20 = high(a[1] * b[1]).
+    adcs x12,x12,x21        // Add low(a[2] * b[1]) and carry.
+    mul x4,x5,x10           // q = current limb 0 * inv mod 2^64.
+    umulh x21,x8,x1         // x21 = high(a[2] * b[1]).
+    adcs x13,x13,x22        // Add low(a[3] * b[1]) and carry.
+    umulh x22,x9,x1         // x22 = high(a[3] * b[1]).
+    adc x14,x14,xzr         // Propagate multiplication carry to limb 4.
+
+    adds x11,x11,x19        // Add high(a[0] * b[1]) to limb 1.
+    // low(q * p[0]) cancels x10.
+    adcs x12,x12,x20        // Add high(a[1] * b[1]) and carry.
+    mul x20,x24,x4          // x20 = low(q * p[1]).
+    adcs x13,x13,x21        // Add high(a[2] * b[1]) and carry.
+    // low(q * p[2]) is zero.
+    adc x14,x14,x22         // Add high(a[3] * b[1]) and final carry.
+    lsl x22,x4,#62          // x22 = low(q * p[3]).
+    ldr x1,[x3,8*2]         // Load rhs limb b[2] for the next round.
+    subs xzr,x10,#1         // Set the low-limb cancellation carry.
+    umulh x19,x23,x4        // x19 = high(q * p[0]).
+    adcs x11,x11,x20        // Add low(q * p[1]) and cancellation carry.
+    umulh x20,x24,x4        // x20 = high(q * p[1]).
+    adcs x12,x12,xzr        // Propagate carry across zero p[2].
+    // high(q * p[2]) is zero.
+    adcs x13,x13,x22        // Add low(q * p[3]) and carry.
+    lsr x22,x4,#2           // x22 = high(q * p[3]).
+    adc x14,x14,xzr         // Propagate carry to limb 4.
+
+    // Shift after round 1 while starting a * b[2].
+    adds x10,x11,x19        // New limb 0 includes high(q * p[0]).
+    mul x19,x6,x1           // x19 = low(a[0] * b[2]).
+    adcs x11,x12,x20        // New limb 1 includes high(q * p[1]).
+    mul x20,x7,x1           // x20 = low(a[1] * b[2]).
+    adcs x12,x13,xzr        // New limb 2; p[2] contributes zero.
+    mul x21,x8,x1           // x21 = low(a[2] * b[2]).
+    adcs x13,x14,x22        // New limb 3 includes high(q * p[3]).
+    mul x22,x9,x1           // x22 = low(a[3] * b[2]).
+    adc x14,xzr,xzr         // Capture the reduction carry as limb 4.
+
+    // Round 2: add a * b[2] and cancel the resulting low limb.
+    adds x10,x10,x19        // Add low(a[0] * b[2]) to limb 0.
+    umulh x19,x6,x1         // x19 = high(a[0] * b[2]).
+    adcs x11,x11,x20        // Add low(a[1] * b[2]) and carry.
+    umulh x20,x7,x1         // x20 = high(a[1] * b[2]).
+    adcs x12,x12,x21        // Add low(a[2] * b[2]) and carry.
+    mul x4,x5,x10           // q = current limb 0 * inv mod 2^64.
+    umulh x21,x8,x1         // x21 = high(a[2] * b[2]).
+    adcs x13,x13,x22        // Add low(a[3] * b[2]) and carry.
+    umulh x22,x9,x1         // x22 = high(a[3] * b[2]).
+    adc x14,x14,xzr         // Propagate multiplication carry to limb 4.
+
+    adds x11,x11,x19        // Add high(a[0] * b[2]) to limb 1.
+    // low(q * p[0]) cancels x10.
+    adcs x12,x12,x20        // Add high(a[1] * b[2]) and carry.
+    mul x20,x24,x4          // x20 = low(q * p[1]).
+    adcs x13,x13,x21        // Add high(a[2] * b[2]) and carry.
+    // low(q * p[2]) is zero.
+    adc x14,x14,x22         // Add high(a[3] * b[2]) and final carry.
+    lsl x22,x4,#62          // x22 = low(q * p[3]).
+    ldr x1,[x3,8*3]         // Load rhs limb b[3] for the last round.
+    subs xzr,x10,#1         // Set the low-limb cancellation carry.
+    umulh x19,x23,x4        // x19 = high(q * p[0]).
+    adcs x11,x11,x20        // Add low(q * p[1]) and cancellation carry.
+    umulh x20,x24,x4        // x20 = high(q * p[1]).
+    adcs x12,x12,xzr        // Propagate carry across zero p[2].
+    // high(q * p[2]) is zero.
+    adcs x13,x13,x22        // Add low(q * p[3]) and carry.
+    lsr x22,x4,#2           // x22 = high(q * p[3]).
+    adc x14,x14,xzr         // Propagate carry to limb 4.
+
+    // Shift after round 2 while starting a * b[3].
+    adds x10,x11,x19        // New limb 0 includes high(q * p[0]).
+    mul x19,x6,x1           // x19 = low(a[0] * b[3]).
+    adcs x11,x12,x20        // New limb 1 includes high(q * p[1]).
+    mul x20,x7,x1           // x20 = low(a[1] * b[3]).
+    adcs x12,x13,xzr        // New limb 2; p[2] contributes zero.
+    mul x21,x8,x1           // x21 = low(a[2] * b[3]).
+    adcs x13,x14,x22        // New limb 3 includes high(q * p[3]).
+    mul x22,x9,x1           // x22 = low(a[3] * b[3]).
+    adc x14,xzr,xzr         // Capture the reduction carry as limb 4.
+
+    // Round 3: add a * b[3] and perform the last Montgomery cancellation.
+    adds x10,x10,x19        // Add low(a[0] * b[3]) to limb 0.
+    umulh x19,x6,x1         // x19 = high(a[0] * b[3]).
+    adcs x11,x11,x20        // Add low(a[1] * b[3]) and carry.
+    umulh x20,x7,x1         // x20 = high(a[1] * b[3]).
+    adcs x12,x12,x21        // Add low(a[2] * b[3]) and carry.
+    mul x4,x5,x10           // q = current limb 0 * inv mod 2^64.
+    umulh x21,x8,x1         // x21 = high(a[2] * b[3]).
+    adcs x13,x13,x22        // Add low(a[3] * b[3]) and carry.
+    umulh x22,x9,x1         // x22 = high(a[3] * b[3]).
+    adc x14,x14,xzr         // Propagate multiplication carry to limb 4.
+
+    adds x11,x11,x19        // Add high(a[0] * b[3]) to limb 1.
+    // low(q * p[0]) cancels x10.
+    adcs x12,x12,x20        // Add high(a[1] * b[3]) and carry.
+    mul x20,x24,x4          // x20 = low(q * p[1]).
+    adcs x13,x13,x21        // Add high(a[2] * b[3]) and carry.
+    // low(q * p[2]) is zero.
+    adc x14,x14,x22         // Add high(a[3] * b[3]) and final carry.
+    lsl x22,x4,#62          // x22 = low(q * p[3]).
+    subs xzr,x10,#1         // Set the low-limb cancellation carry.
+    umulh x19,x23,x4        // x19 = high(q * p[0]).
+    adcs x11,x11,x20        // Add low(q * p[1]) and cancellation carry.
+    umulh x20,x24,x4        // x20 = high(q * p[1]).
+    adcs x12,x12,xzr        // Propagate carry across zero p[2].
+    // high(q * p[2]) is zero.
+    adcs x13,x13,x22        // Add low(q * p[3]) and carry.
+    lsr x22,x4,#2           // x22 = high(q * p[3]).
+    adc x14,x14,xzr         // Propagate carry to limb 4.
+
+    // Shift out the fourth cancelled limb; the result fits 256 bits.
+    adds x10,x11,x19        // Final candidate limb 0.
+    adcs x11,x12,x20        // Final candidate limb 1.
+    adcs x12,x13,xzr        // Final candidate limb 2.
+    adc x13,x14,x22         // Final candidate limb 3.
+
+    // Subtract p = [p0,p1,0,2^62]; the upper limbs are materialized inline.
+    subs x19,x10,x23        // Tentative result limb 0 = candidate - p[0].
+    mov x22,#1<<62          // Materialize p[3] = 2^62.
+    sbcs x20,x11,x24        // Tentative result limb 1 minus p[1].
+    sbcs x21,x12,xzr        // Tentative result limb 2; p[2] is zero.
+    sbcs x22,x13,x22        // Tentative result limb 3 minus p[3].
+
+    // `lo` means subtraction borrowed, so retain the original candidate.
+    csel x10,x10,x19,lo     // Select canonical output limb 0.
+    csel x11,x11,x20,lo     // Select canonical output limb 1.
+    csel x12,x12,x21,lo     // Select canonical output limb 2.
+    csel x13,x13,x22,lo     // Select canonical output limb 3.
+
+    stp x10,x11,[x0]        // Store output limbs 0 and 1.
+    stp x12,x13,[x0,#16]    // Store output limbs 2 and 3.
+
+    ldp x19,x20,[x29,#16]   // Restore callee-saved x19 and x20.
+    ldp x21,x22,[x29,#32]   // Restore callee-saved x21 and x22.
+    ldp x23,x24,[x29,#48]   // Restore callee-saved x23 and x24.
+    ldr x29,[sp],#80        // Restore frame pointer and release the frame.
+    ret                     // Return; x30 still holds the caller's address.

--- a/src/asm/pasta_mul-armv8.S
+++ b/src/asm/pasta_mul-armv8.S
@@ -5,10 +5,13 @@
 // Adapted from the pre-generated Mach-O assembly in Semolina v0.1.4:
 // https://github.com/supranational/semolina/blob/v0.1.4/src/mach-o/pasta_mul-armv8.S
 //
-// Only Montgomery multiplication, squaring, fused repeated-squaring
-// multiplication, conversion, and their shared reduction helper are retained.
-// Symbols are renamed for this crate. The implementation relies on both Pasta
-// moduli having limb 2 equal to zero and limb 3 equal to 2^62.
+// Only the fused repeated-squaring multiplication, the conversion out of
+// Montgomery form, and their shared reduction helper are retained here.
+// Single Montgomery multiplication and squaring live as inline `asm!`
+// transcriptions of the same upstream routines in
+// src/fields/aarch64_asm.rs. Symbols are renamed for this crate. The
+// implementation relies on both Pasta moduli having limb 2 equal to zero
+// and limb 3 equal to 2^62.
 
 // All field elements and moduli are four little-endian 64-bit limbs. `inv` is
 // -modulus[0]^-1 mod 2^64. The routines implement Montgomery reduction with
@@ -17,8 +20,6 @@
 //
 // Apple AArch64 argument registers:
 //
-// - mul:        x0 = out, x1 = lhs, x2 = rhs, x3 = modulus, x4 = inv
-// - square:     x0 = out, x1 = value, x2 = modulus, x3 = inv
 // - sqr_n_mul:  x0 = out, x1 = value, x2 = count, x3 = rhs, x4 = modulus,
 //               x5 = inv
 // - from_mont:  x0 = out, x1 = value, x2 = modulus, x3 = inv
@@ -27,323 +28,6 @@
 // reductions use `csel` after a full-width subtraction.
 
 .text
-
-.globl _pasta_curves_mul_mont_pasta
-.private_extern _pasta_curves_mul_mont_pasta
-
-.align 5
-_pasta_curves_mul_mont_pasta:
-    stp x29,x30,[sp,#-64]! // Allocate frame; save frame pointer and LR.
-    add x29,sp,#0           // Set the frame pointer to the new stack top.
-    stp x19,x20,[sp,#16]    // Preserve callee-saved accumulator limbs 0-1.
-    stp x21,x22,[sp,#32]    // Preserve callee-saved accumulator limbs 2-3.
-    stp x23,x24,[sp,#48]    // Preserve the carry limb and paired x24.
-
-    ldp x10,x11,[x1]        // Load lhs limbs a[0] and a[1].
-    ldr x9,[x2]             // Load rhs limb b[0].
-    ldp x12,x13,[x1,#16]    // Load lhs limbs a[2] and a[3].
-
-    // Form the five-limb product a * b[0] in x19..x23.
-    mul x19,x10,x9          // x19 = low(a[0] * b[0]).
-    ldp x5,x6,[x3]          // Load modulus limbs p[0] and p[1].
-    mul x20,x11,x9          // x20 = low(a[1] * b[0]).
-    ldp x7,x8,[x3,#16]      // Load p[2] = 0 and p[3] = 2^62.
-    mul x21,x12,x9          // x21 = low(a[2] * b[0]).
-    mul x22,x13,x9          // x22 = low(a[3] * b[0]).
-
-    umulh x14,x10,x9        // x14 = high(a[0] * b[0]).
-    umulh x15,x11,x9        // x15 = high(a[1] * b[0]).
-    mul x3,x4,x19           // q = x19 * inv mod 2^64.
-    umulh x16,x12,x9        // x16 = high(a[2] * b[0]).
-    umulh x17,x13,x9        // x17 = high(a[3] * b[0]).
-    adds x20,x20,x14        // Add high(a[0] * b[0]) into limb 1.
-    // low(q * p[0]) cancels x19 and is discarded by the limb shift.
-    adcs x21,x21,x15        // Add high(a[1] * b[0]) and carry.
-    mul x15,x6,x3           // x15 = low(q * p[1]).
-    adcs x22,x22,x16        // Add high(a[2] * b[0]) and carry.
-    // q * p[2] is zero because p[2] = 0.
-    adc x23,xzr,x17         // Finish a * b[0] with its fifth limb.
-    lsl x17,x3,#62          // x17 = low(q * p[3]).
-    ldr x9,[x2,8*1]         // Load rhs limb b[1] for the next round.
-    // Carry from x19 + low(q*p[0]) is one exactly when x19 is nonzero.
-    subs xzr,x19,#1         // Set that carry without computing the zero sum.
-    umulh x14,x5,x3         // x14 = high(q * p[0]).
-    adcs x20,x20,x15        // Add low(q * p[1]) and cancellation carry.
-    umulh x15,x6,x3         // x15 = high(q * p[1]).
-    adcs x21,x21,xzr        // Propagate carry; p[2]'s product is zero.
-    // high(q * p[2]) is zero.
-    adcs x22,x22,x17        // Add low(q * p[3]) and carry.
-    lsr x17,x3,#2           // x17 = high(q * p[3]).
-    adc x23,x23,xzr         // Propagate carry into the fifth limb.
-
-    // Drop the cancelled low limb: (a*b[0] + q*p) / 2^64.
-    adds x19,x20,x14        // New limb 0 includes high(q * p[0]).
-    mul x14,x10,x9          // x14 = low(a[0] * b[1]).
-    adcs x20,x21,x15        // New limb 1 includes high(q * p[1]).
-    mul x15,x11,x9          // x15 = low(a[1] * b[1]).
-    adcs x21,x22,xzr        // New limb 2; p[2] contributes zero.
-    mul x16,x12,x9          // x16 = low(a[2] * b[1]).
-    adcs x22,x23,x17        // New limb 3 includes high(q * p[3]).
-    mul x17,x13,x9          // x17 = low(a[3] * b[1]).
-    adc x23,xzr,xzr         // Capture the reduction carry as limb 4.
-
-    // Round 1: add a * b[1] to the reduced accumulator.
-    adds x19,x19,x14        // Add low(a[0] * b[1]) to limb 0.
-    umulh x14,x10,x9        // x14 = high(a[0] * b[1]).
-    adcs x20,x20,x15        // Add low(a[1] * b[1]) and carry.
-    umulh x15,x11,x9        // x15 = high(a[1] * b[1]).
-    adcs x21,x21,x16        // Add low(a[2] * b[1]) and carry.
-    mul x3,x4,x19           // q = current limb 0 * inv mod 2^64.
-    umulh x16,x12,x9        // x16 = high(a[2] * b[1]).
-    adcs x22,x22,x17        // Add low(a[3] * b[1]) and carry.
-    umulh x17,x13,x9        // x17 = high(a[3] * b[1]).
-    adc x23,x23,xzr         // Propagate multiplication carry to limb 4.
-
-    adds x20,x20,x14        // Add high(a[0] * b[1]) to limb 1.
-    // low(q * p[0]) cancels x19.
-    adcs x21,x21,x15        // Add high(a[1] * b[1]) and carry.
-    mul x15,x6,x3           // x15 = low(q * p[1]).
-    adcs x22,x22,x16        // Add high(a[2] * b[1]) and carry.
-    // low(q * p[2]) is zero.
-    adc x23,x23,x17         // Add high(a[3] * b[1]) and final carry.
-    lsl x17,x3,#62          // x17 = low(q * p[3]).
-    ldr x9,[x2,8*2]         // Load rhs limb b[2] for the next round.
-    subs xzr,x19,#1         // Set the low-limb cancellation carry.
-    umulh x14,x5,x3         // x14 = high(q * p[0]).
-    adcs x20,x20,x15        // Add low(q * p[1]) and cancellation carry.
-    umulh x15,x6,x3         // x15 = high(q * p[1]).
-    adcs x21,x21,xzr        // Propagate carry across zero p[2].
-    // high(q * p[2]) is zero.
-    adcs x22,x22,x17        // Add low(q * p[3]) and carry.
-    lsr x17,x3,#2           // x17 = high(q * p[3]).
-    adc x23,x23,xzr         // Propagate carry to limb 4.
-
-    // Shift after round 1 while starting a * b[2].
-    adds x19,x20,x14        // New limb 0 includes high(q * p[0]).
-    mul x14,x10,x9          // x14 = low(a[0] * b[2]).
-    adcs x20,x21,x15        // New limb 1 includes high(q * p[1]).
-    mul x15,x11,x9          // x15 = low(a[1] * b[2]).
-    adcs x21,x22,xzr        // New limb 2; p[2] contributes zero.
-    mul x16,x12,x9          // x16 = low(a[2] * b[2]).
-    adcs x22,x23,x17        // New limb 3 includes high(q * p[3]).
-    mul x17,x13,x9          // x17 = low(a[3] * b[2]).
-    adc x23,xzr,xzr         // Capture the reduction carry as limb 4.
-
-    // Round 2: add a * b[2] and cancel the resulting low limb.
-    adds x19,x19,x14        // Add low(a[0] * b[2]) to limb 0.
-    umulh x14,x10,x9        // x14 = high(a[0] * b[2]).
-    adcs x20,x20,x15        // Add low(a[1] * b[2]) and carry.
-    umulh x15,x11,x9        // x15 = high(a[1] * b[2]).
-    adcs x21,x21,x16        // Add low(a[2] * b[2]) and carry.
-    mul x3,x4,x19           // q = current limb 0 * inv mod 2^64.
-    umulh x16,x12,x9        // x16 = high(a[2] * b[2]).
-    adcs x22,x22,x17        // Add low(a[3] * b[2]) and carry.
-    umulh x17,x13,x9        // x17 = high(a[3] * b[2]).
-    adc x23,x23,xzr         // Propagate multiplication carry to limb 4.
-
-    adds x20,x20,x14        // Add high(a[0] * b[2]) to limb 1.
-    // low(q * p[0]) cancels x19.
-    adcs x21,x21,x15        // Add high(a[1] * b[2]) and carry.
-    mul x15,x6,x3           // x15 = low(q * p[1]).
-    adcs x22,x22,x16        // Add high(a[2] * b[2]) and carry.
-    // low(q * p[2]) is zero.
-    adc x23,x23,x17         // Add high(a[3] * b[2]) and final carry.
-    lsl x17,x3,#62          // x17 = low(q * p[3]).
-    ldr x9,[x2,8*3]         // Load rhs limb b[3] for the last round.
-    subs xzr,x19,#1         // Set the low-limb cancellation carry.
-    umulh x14,x5,x3         // x14 = high(q * p[0]).
-    adcs x20,x20,x15        // Add low(q * p[1]) and cancellation carry.
-    umulh x15,x6,x3         // x15 = high(q * p[1]).
-    adcs x21,x21,xzr        // Propagate carry across zero p[2].
-    // high(q * p[2]) is zero.
-    adcs x22,x22,x17        // Add low(q * p[3]) and carry.
-    lsr x17,x3,#2           // x17 = high(q * p[3]).
-    adc x23,x23,xzr         // Propagate carry to limb 4.
-
-    // Shift after round 2 while starting a * b[3].
-    adds x19,x20,x14        // New limb 0 includes high(q * p[0]).
-    mul x14,x10,x9          // x14 = low(a[0] * b[3]).
-    adcs x20,x21,x15        // New limb 1 includes high(q * p[1]).
-    mul x15,x11,x9          // x15 = low(a[1] * b[3]).
-    adcs x21,x22,xzr        // New limb 2; p[2] contributes zero.
-    mul x16,x12,x9          // x16 = low(a[2] * b[3]).
-    adcs x22,x23,x17        // New limb 3 includes high(q * p[3]).
-    mul x17,x13,x9          // x17 = low(a[3] * b[3]).
-    adc x23,xzr,xzr         // Capture the reduction carry as limb 4.
-
-    // Round 3: add a * b[3] and perform the last Montgomery cancellation.
-    adds x19,x19,x14        // Add low(a[0] * b[3]) to limb 0.
-    umulh x14,x10,x9        // x14 = high(a[0] * b[3]).
-    adcs x20,x20,x15        // Add low(a[1] * b[3]) and carry.
-    umulh x15,x11,x9        // x15 = high(a[1] * b[3]).
-    adcs x21,x21,x16        // Add low(a[2] * b[3]) and carry.
-    mul x3,x4,x19           // q = current limb 0 * inv mod 2^64.
-    umulh x16,x12,x9        // x16 = high(a[2] * b[3]).
-    adcs x22,x22,x17        // Add low(a[3] * b[3]) and carry.
-    umulh x17,x13,x9        // x17 = high(a[3] * b[3]).
-    adc x23,x23,xzr         // Propagate multiplication carry to limb 4.
-
-    adds x20,x20,x14        // Add high(a[0] * b[3]) to limb 1.
-    // low(q * p[0]) cancels x19.
-    adcs x21,x21,x15        // Add high(a[1] * b[3]) and carry.
-    mul x15,x6,x3           // x15 = low(q * p[1]).
-    adcs x22,x22,x16        // Add high(a[2] * b[3]) and carry.
-    // low(q * p[2]) is zero.
-    adc x23,x23,x17         // Add high(a[3] * b[3]) and final carry.
-    lsl x17,x3,#62          // x17 = low(q * p[3]).
-    subs xzr,x19,#1         // Set the low-limb cancellation carry.
-    umulh x14,x5,x3         // x14 = high(q * p[0]).
-    adcs x20,x20,x15        // Add low(q * p[1]) and cancellation carry.
-    umulh x15,x6,x3         // x15 = high(q * p[1]).
-    adcs x21,x21,xzr        // Propagate carry across zero p[2].
-    // high(q * p[2]) is zero.
-    adcs x22,x22,x17        // Add low(q * p[3]) and carry.
-    lsr x17,x3,#2           // x17 = high(q * p[3]).
-    adc x23,x23,xzr         // Propagate carry to limb 4.
-
-    // Shift out the fourth cancelled limb. x23 records any 257th bit.
-    adds x19,x20,x14        // Final candidate limb 0.
-    adcs x20,x21,x15        // Final candidate limb 1.
-    adcs x21,x22,xzr        // Final candidate limb 2.
-    adcs x22,x23,x17        // Final candidate limb 3.
-    adc x23,xzr,xzr         // Final candidate carry limb.
-
-    // Subtract the five-limb value p = [p0,p1,0,p3,0].
-    subs x14,x19,x5         // Tentative result limb 0 = candidate - p[0].
-    sbcs x15,x20,x6         // Tentative result limb 1 minus p[1].
-    sbcs x16,x21,xzr        // Tentative result limb 2; p[2] is zero.
-    sbcs x17,x22,x8         // Tentative result limb 3 minus p[3].
-    sbcs xzr,x23,xzr        // Include the carry limb in the comparison.
-
-    // `lo` means subtraction borrowed, so retain the original candidate.
-    csel x19,x19,x14,lo     // Select canonical output limb 0.
-    csel x20,x20,x15,lo     // Select canonical output limb 1.
-    csel x21,x21,x16,lo     // Select canonical output limb 2.
-    csel x22,x22,x17,lo     // Select canonical output limb 3.
-
-    stp x19,x20,[x0]        // Store output limbs 0 and 1.
-    stp x21,x22,[x0,#16]    // Store output limbs 2 and 3.
-
-    ldp x19,x20,[x29,#16]   // Restore callee-saved x19 and x20.
-    ldp x21,x22,[x29,#32]   // Restore callee-saved x21 and x22.
-    ldp x23,x24,[x29,#48]   // Restore callee-saved x23 and x24.
-    ldr x29,[sp],#64        // Restore frame pointer and release the frame.
-    ret                     // Return; x30 still holds the caller's address.
-
-.globl _pasta_curves_sqr_mont_pasta
-.private_extern _pasta_curves_sqr_mont_pasta
-
-.align 5
-_pasta_curves_sqr_mont_pasta:
-    .long 3573752639        // `paciasp`: sign LR with the entry stack pointer.
-    stp x29,x30,[sp,#-48]! // Allocate frame; save frame pointer and signed LR.
-    add x29,sp,#0           // Set the frame pointer to the new stack top.
-    stp x19,x20,[sp,#16]    // Preserve callee-saved product limbs 4 and 5.
-    stp x21,x22,[sp,#32]    // Preserve callee-saved product limbs 6 and 7.
-
-    ldp x5,x6,[x1]          // Load value limbs a[0] and a[1].
-    ldp x7,x8,[x1,#16]      // Load value limbs a[2] and a[3].
-    mov x4,x3               // Move inv into the helper's expected register.
-
-    ////////////////////////////////////////////////////////////////
-    //  |  |  |  |  |  |a1*a0|  |
-    //  |  |  |  |  |a2*a0|  |  |
-    //  |  |a3*a2|a3*a0|  |  |  |
-    //  |  |  |  |a2*a1|  |  |  |
-    //  |  |  |a3*a1|  |  |  |  |
-    // *|  |  |  |  |  |  |  | 2|
-    // +|a3*a3|a2*a2|a1*a1|a0*a0|
-    //  |--+--+--+--+--+--+--+--|
-    //  |A7|A6|A5|A4|A3|A2|A1|A0|
-    // A0..A7 map to x10,x11,x12,x13,x19,x20,x21,x22.
-    //
-    //  "can't overflow" below mark carrying into high part of
-    //  multiplication result, which can't overflow, because it
-    //  can never be all ones.
-
-    mul x11,x6,x5           // x11 = low(a[1] * a[0]).
-    umulh x15,x6,x5         // x15 = high(a[1] * a[0]).
-    mul x12,x7,x5           // x12 = low(a[2] * a[0]).
-    umulh x16,x7,x5         // x16 = high(a[2] * a[0]).
-    mul x13,x8,x5           // x13 = low(a[3] * a[0]).
-    umulh x19,x8,x5         // x19 = high(a[3] * a[0]).
-
-    adds x12,x12,x15        // Fold high(a[1] * a[0]) into product limb 2.
-    mul x14,x7,x6           // x14 = low(a[2] * a[1]).
-    umulh x15,x7,x6         // x15 = high(a[2] * a[1]).
-    adcs x13,x13,x16        // Fold high(a[2] * a[0]) into product limb 3.
-    mul x16,x8,x6           // x16 = low(a[3] * a[1]).
-    umulh x17,x8,x6         // x17 = high(a[3] * a[1]).
-    adc x19,x19,xzr         // Propagate carry into product limb 4.
-
-    mul x20,x8,x7           // x20 = low(a[3] * a[2]).
-    umulh x21,x8,x7         // x21 = high(a[3] * a[2]).
-
-    adds x15,x15,x16        // Combine terms contributing to product limb 4.
-    mul x10,x5,x5           // x10 = low(a[0]^2), product limb 0.
-    adc x16,x17,xzr         // Combine terms contributing to product limb 5.
-
-    adds x13,x13,x14        // Add low(a[2] * a[1]) into product limb 3.
-    umulh x5,x5,x5          // x5 = high(a[0]^2).
-    adcs x19,x19,x15        // Accumulate cross terms into product limb 4.
-    mul x15,x6,x6           // x15 = low(a[1]^2).
-    adcs x20,x20,x16        // Accumulate cross terms into product limb 5.
-    umulh x6,x6,x6          // x6 = high(a[1]^2).
-    adc x21,x21,xzr         // Propagate carry into product limb 6.
-
-    adds x11,x11,x11        // Double cross-term product limb 1.
-    mul x16,x7,x7           // x16 = low(a[2]^2).
-    adcs x12,x12,x12        // Double cross-term product limb 2.
-    umulh x7,x7,x7          // x7 = high(a[2]^2).
-    adcs x13,x13,x13        // Double cross-term product limb 3.
-    mul x17,x8,x8           // x17 = low(a[3]^2).
-    adcs x19,x19,x19        // Double cross-term product limb 4.
-    umulh x8,x8,x8          // x8 = high(a[3]^2).
-    adcs x20,x20,x20        // Double cross-term product limb 5.
-    adcs x21,x21,x21        // Double cross-term product limb 6.
-    adc x22,xzr,xzr         // Capture the doubled cross-term carry in limb 7.
-
-    // Add diagonal squares to obtain a^2 in x10,x11,x12,x13,x19..x22.
-    adds x11,x11,x5         // Add high(a[0]^2) to product limb 1.
-    adcs x12,x12,x15        // Add low(a[1]^2) to product limb 2.
-    adcs x13,x13,x6         // Add high(a[1]^2) to product limb 3.
-    adcs x19,x19,x16        // Add low(a[2]^2) to product limb 4.
-    adcs x20,x20,x7         // Add high(a[2]^2) to product limb 5.
-    adcs x21,x21,x17        // Add low(a[3]^2) to product limb 6.
-    adc x22,x22,x8          // Add high(a[3]^2) to product limb 7.
-
-    // Reduce the lower four limbs; upper limbs remain in callee-saved regs.
-    bl L$pasta_curves_mul_by_1_mont_pasta // Reduce x10..x13 by R.
-    ldr x30,[x29,#8]        // Restore signed LR clobbered by `bl`.
-
-    // Add the untouched upper half, completing reduction of the 512-bit square.
-    adds x10,x10,x19        // Add original product limb 4 to result limb 0.
-    adcs x11,x11,x20        // Add original product limb 5 and carry.
-    adcs x12,x12,x21        // Add original product limb 6 and carry.
-    adcs x13,x13,x22        // Add original product limb 7 and carry.
-    adc x19,xzr,xzr         // Capture a possible 257th candidate bit.
-
-    // Tentatively subtract p as a five-limb value.
-    subs x14,x10,x5         // Tentative result limb 0 = candidate - p[0].
-    sbcs x15,x11,x6         // Tentative result limb 1 minus p[1].
-    sbcs x16,x12,x7         // Tentative result limb 2 minus p[2] = 0.
-    sbcs x17,x13,x8         // Tentative result limb 3 minus p[3].
-    sbcs xzr,x19,xzr        // Include the candidate carry in the comparison.
-
-    // If subtraction borrowed (`lo`), keep the original candidate.
-    csel x10,x10,x14,lo     // Select canonical output limb 0.
-    csel x11,x11,x15,lo     // Select canonical output limb 1.
-    csel x12,x12,x16,lo     // Select canonical output limb 2.
-    csel x13,x13,x17,lo     // Select canonical output limb 3.
-
-    stp x10,x11,[x0]        // Store output limbs 0 and 1.
-    stp x12,x13,[x0,#16]    // Store output limbs 2 and 3.
-
-    ldp x19,x20,[x29,#16]   // Restore callee-saved x19 and x20.
-    ldp x21,x22,[x29,#32]   // Restore callee-saved x21 and x22.
-    ldr x29,[sp],#48        // Restore frame pointer and entry stack pointer.
-    .long 3573752767        // `autiasp`: authenticate LR with entry SP.
-    ret                     // Return through the authenticated address.
 
 .globl _pasta_curves_from_mont_pasta
 .private_extern _pasta_curves_from_mont_pasta
@@ -473,7 +157,7 @@ L$pasta_curves_mul_by_1_mont_pasta:
     adcs x12,x13,xzr        // Output limb 2; p[2] contributes zero.
     adc x13,x9,x17          // Output limb 3 includes high(q * p[3]).
 
-    ret                     // Return to square or from_mont through x30.
+    ret                     // Return to from_mont through x30.
 
 .globl _pasta_curves_sqr_n_mul_mont_pasta
 .private_extern _pasta_curves_sqr_n_mul_mont_pasta
@@ -507,7 +191,8 @@ _pasta_curves_sqr_n_mul_mont_pasta:
 L$pasta_curves_sqr_n_mul_loop:
     sub x2,x2,#1            // Consume one squaring from the count.
 
-    // Square a (in x6..x9) exactly as in sqr_mont above; the 512-bit
+    // Square a (in x6..x9) exactly as the inline `square` in
+    // src/fields/aarch64_asm.rs does; the 512-bit
     // product limbs A0..A7 map to x10,x11,x12,x13,x14,x15,x16,x17.
 
     mul x11,x7,x6           // x11 = low(a[1] * a[0]).
@@ -653,7 +338,8 @@ L$pasta_curves_sqr_n_mul_loop:
 
     cbnz x2,L$pasta_curves_sqr_n_mul_loop // Square again if count remains.
 
-    // Multiply the accumulator (x6..x9) by rhs, as in mul_mont above but
+    // Multiply the accumulator (x6..x9) by rhs, as the inline `mul` in
+    // src/fields/aarch64_asm.rs does, but
     // with the five-limb product in x10..x14 and temporaries in x19..x22.
     ldr x1,[x3]             // Load rhs limb b[0].
 

--- a/src/curves.rs
+++ b/src/curves.rs
@@ -197,7 +197,7 @@ macro_rules! new_curve_impl {
                     acc = $base::conditional_select(&(acc * p.z), &acc, skip);
 
                     // Set the coordinates to the correct value
-                    let tmp2 = tmp.square();
+                    let tmp2 = Field::square(&tmp);
                     let tmp3 = tmp2 * tmp;
 
                     q.x = p.x * tmp2;
@@ -209,7 +209,7 @@ macro_rules! new_curve_impl {
 
             fn to_affine(&self) -> Self::AffineRepr {
                 let zinv = self.z.invert().unwrap_or($base::zero());
-                let zinv2 = zinv.square();
+                let zinv2 = Field::square(&zinv);
                 let x = self.x * zinv2;
                 let zinv3 = zinv2 * zinv;
                 let y = self.y * zinv3;
@@ -368,8 +368,8 @@ macro_rules! new_curve_impl {
                 } else if bool::from(rhs.is_identity()) {
                     *self
                 } else {
-                    let z1z1 = self.z.square();
-                    let z2z2 = rhs.z.square();
+                    let z1z1 = Field::square(&self.z);
+                    let z2z2 = Field::square(&rhs.z);
                     let u1 = self.x * z2z2;
                     let u2 = rhs.x * z1z1;
                     let s1 = self.y * z2z2 * rhs.z;
@@ -383,16 +383,16 @@ macro_rules! new_curve_impl {
                         }
                     } else {
                         let h = u2 - u1;
-                        let i = (h + h).square();
+                        let i = Field::square(&(h + h));
                         let j = h * i;
                         let r = s2 - s1;
                         let r = r + r;
                         let v = u1 * i;
-                        let x3 = r.square() - j - v - v;
+                        let x3 = Field::square(&r) - j - v - v;
                         let s1 = s1 * j;
                         let s1 = s1 + s1;
                         let y3 = r * (v - x3) - s1;
-                        let z3 = (self.z + rhs.z).square() - z1z1 - z2z2;
+                        let z3 = Field::square(&(self.z + rhs.z)) - z1z1 - z2z2;
                         let z3 = z3 * h;
 
                         $name {
@@ -412,7 +412,7 @@ macro_rules! new_curve_impl {
                 } else if bool::from(rhs.is_identity()) {
                     *self
                 } else {
-                    let z1z1 = self.z.square();
+                    let z1z1 = Field::square(&self.z);
                     let u2 = rhs.x * z1z1;
                     let s2 = rhs.y * z1z1 * self.z;
 
@@ -424,18 +424,18 @@ macro_rules! new_curve_impl {
                         }
                     } else {
                         let h = u2 - self.x;
-                        let hh = h.square();
+                        let hh = Field::square(&h);
                         let i = hh + hh;
                         let i = i + i;
                         let j = h * i;
                         let r = s2 - self.y;
                         let r = r + r;
                         let v = self.x * i;
-                        let x3 = r.square() - j - v - v;
+                        let x3 = Field::square(&r) - j - v - v;
                         let j = self.y * j;
                         let j = j + j;
                         let y3 = r * (v - x3) - j;
-                        let z3 = (self.z + h).square() - z1z1 - hh;
+                        let z3 = Field::square(&(self.z + h)) - z1z1 - hh;
 
                         $name {
                             x: x3, y: y3, z: z3
@@ -539,14 +539,14 @@ macro_rules! new_curve_impl {
                         }
                     } else {
                         let h = rhs.x - self.x;
-                        let hh = h.square();
+                        let hh = Field::square(&h);
                         let i = hh + hh;
                         let i = i + i;
                         let j = h * i;
                         let r = rhs.y - self.y;
                         let r = r + r;
                         let v = self.x * i;
-                        let x3 = r.square() - j - v - v;
+                        let x3 = Field::square(&r) - j - v - v;
                         let j = self.y * j;
                         let j = j + j;
                         let y3 = r * (v - x3) - j;
@@ -814,15 +814,15 @@ macro_rules! impl_projective_curve_specific {
             //
             // There are no points of order 2.
 
-            let a = self.x.square();
-            let b = self.y.square();
-            let c = b.square();
+            let a = Field::square(&self.x);
+            let b = Field::square(&self.y);
+            let c = Field::square(&b);
             let d = self.x + b;
-            let d = d.square();
+            let d = Field::square(&d);
             let d = d - a - c;
             let d = d + d;
             let e = a + a + a;
-            let f = e.square();
+            let f = Field::square(&e);
             let z3 = self.z * self.y;
             let z3 = z3 + z3;
             let x3 = f - (d + d);

--- a/src/fields.rs
+++ b/src/fields.rs
@@ -4,6 +4,16 @@
 mod fp;
 mod fq;
 
+// Keep the assembly FFI exception contained within a private module whose
+// public interface consists only of safe wrappers.
+#[allow(unsafe_code)]
+#[cfg(all(
+    feature = "aarch64-asm",
+    target_arch = "aarch64",
+    target_vendor = "apple"
+))]
+mod aarch64_asm;
+
 pub use fp::*;
 pub use fq::*;
 

--- a/src/fields/aarch64_asm.rs
+++ b/src/fields/aarch64_asm.rs
@@ -1,0 +1,43 @@
+//! Private bindings to the Apple AArch64 Pasta field backend.
+
+type Limbs = [u64; 4];
+
+extern "C" {
+    fn pasta_curves_mul_mont_pasta(
+        out: *mut Limbs,
+        lhs: *const Limbs,
+        rhs: *const Limbs,
+        modulus: *const Limbs,
+        inv: u64,
+    );
+    fn pasta_curves_sqr_mont_pasta(
+        out: *mut Limbs,
+        value: *const Limbs,
+        modulus: *const Limbs,
+        inv: u64,
+    );
+}
+
+/// Multiplies two canonical Montgomery residues for a Pasta modulus.
+#[inline]
+pub(super) fn mul(lhs: &Limbs, rhs: &Limbs, modulus: &Limbs, inv: u64) -> Limbs {
+    let mut out = Limbs::default();
+    // SAFETY: All pointers refer to four initialized `u64` limbs for the
+    // duration of the call. The backend writes exactly four limbs to `out`.
+    unsafe {
+        pasta_curves_mul_mont_pasta(&mut out, lhs, rhs, modulus, inv);
+    }
+    out
+}
+
+/// Squares a canonical Montgomery residue for a Pasta modulus.
+#[inline]
+pub(super) fn square(value: &Limbs, modulus: &Limbs, inv: u64) -> Limbs {
+    let mut out = Limbs::default();
+    // SAFETY: All pointers refer to four initialized `u64` limbs for the
+    // duration of the call. The backend writes exactly four limbs to `out`.
+    unsafe {
+        pasta_curves_sqr_mont_pasta(&mut out, value, modulus, inv);
+    }
+    out
+}

--- a/src/fields/aarch64_asm.rs
+++ b/src/fields/aarch64_asm.rs
@@ -16,6 +16,12 @@ extern "C" {
         modulus: *const Limbs,
         inv: u64,
     );
+    fn pasta_curves_from_mont_pasta(
+        out: *mut Limbs,
+        value: *const Limbs,
+        modulus: *const Limbs,
+        inv: u64,
+    );
 }
 
 /// Multiplies two canonical Montgomery residues for a Pasta modulus.
@@ -26,6 +32,18 @@ pub(super) fn mul(lhs: &Limbs, rhs: &Limbs, modulus: &Limbs, inv: u64) -> Limbs 
     // duration of the call. The backend writes exactly four limbs to `out`.
     unsafe {
         pasta_curves_mul_mont_pasta(&mut out, lhs, rhs, modulus, inv);
+    }
+    out
+}
+
+/// Converts a canonical Montgomery residue into its canonical integer.
+#[inline]
+pub(super) fn from_mont(value: &Limbs, modulus: &Limbs, inv: u64) -> Limbs {
+    let mut out = Limbs::default();
+    // SAFETY: All pointers refer to four initialized `u64` limbs for the
+    // duration of the call. The backend writes exactly four limbs to `out`.
+    unsafe {
+        pasta_curves_from_mont_pasta(&mut out, value, modulus, inv);
     }
     out
 }

--- a/src/fields/aarch64_asm.rs
+++ b/src/fields/aarch64_asm.rs
@@ -42,6 +42,22 @@
 //! `fq.rs` still pin the unreduced-`lhs` behaviour against the `R2`/`R3`
 //! constants in case a future caller relies on it.
 //!
+//! The canonical-`rhs` requirement and the accumulator no-wrap requirement
+//! are separate. Canonical `rhs` gives `rhs < p`; the per-limb bound above
+//! does not imply this. If `m < R` is the Montgomery cancellation factor and
+//! `lhs < R` is any four-limb value, the final candidate satisfies
+//! `(lhs * rhs + m * p) / R < 2p < R`. The separate per-limb condition only
+//! ensures that the implementation computes this candidate without an
+//! intermediate five-limb addition wrapping.
+//!
+//! Because `mul` relies on that bound to omit a fifth candidate limb, a
+//! non-canonical `rhs` is no longer merely tolerated with a non-canonical
+//! (but congruent) output: for `rhs >= R - p` the candidate can reach `R`,
+//! and the dropped limb makes the result an **incorrect residue** that still
+//! looks canonical. Every in-crate caller supplies a canonical `rhs` by
+//! construction; `mul` and `square` debug-assert the precondition so a future
+//! caller that breaks it fails loudly under test instead of silently.
+//!
 //! There are no branches and no memory accesses inside the blocks, so the
 //! code is constant-time.
 
@@ -66,11 +82,28 @@ extern "C" {
     );
 }
 
+/// Whether `value < modulus` as little-endian 256-bit integers.
+#[inline(always)]
+fn is_canonical(value: &Limbs, modulus: &Limbs) -> bool {
+    for i in (0..4).rev() {
+        if value[i] != modulus[i] {
+            return value[i] < modulus[i];
+        }
+    }
+    false
+}
+
 /// Multiplies two Montgomery residues for a Pasta modulus. `rhs` must be
-/// canonical. `lhs` may be unreduced only if every `rhs` limb is at most
-/// `2^64 - 4`; see the module docs for the carry-chain bound behind this.
+/// canonical (debug-asserted; a violation yields an incorrect residue, see
+/// the module docs). `lhs` may be unreduced only if every `rhs` limb is at
+/// most `2^64 - 4`; see the module docs for the carry-chain bound behind
+/// this.
 #[inline(always)]
 pub(super) fn mul(lhs: &Limbs, rhs: &Limbs, modulus: &Limbs, inv: u64) -> Limbs {
+    debug_assert!(
+        is_canonical(rhs, modulus),
+        "aarch64_asm::mul requires a canonical rhs"
+    );
     let (o0, o1, o2, o3): (u64, u64, u64, u64);
     // SAFETY: straight-line register-only arithmetic; no memory access, no
     // stack use, and outputs depend only on the declared inputs.
@@ -230,20 +263,20 @@ pub(super) fn mul(lhs: &Limbs, rhs: &Limbs, modulus: &Limbs, inv: u64) -> Limbs 
             "lsr {t3}, {q}, #2",                // t3 = high(q * p[3]).
             "adc {r4}, {r4}, xzr",              // Propagate carry to limb 4.
 
-            // Shift out the fourth cancelled limb. r4 records any 257th bit.
+            // Shift out the fourth cancelled limb. Canonical rhs gives
+            // lhs*rhs < R*p, and m < R gives m*p < R*p. Thus the candidate
+            // (lhs*rhs + m*p)/R is below 2p < R, so no fifth limb exists.
             "adds {r0}, {r1}, {t0}",            // Final candidate limb 0.
             "adcs {r1}, {r2}, {t1}",            // Final candidate limb 1.
             "adcs {r2}, {r3}, xzr",             // Final candidate limb 2.
             "adcs {r3}, {r4}, {t3}",            // Final candidate limb 3.
-            "adc {r4}, xzr, xzr",               // Final candidate carry limb.
 
-            // Subtract the five-limb value p = [p0,p1,0,p3,0].
+            // Subtract p = [p0,p1,0,p3].
             "mov {q}, #0x4000000000000000",     // Materialize p3 = 2^62.
             "subs {t0}, {r0}, {p0}",            // Tentative result limb 0 = candidate - p[0].
             "sbcs {t1}, {r1}, {p1}",            // Tentative result limb 1 minus p[1].
             "sbcs {t2}, {r2}, xzr",             // Tentative result limb 2; p[2] is zero.
             "sbcs {t3}, {r3}, {q}",             // Tentative result limb 3 minus p[3].
-            "sbcs xzr, {r4}, xzr",              // Include the carry limb in the comparison.
 
             // `lo` means subtraction borrowed, so retain the original candidate.
             "csel {r0}, {r0}, {t0}, lo",        // Select canonical output limb 0.
@@ -277,9 +310,14 @@ pub(super) fn mul(lhs: &Limbs, rhs: &Limbs, modulus: &Limbs, inv: u64) -> Limbs 
     [o0, o1, o2, o3]
 }
 
-/// Squares a canonical Montgomery residue for a Pasta modulus.
+/// Squares a canonical Montgomery residue for a Pasta modulus (the input's
+/// canonicity is debug-asserted).
 #[inline(always)]
 pub(super) fn square(value: &Limbs, modulus: &Limbs, inv: u64) -> Limbs {
+    debug_assert!(
+        is_canonical(value, modulus),
+        "aarch64_asm::square requires a canonical input"
+    );
     let mut a0 = value[0];
     let mut a1 = value[1];
     let mut a2 = value[2];

--- a/src/fields/aarch64_asm.rs
+++ b/src/fields/aarch64_asm.rs
@@ -1,21 +1,55 @@
-//! Private bindings to the Apple AArch64 Pasta field backend.
+//! Private Apple AArch64 backend for the Pasta fields.
+//!
+//! Montgomery multiplication and squaring are implemented as inline `asm!`
+//! blocks below; the fused repeated-squaring chain and the canonical-form
+//! conversion remain in `src/asm/pasta_mul-armv8.S` and are reached through
+//! `extern "C"`.
+//!
+//! The inline blocks are register-renamed transcriptions of the upstream
+//! Semolina v0.1.4 routines (`mul_mont_pasta`, and the squaring loop body of
+//! the vendored `sqr_n_mul_mont_pasta`), with rhs limbs and the modulus
+//! constants supplied in registers instead of loaded from memory. The
+//! per-instruction comments are carried over from the removed assembly
+//! routines. Because the operands are
+//! ordinary register operands and the blocks are declared
+//! `options(pure, nomem, nostack)`, LLVM inlines the wrappers into callers
+//! and keeps field values in registers between operations — there is no
+//! call, pointer, or ABI-clobber traffic per field operation.
+//!
+//! Like the assembly file, the arithmetic relies on the shared Pasta modulus
+//! shape: `modulus[2] = 0` and `modulus[3] = 2^62` (materialized inline as an
+//! immediate). Only `modulus[0]`, `modulus[1]`, and `inv` vary between Fp
+//! and Fq, so a single implementation serves both fields.
+//!
+//! Canonicity contract (same as the assembly): `rhs` in `mul` and the input
+//! of `square` must be canonical (below the modulus). `lhs` in `mul` may be
+//! an unreduced 256-bit value **only if every `rhs` limb is at most
+//! `2^64 - 4`**; with both operands canonical the routines are always safe.
+//! Outputs are canonical.
+//!
+//! The `lhs` caveat exists because `mul` keeps a five-limb accumulator (one
+//! word fewer than textbook CIOS). The only carry chain that can wrap is the
+//! one folding in the high cross-products: its tail computes
+//! `acc4 + high(lhs[3] * rhs_limb) + carry` with `acc4 <= 2`, which reaches
+//! `2^64` only when `high(lhs[3] * rhs_limb) >= 2^64 - 3`, i.e. when
+//! `lhs[3]` and some `rhs` limb are both within 3 of `2^64`. A canonical
+//! `lhs` has `lhs[3] <= 2^62`, and any `rhs` limb `<= 2^64 - 4` caps the
+//! high product at `2^64 - 5`, so either condition alone rules the wrap out.
+//! No current caller passes an unreduced `lhs`: `from_u512`, the one place
+//! that produces unreduced values, deliberately uses the portable
+//! multiplication instead. The
+//! `aarch64_asm_mul_unreduced_lhs_matches_portable` tests in `fp.rs` and
+//! `fq.rs` still pin the unreduced-`lhs` behaviour against the `R2`/`R3`
+//! constants in case a future caller relies on it.
+//!
+//! There are no branches and no memory accesses inside the blocks, so the
+//! code is constant-time.
+
+use core::arch::asm;
 
 type Limbs = [u64; 4];
 
 extern "C" {
-    fn pasta_curves_mul_mont_pasta(
-        out: *mut Limbs,
-        lhs: *const Limbs,
-        rhs: *const Limbs,
-        modulus: *const Limbs,
-        inv: u64,
-    );
-    fn pasta_curves_sqr_mont_pasta(
-        out: *mut Limbs,
-        value: *const Limbs,
-        modulus: *const Limbs,
-        inv: u64,
-    );
     fn pasta_curves_sqr_n_mul_mont_pasta(
         out: *mut Limbs,
         value: *const Limbs,
@@ -32,40 +66,412 @@ extern "C" {
     );
 }
 
-/// Multiplies two canonical Montgomery residues for a Pasta modulus.
-#[inline]
+/// Multiplies two Montgomery residues for a Pasta modulus. `rhs` must be
+/// canonical. `lhs` may be unreduced only if every `rhs` limb is at most
+/// `2^64 - 4`; see the module docs for the carry-chain bound behind this.
+#[inline(always)]
 pub(super) fn mul(lhs: &Limbs, rhs: &Limbs, modulus: &Limbs, inv: u64) -> Limbs {
-    let mut out = Limbs::default();
-    // SAFETY: All pointers refer to four initialized `u64` limbs for the
-    // duration of the call. The backend writes exactly four limbs to `out`.
+    let (o0, o1, o2, o3): (u64, u64, u64, u64);
+    // SAFETY: straight-line register-only arithmetic; no memory access, no
+    // stack use, and outputs depend only on the declared inputs.
     unsafe {
-        pasta_curves_mul_mont_pasta(&mut out, lhs, rhs, modulus, inv);
-    }
-    out
-}
+        asm!(
+            // Round 0: lhs * rhs[0], then cancel the low limb.
+            // Form the five-limb product a * b[0] in r0..r4.
+            "mul {r0}, {a0}, {b0}",             // r0 = low(a[0] * b[0]).
+            "mul {r1}, {a1}, {b0}",             // r1 = low(a[1] * b[0]).
+            "mul {r2}, {a2}, {b0}",             // r2 = low(a[2] * b[0]).
+            "mul {r3}, {a3}, {b0}",             // r3 = low(a[3] * b[0]).
 
-/// Converts a canonical Montgomery residue into its canonical integer.
-#[inline]
-pub(super) fn from_mont(value: &Limbs, modulus: &Limbs, inv: u64) -> Limbs {
-    let mut out = Limbs::default();
-    // SAFETY: All pointers refer to four initialized `u64` limbs for the
-    // duration of the call. The backend writes exactly four limbs to `out`.
-    unsafe {
-        pasta_curves_from_mont_pasta(&mut out, value, modulus, inv);
+            "umulh {t0}, {a0}, {b0}",           // t0 = high(a[0] * b[0]).
+            "umulh {t1}, {a1}, {b0}",           // t1 = high(a[1] * b[0]).
+            "mul {q}, {inv}, {r0}",             // q = r0 * inv mod 2^64.
+            "umulh {t2}, {a2}, {b0}",           // t2 = high(a[2] * b[0]).
+            "umulh {t3}, {a3}, {b0}",           // t3 = high(a[3] * b[0]).
+            "adds {r1}, {r1}, {t0}",            // Add high(a[0] * b[0]) into limb 1.
+            // low(q * p[0]) cancels r0 and is discarded by the limb shift.
+            "adcs {r2}, {r2}, {t1}",            // Add high(a[1] * b[0]) and carry.
+            "mul {t1}, {p1}, {q}",              // t1 = low(q * p[1]).
+            "adcs {r3}, {r3}, {t2}",            // Add high(a[2] * b[0]) and carry.
+            // q * p[2] is zero because p[2] = 0.
+            "adc {r4}, xzr, {t3}",              // Finish a * b[0] with its fifth limb.
+            "lsl {t3}, {q}, #62",               // t3 = low(q * p[3]).
+            // Carry from r0 + low(q*p[0]) is one exactly when r0 is nonzero.
+            "subs xzr, {r0}, #1",               // Set that carry without computing the zero sum.
+            "umulh {t0}, {p0}, {q}",            // t0 = high(q * p[0]).
+            "adcs {r1}, {r1}, {t1}",            // Add low(q * p[1]) and cancellation carry.
+            "umulh {t1}, {p1}, {q}",            // t1 = high(q * p[1]).
+            "adcs {r2}, {r2}, xzr",             // Propagate carry; p[2]'s product is zero.
+            // high(q * p[2]) is zero.
+            "adcs {r3}, {r3}, {t3}",            // Add low(q * p[3]) and carry.
+            "lsr {t3}, {q}, #2",                // t3 = high(q * p[3]).
+            "adc {r4}, {r4}, xzr",              // Propagate carry into the fifth limb.
+
+            // Drop the cancelled low limb: (a*b[0] + q*p) / 2^64.
+            "adds {r0}, {r1}, {t0}",            // New limb 0 includes high(q * p[0]).
+            "mul {t0}, {a0}, {b1}",             // t0 = low(a[0] * b[1]).
+            "adcs {r1}, {r2}, {t1}",            // New limb 1 includes high(q * p[1]).
+            "mul {t1}, {a1}, {b1}",             // t1 = low(a[1] * b[1]).
+            "adcs {r2}, {r3}, xzr",             // New limb 2; p[2] contributes zero.
+            "mul {t2}, {a2}, {b1}",             // t2 = low(a[2] * b[1]).
+            "adcs {r3}, {r4}, {t3}",            // New limb 3 includes high(q * p[3]).
+            "mul {t3}, {a3}, {b1}",             // t3 = low(a[3] * b[1]).
+            "adc {r4}, xzr, xzr",               // Capture the reduction carry as limb 4.
+
+            // Round 1: add a * b[1] to the reduced accumulator.
+            "adds {r0}, {r0}, {t0}",            // Add low(a[0] * b[1]) to limb 0.
+            "umulh {t0}, {a0}, {b1}",           // t0 = high(a[0] * b[1]).
+            "adcs {r1}, {r1}, {t1}",            // Add low(a[1] * b[1]) and carry.
+            "umulh {t1}, {a1}, {b1}",           // t1 = high(a[1] * b[1]).
+            "adcs {r2}, {r2}, {t2}",            // Add low(a[2] * b[1]) and carry.
+            "mul {q}, {inv}, {r0}",             // q = current limb 0 * inv mod 2^64.
+            "umulh {t2}, {a2}, {b1}",           // t2 = high(a[2] * b[1]).
+            "adcs {r3}, {r3}, {t3}",            // Add low(a[3] * b[1]) and carry.
+            "umulh {t3}, {a3}, {b1}",           // t3 = high(a[3] * b[1]).
+            "adc {r4}, {r4}, xzr",              // Propagate multiplication carry to limb 4.
+
+            "adds {r1}, {r1}, {t0}",            // Add high(a[0] * b[1]) to limb 1.
+            // low(q * p[0]) cancels r0.
+            "adcs {r2}, {r2}, {t1}",            // Add high(a[1] * b[1]) and carry.
+            "mul {t1}, {p1}, {q}",              // t1 = low(q * p[1]).
+            "adcs {r3}, {r3}, {t2}",            // Add high(a[2] * b[1]) and carry.
+            // low(q * p[2]) is zero.
+            "adc {r4}, {r4}, {t3}",             // Add high(a[3] * b[1]) and final carry.
+            "lsl {t3}, {q}, #62",               // t3 = low(q * p[3]).
+            "subs xzr, {r0}, #1",               // Set the low-limb cancellation carry.
+            "umulh {t0}, {p0}, {q}",            // t0 = high(q * p[0]).
+            "adcs {r1}, {r1}, {t1}",            // Add low(q * p[1]) and cancellation carry.
+            "umulh {t1}, {p1}, {q}",            // t1 = high(q * p[1]).
+            "adcs {r2}, {r2}, xzr",             // Propagate carry across zero p[2].
+            // high(q * p[2]) is zero.
+            "adcs {r3}, {r3}, {t3}",            // Add low(q * p[3]) and carry.
+            "lsr {t3}, {q}, #2",                // t3 = high(q * p[3]).
+            "adc {r4}, {r4}, xzr",              // Propagate carry to limb 4.
+
+            // Shift after round 1 while starting a * b[2].
+            "adds {r0}, {r1}, {t0}",            // New limb 0 includes high(q * p[0]).
+            "mul {t0}, {a0}, {b2}",             // t0 = low(a[0] * b[2]).
+            "adcs {r1}, {r2}, {t1}",            // New limb 1 includes high(q * p[1]).
+            "mul {t1}, {a1}, {b2}",             // t1 = low(a[1] * b[2]).
+            "adcs {r2}, {r3}, xzr",             // New limb 2; p[2] contributes zero.
+            "mul {t2}, {a2}, {b2}",             // t2 = low(a[2] * b[2]).
+            "adcs {r3}, {r4}, {t3}",            // New limb 3 includes high(q * p[3]).
+            "mul {t3}, {a3}, {b2}",             // t3 = low(a[3] * b[2]).
+            "adc {r4}, xzr, xzr",               // Capture the reduction carry as limb 4.
+
+            // Round 2: add a * b[2] and cancel the resulting low limb.
+            "adds {r0}, {r0}, {t0}",            // Add low(a[0] * b[2]) to limb 0.
+            "umulh {t0}, {a0}, {b2}",           // t0 = high(a[0] * b[2]).
+            "adcs {r1}, {r1}, {t1}",            // Add low(a[1] * b[2]) and carry.
+            "umulh {t1}, {a1}, {b2}",           // t1 = high(a[1] * b[2]).
+            "adcs {r2}, {r2}, {t2}",            // Add low(a[2] * b[2]) and carry.
+            "mul {q}, {inv}, {r0}",             // q = current limb 0 * inv mod 2^64.
+            "umulh {t2}, {a2}, {b2}",           // t2 = high(a[2] * b[2]).
+            "adcs {r3}, {r3}, {t3}",            // Add low(a[3] * b[2]) and carry.
+            "umulh {t3}, {a3}, {b2}",           // t3 = high(a[3] * b[2]).
+            "adc {r4}, {r4}, xzr",              // Propagate multiplication carry to limb 4.
+
+            "adds {r1}, {r1}, {t0}",            // Add high(a[0] * b[2]) to limb 1.
+            // low(q * p[0]) cancels r0.
+            "adcs {r2}, {r2}, {t1}",            // Add high(a[1] * b[2]) and carry.
+            "mul {t1}, {p1}, {q}",              // t1 = low(q * p[1]).
+            "adcs {r3}, {r3}, {t2}",            // Add high(a[2] * b[2]) and carry.
+            // low(q * p[2]) is zero.
+            "adc {r4}, {r4}, {t3}",             // Add high(a[3] * b[2]) and final carry.
+            "lsl {t3}, {q}, #62",               // t3 = low(q * p[3]).
+            "subs xzr, {r0}, #1",               // Set the low-limb cancellation carry.
+            "umulh {t0}, {p0}, {q}",            // t0 = high(q * p[0]).
+            "adcs {r1}, {r1}, {t1}",            // Add low(q * p[1]) and cancellation carry.
+            "umulh {t1}, {p1}, {q}",            // t1 = high(q * p[1]).
+            "adcs {r2}, {r2}, xzr",             // Propagate carry across zero p[2].
+            // high(q * p[2]) is zero.
+            "adcs {r3}, {r3}, {t3}",            // Add low(q * p[3]) and carry.
+            "lsr {t3}, {q}, #2",                // t3 = high(q * p[3]).
+            "adc {r4}, {r4}, xzr",              // Propagate carry to limb 4.
+
+            // Shift after round 2 while starting a * b[3].
+            "adds {r0}, {r1}, {t0}",            // New limb 0 includes high(q * p[0]).
+            "mul {t0}, {a0}, {b3}",             // t0 = low(a[0] * b[3]).
+            "adcs {r1}, {r2}, {t1}",            // New limb 1 includes high(q * p[1]).
+            "mul {t1}, {a1}, {b3}",             // t1 = low(a[1] * b[3]).
+            "adcs {r2}, {r3}, xzr",             // New limb 2; p[2] contributes zero.
+            "mul {t2}, {a2}, {b3}",             // t2 = low(a[2] * b[3]).
+            "adcs {r3}, {r4}, {t3}",            // New limb 3 includes high(q * p[3]).
+            "mul {t3}, {a3}, {b3}",             // t3 = low(a[3] * b[3]).
+            "adc {r4}, xzr, xzr",               // Capture the reduction carry as limb 4.
+
+            // Round 3: add a * b[3] and perform the last Montgomery cancellation.
+            "adds {r0}, {r0}, {t0}",            // Add low(a[0] * b[3]) to limb 0.
+            "umulh {t0}, {a0}, {b3}",           // t0 = high(a[0] * b[3]).
+            "adcs {r1}, {r1}, {t1}",            // Add low(a[1] * b[3]) and carry.
+            "umulh {t1}, {a1}, {b3}",           // t1 = high(a[1] * b[3]).
+            "adcs {r2}, {r2}, {t2}",            // Add low(a[2] * b[3]) and carry.
+            "mul {q}, {inv}, {r0}",             // q = current limb 0 * inv mod 2^64.
+            "umulh {t2}, {a2}, {b3}",           // t2 = high(a[2] * b[3]).
+            "adcs {r3}, {r3}, {t3}",            // Add low(a[3] * b[3]) and carry.
+            "umulh {t3}, {a3}, {b3}",           // t3 = high(a[3] * b[3]).
+            "adc {r4}, {r4}, xzr",              // Propagate multiplication carry to limb 4.
+
+            "adds {r1}, {r1}, {t0}",            // Add high(a[0] * b[3]) to limb 1.
+            // low(q * p[0]) cancels r0.
+            "adcs {r2}, {r2}, {t1}",            // Add high(a[1] * b[3]) and carry.
+            "mul {t1}, {p1}, {q}",              // t1 = low(q * p[1]).
+            "adcs {r3}, {r3}, {t2}",            // Add high(a[2] * b[3]) and carry.
+            // low(q * p[2]) is zero.
+            "adc {r4}, {r4}, {t3}",             // Add high(a[3] * b[3]) and final carry.
+            "lsl {t3}, {q}, #62",               // t3 = low(q * p[3]).
+            "subs xzr, {r0}, #1",               // Set the low-limb cancellation carry.
+            "umulh {t0}, {p0}, {q}",            // t0 = high(q * p[0]).
+            "adcs {r1}, {r1}, {t1}",            // Add low(q * p[1]) and cancellation carry.
+            "umulh {t1}, {p1}, {q}",            // t1 = high(q * p[1]).
+            "adcs {r2}, {r2}, xzr",             // Propagate carry across zero p[2].
+            // high(q * p[2]) is zero.
+            "adcs {r3}, {r3}, {t3}",            // Add low(q * p[3]) and carry.
+            "lsr {t3}, {q}, #2",                // t3 = high(q * p[3]).
+            "adc {r4}, {r4}, xzr",              // Propagate carry to limb 4.
+
+            // Shift out the fourth cancelled limb. r4 records any 257th bit.
+            "adds {r0}, {r1}, {t0}",            // Final candidate limb 0.
+            "adcs {r1}, {r2}, {t1}",            // Final candidate limb 1.
+            "adcs {r2}, {r3}, xzr",             // Final candidate limb 2.
+            "adcs {r3}, {r4}, {t3}",            // Final candidate limb 3.
+            "adc {r4}, xzr, xzr",               // Final candidate carry limb.
+
+            // Subtract the five-limb value p = [p0,p1,0,p3,0].
+            "mov {q}, #0x4000000000000000",     // Materialize p3 = 2^62.
+            "subs {t0}, {r0}, {p0}",            // Tentative result limb 0 = candidate - p[0].
+            "sbcs {t1}, {r1}, {p1}",            // Tentative result limb 1 minus p[1].
+            "sbcs {t2}, {r2}, xzr",             // Tentative result limb 2; p[2] is zero.
+            "sbcs {t3}, {r3}, {q}",             // Tentative result limb 3 minus p[3].
+            "sbcs xzr, {r4}, xzr",              // Include the carry limb in the comparison.
+
+            // `lo` means subtraction borrowed, so retain the original candidate.
+            "csel {r0}, {r0}, {t0}, lo",        // Select canonical output limb 0.
+            "csel {r1}, {r1}, {t1}, lo",        // Select canonical output limb 1.
+            "csel {r2}, {r2}, {t2}, lo",        // Select canonical output limb 2.
+            "csel {r3}, {r3}, {t3}, lo",        // Select canonical output limb 3.
+            a0 = in(reg) lhs[0],
+            a1 = in(reg) lhs[1],
+            a2 = in(reg) lhs[2],
+            a3 = in(reg) lhs[3],
+            b0 = in(reg) rhs[0],
+            b1 = in(reg) rhs[1],
+            b2 = in(reg) rhs[2],
+            b3 = in(reg) rhs[3],
+            p0 = in(reg) modulus[0],
+            p1 = in(reg) modulus[1],
+            inv = in(reg) inv,
+            q = out(reg) _,
+            t0 = out(reg) _,
+            t1 = out(reg) _,
+            t2 = out(reg) _,
+            t3 = out(reg) _,
+            r0 = out(reg) o0,
+            r1 = out(reg) o1,
+            r2 = out(reg) o2,
+            r3 = out(reg) o3,
+            r4 = out(reg) _,
+            options(pure, nomem, nostack),
+        );
     }
-    out
+    [o0, o1, o2, o3]
 }
 
 /// Squares a canonical Montgomery residue for a Pasta modulus.
-#[inline]
+#[inline(always)]
 pub(super) fn square(value: &Limbs, modulus: &Limbs, inv: u64) -> Limbs {
-    let mut out = Limbs::default();
-    // SAFETY: All pointers refer to four initialized `u64` limbs for the
-    // duration of the call. The backend writes exactly four limbs to `out`.
+    let mut a0 = value[0];
+    let mut a1 = value[1];
+    let mut a2 = value[2];
+    let mut a3 = value[3];
+    // SAFETY: straight-line register-only arithmetic; no memory access, no
+    // stack use, and outputs depend only on the declared inputs.
     unsafe {
-        pasta_curves_sqr_mont_pasta(&mut out, value, modulus, inv);
+        asm!(
+            // 512-bit square: cross products, doubling, diagonals.
+            // Square a (in a0..a3) exactly as in sqr_mont above; the 512-bit
+            // product limbs A0..A7 map to z0,z1,z2,z3,z4,z5,z6,z7.
+
+            "mul {z1}, {a1}, {a0}",             // z1 = low(a[1] * a[0]).
+            "umulh {w1}, {a1}, {a0}",           // w1 = high(a[1] * a[0]).
+            "mul {z2}, {a2}, {a0}",             // z2 = low(a[2] * a[0]).
+            "umulh {w2}, {a2}, {a0}",           // w2 = high(a[2] * a[0]).
+            "mul {z3}, {a3}, {a0}",             // z3 = low(a[3] * a[0]).
+            "umulh {z4}, {a3}, {a0}",           // z4 = high(a[3] * a[0]).
+
+            "adds {z2}, {z2}, {w1}",            // Fold high(a[1] * a[0]) into product limb 2.
+            "mul {w0}, {a2}, {a1}",             // w0 = low(a[2] * a[1]).
+            "umulh {w1}, {a2}, {a1}",           // w1 = high(a[2] * a[1]).
+            "adcs {z3}, {z3}, {w2}",            // Fold high(a[2] * a[0]) into product limb 3.
+            "mul {w2}, {a3}, {a1}",             // w2 = low(a[3] * a[1]).
+            "umulh {w3}, {a3}, {a1}",           // w3 = high(a[3] * a[1]).
+            "adc {z4}, {z4}, xzr",              // Propagate carry into product limb 4.
+
+            "mul {z5}, {a3}, {a2}",             // z5 = low(a[3] * a[2]).
+            "umulh {z6}, {a3}, {a2}",           // z6 = high(a[3] * a[2]).
+
+            "adds {w1}, {w1}, {w2}",            // Combine terms contributing to product limb 4.
+            "mul {z0}, {a0}, {a0}",             // z0 = low(a[0]^2), product limb 0.
+            "adc {w2}, {w3}, xzr",              // Combine terms contributing to product limb 5.
+
+            "adds {z3}, {z3}, {w0}",            // Add low(a[2] * a[1]) into product limb 3.
+            "umulh {a0}, {a0}, {a0}",           // a0 = high(a[0]^2).
+            "adcs {z4}, {z4}, {w1}",            // Accumulate cross terms into product limb 4.
+            "mul {w1}, {a1}, {a1}",             // w1 = low(a[1]^2).
+            "adcs {z5}, {z5}, {w2}",            // Accumulate cross terms into product limb 5.
+            "umulh {a1}, {a1}, {a1}",           // a1 = high(a[1]^2).
+            "adc {z6}, {z6}, xzr",              // Propagate carry into product limb 6.
+
+            "adds {z1}, {z1}, {z1}",            // Double cross-term product limb 1.
+            "mul {w2}, {a2}, {a2}",             // w2 = low(a[2]^2).
+            "adcs {z2}, {z2}, {z2}",            // Double cross-term product limb 2.
+            "umulh {a2}, {a2}, {a2}",           // a2 = high(a[2]^2).
+            "adcs {z3}, {z3}, {z3}",            // Double cross-term product limb 3.
+            "mul {w3}, {a3}, {a3}",             // w3 = low(a[3]^2).
+            "adcs {z4}, {z4}, {z4}",            // Double cross-term product limb 4.
+            "umulh {a3}, {a3}, {a3}",           // a3 = high(a[3]^2).
+            "adcs {z5}, {z5}, {z5}",            // Double cross-term product limb 5.
+            "adcs {z6}, {z6}, {z6}",            // Double cross-term product limb 6.
+            "adc {z7}, xzr, xzr",               // Capture the doubled cross-term carry in limb 7.
+
+            "mul {q}, {inv}, {z0}",             // q = product limb 0 * inv mod 2^64.
+
+            // Add diagonal squares to obtain a^2 in z0..z7.
+            "adds {z1}, {z1}, {a0}",            // Add high(a[0]^2) to product limb 1.
+            "adcs {z2}, {z2}, {w1}",            // Add low(a[1]^2) to product limb 2.
+            "adcs {z3}, {z3}, {a1}",            // Add high(a[1]^2) to product limb 3.
+            "adcs {z4}, {z4}, {w2}",            // Add low(a[2]^2) to product limb 4.
+            "adcs {z5}, {z5}, {a2}",            // Add high(a[2]^2) to product limb 5.
+            "adcs {z6}, {z6}, {w3}",            // Add low(a[3]^2) to product limb 6.
+            "adc {z7}, {z7}, {a3}",             // Add high(a[3]^2) to product limb 7.
+
+            // Montgomery cancellation 0 on the low half, as in the shared helper.
+            // low(q * p[0]) cancels z0 and is discarded by the limb shift.
+            "mul {w1}, {p1}, {q}",              // w1 = low(q * p[1]).
+            // q * p[2] is zero because p[2] = 0.
+            "lsl {w3}, {q}, #62",               // w3 = low(q * p[3]).
+            // Carry from z0 + low(q*p[0]) is one exactly when z0 is nonzero.
+            "subs xzr, {z0}, #1",               // Set that cancellation carry.
+            "umulh {w0}, {p0}, {q}",            // w0 = high(q * p[0]).
+            "adcs {z1}, {z1}, {w1}",            // Add low(q * p[1]) and cancellation carry.
+            "umulh {w1}, {p1}, {q}",            // w1 = high(q * p[1]).
+            "adcs {z2}, {z2}, xzr",             // Propagate carry across zero p[2].
+            // high(q * p[2]) is zero.
+            "adcs {z3}, {z3}, {w3}",            // Add low(q * p[3]) and carry.
+            "lsr {w3}, {q}, #2",                // w3 = high(q * p[3]).
+            "adc {cy}, xzr, xzr",               // Save the carry above limb 3.
+
+            // Shift out cancelled limb 0 and start cancellation 1.
+            "adds {z0}, {z1}, {w0}",            // New limb 0 includes high(q * p[0]).
+            "adcs {z1}, {z2}, {w1}",            // New limb 1 includes high(q * p[1]).
+            "adcs {z2}, {z3}, xzr",             // New limb 2; p[2] contributes zero.
+            "mul {q}, {inv}, {z0}",             // Next q = new limb 0 * inv mod 2^64.
+            "adc {z3}, {cy}, {w3}",             // New limb 3 includes high(q * p[3]).
+            // low(q * p[0]) cancels z0 and is discarded.
+            "mul {w1}, {p1}, {q}",              // w1 = low(next q * p[1]).
+            // next q * p[2] is zero.
+            "lsl {w3}, {q}, #62",               // w3 = low(next q * p[3]).
+            "subs xzr, {z0}, #1",               // Set the low-limb cancellation carry.
+            "umulh {w0}, {p0}, {q}",            // w0 = high(next q * p[0]).
+            "adcs {z1}, {z1}, {w1}",            // Add low(next q * p[1]) and carry.
+            "umulh {w1}, {p1}, {q}",            // w1 = high(next q * p[1]).
+            "adcs {z2}, {z2}, xzr",             // Propagate carry across zero p[2].
+            // high(next q * p[2]) is zero.
+            "adcs {z3}, {z3}, {w3}",            // Add low(next q * p[3]) and carry.
+            "lsr {w3}, {q}, #2",                // w3 = high(next q * p[3]).
+            "adc {cy}, xzr, xzr",               // Save the carry above limb 3.
+
+            // Shift out cancelled limb 1 and start cancellation 2.
+            "adds {z0}, {z1}, {w0}",            // New limb 0 includes high(q * p[0]).
+            "adcs {z1}, {z2}, {w1}",            // New limb 1 includes high(q * p[1]).
+            "adcs {z2}, {z3}, xzr",             // New limb 2; p[2] contributes zero.
+            "mul {q}, {inv}, {z0}",             // Next q = new limb 0 * inv mod 2^64.
+            "adc {z3}, {cy}, {w3}",             // New limb 3 includes high(q * p[3]).
+            // low(q * p[0]) cancels z0 and is discarded.
+            "mul {w1}, {p1}, {q}",              // w1 = low(next q * p[1]).
+            // next q * p[2] is zero.
+            "lsl {w3}, {q}, #62",               // w3 = low(next q * p[3]).
+            "subs xzr, {z0}, #1",               // Set the low-limb cancellation carry.
+            "umulh {w0}, {p0}, {q}",            // w0 = high(next q * p[0]).
+            "adcs {z1}, {z1}, {w1}",            // Add low(next q * p[1]) and carry.
+            "umulh {w1}, {p1}, {q}",            // w1 = high(next q * p[1]).
+            "adcs {z2}, {z2}, xzr",             // Propagate carry across zero p[2].
+            // high(next q * p[2]) is zero.
+            "adcs {z3}, {z3}, {w3}",            // Add low(next q * p[3]) and carry.
+            "lsr {w3}, {q}, #2",                // w3 = high(next q * p[3]).
+            "adc {cy}, xzr, xzr",               // Save the carry above limb 3.
+
+            // Shift out cancelled limb 2 and start cancellation 3.
+            "adds {z0}, {z1}, {w0}",            // New limb 0 includes high(q * p[0]).
+            "adcs {z1}, {z2}, {w1}",            // New limb 1 includes high(q * p[1]).
+            "adcs {z2}, {z3}, xzr",             // New limb 2; p[2] contributes zero.
+            "mul {q}, {inv}, {z0}",             // Final q = new limb 0 * inv mod 2^64.
+            "adc {z3}, {cy}, {w3}",             // New limb 3 includes high(q * p[3]).
+            // low(q * p[0]) cancels z0 and is discarded.
+            "mul {w1}, {p1}, {q}",              // w1 = low(final q * p[1]).
+            // final q * p[2] is zero.
+            "lsl {w3}, {q}, #62",               // w3 = low(final q * p[3]).
+            "subs xzr, {z0}, #1",               // Set the low-limb cancellation carry.
+            "umulh {w0}, {p0}, {q}",            // w0 = high(final q * p[0]).
+            "adcs {z1}, {z1}, {w1}",            // Add low(final q * p[1]) and carry.
+            "umulh {w1}, {p1}, {q}",            // w1 = high(final q * p[1]).
+            "adcs {z2}, {z2}, xzr",             // Propagate carry across zero p[2].
+            // high(final q * p[2]) is zero.
+            "adcs {z3}, {z3}, {w3}",            // Add low(final q * p[3]) and carry.
+            "lsr {w3}, {q}, #2",                // w3 = high(final q * p[3]).
+            "adc {cy}, xzr, xzr",               // Save the carry above limb 3.
+
+            // Shift out cancelled limb 3 to finish dividing the low half by R.
+            "adds {z0}, {z1}, {w0}",            // Reduced limb 0 includes high(q * p[0]).
+            "adcs {z1}, {z2}, {w1}",            // Reduced limb 1 includes high(q * p[1]).
+            "adcs {z2}, {z3}, xzr",             // Reduced limb 2; p[2] contributes zero.
+            "adc {z3}, {cy}, {w3}",             // Reduced limb 3 includes high(q * p[3]).
+            // Add the upper product half; the sum stays below 2p (see above), so no
+            // carry escapes and no conditional subtraction is needed mid-loop.
+            "adds {a0}, {z0}, {z4}",            // Next-iteration a[0].
+            "adcs {a1}, {z1}, {z5}",            // Next-iteration a[1].
+            "adcs {a2}, {z2}, {z6}",            // Next-iteration a[2].
+            "adc {a3}, {z3}, {z7}",             // Next-iteration a[3].
+
+            // Conditional subtraction of p = [p0, p1, 0, 2^62]. The input is
+            // canonical, so the candidate is below 1.25p < 2^255: no bit 256
+            // exists and a four-limb comparison suffices.
+            "mov {q}, #0x4000000000000000",     // Materialize p3 = 2^62.
+            "subs {z0}, {a0}, {p0}",            // Tentative limb 0 = candidate - p0.
+            "sbcs {z1}, {a1}, {p1}",            // Tentative limb 1 minus p1.
+            "sbcs {z2}, {a2}, xzr",             // Tentative limb 2; p2 is zero.
+            "sbcs {z3}, {a3}, {q}",             // Tentative limb 3 minus p3.
+            // `lo` means the subtraction borrowed, so retain the original
+            // candidate.
+            "csel {a0}, {a0}, {z0}, lo",        // Select canonical output limb 0.
+            "csel {a1}, {a1}, {z1}, lo",        // Select canonical output limb 1.
+            "csel {a2}, {a2}, {z2}, lo",        // Select canonical output limb 2.
+            "csel {a3}, {a3}, {z3}, lo",        // Select canonical output limb 3.
+            a0 = inout(reg) a0,
+            a1 = inout(reg) a1,
+            a2 = inout(reg) a2,
+            a3 = inout(reg) a3,
+            p0 = in(reg) modulus[0],
+            p1 = in(reg) modulus[1],
+            inv = in(reg) inv,
+            q = out(reg) _,
+            cy = out(reg) _,
+            z0 = out(reg) _,
+            z1 = out(reg) _,
+            z2 = out(reg) _,
+            z3 = out(reg) _,
+            z4 = out(reg) _,
+            z5 = out(reg) _,
+            z6 = out(reg) _,
+            z7 = out(reg) _,
+            w0 = out(reg) _,
+            w1 = out(reg) _,
+            w2 = out(reg) _,
+            w3 = out(reg) _,
+            options(pure, nomem, nostack),
+        );
     }
-    out
+    [a0, a1, a2, a3]
 }
 
 /// Squares a canonical Montgomery residue `count` times, then multiplies the
@@ -87,6 +493,18 @@ pub(super) fn sqr_n_mul(
     // duration of the call. The backend writes exactly four limbs to `out`.
     unsafe {
         pasta_curves_sqr_n_mul_mont_pasta(&mut out, value, count, rhs, modulus, inv);
+    }
+    out
+}
+
+/// Converts a canonical Montgomery residue into its canonical integer.
+#[inline]
+pub(super) fn from_mont(value: &Limbs, modulus: &Limbs, inv: u64) -> Limbs {
+    let mut out = Limbs::default();
+    // SAFETY: All pointers refer to four initialized `u64` limbs for the
+    // duration of the call. The backend writes exactly four limbs to `out`.
+    unsafe {
+        pasta_curves_from_mont_pasta(&mut out, value, modulus, inv);
     }
     out
 }

--- a/src/fields/aarch64_asm.rs
+++ b/src/fields/aarch64_asm.rs
@@ -16,6 +16,14 @@ extern "C" {
         modulus: *const Limbs,
         inv: u64,
     );
+    fn pasta_curves_sqr_n_mul_mont_pasta(
+        out: *mut Limbs,
+        value: *const Limbs,
+        count: usize,
+        rhs: *const Limbs,
+        modulus: *const Limbs,
+        inv: u64,
+    );
     fn pasta_curves_from_mont_pasta(
         out: *mut Limbs,
         value: *const Limbs,
@@ -56,6 +64,29 @@ pub(super) fn square(value: &Limbs, modulus: &Limbs, inv: u64) -> Limbs {
     // duration of the call. The backend writes exactly four limbs to `out`.
     unsafe {
         pasta_curves_sqr_mont_pasta(&mut out, value, modulus, inv);
+    }
+    out
+}
+
+/// Squares a canonical Montgomery residue `count` times, then multiplies the
+/// result by the canonical Montgomery residue `rhs`, keeping the accumulator
+/// in registers throughout.
+#[inline]
+pub(super) fn sqr_n_mul(
+    value: &Limbs,
+    count: usize,
+    rhs: &Limbs,
+    modulus: &Limbs,
+    inv: u64,
+) -> Limbs {
+    // The assembly decrements the count before testing it, so a zero count
+    // would wrap around and effectively never terminate.
+    assert!(count >= 1);
+    let mut out = Limbs::default();
+    // SAFETY: All pointers refer to four initialized `u64` limbs for the
+    // duration of the call. The backend writes exactly four limbs to `out`.
+    unsafe {
+        pasta_curves_sqr_n_mul_mont_pasta(&mut out, value, count, rhs, modulus, inv);
     }
     out
 }

--- a/src/fields/fp.rs
+++ b/src/fields/fp.rs
@@ -297,8 +297,14 @@ impl Fp {
         // constant `R2` or `R3`.
         let d0 = Fp([limbs[0], limbs[1], limbs[2], limbs[3]]);
         let d1 = Fp([limbs[4], limbs[5], limbs[6], limbs[7]]);
-        // Convert to Montgomery form
-        d0 * R2 + d1 * R3
+        // Convert to Montgomery form. `d0` and `d1` are unreduced, so use the
+        // portable multiplication: its classical 8-limb reduction is valid for
+        // any 256-bit value times a canonical constant, with no precondition
+        // on the constant's limbs. The inline-assembly `mul` tolerates an
+        // unreduced lhs only while every rhs limb stays at most `2^64 - 4`
+        // (see `aarch64_asm.rs`); this cold path is not worth carrying that
+        // coupling, and hashing dominates its callers anyway.
+        Fp::mul(&d0, &R2).add(&Fp::mul(&d1, &R3))
     }
 
     /// Converts from an integer represented in little endian
@@ -1071,7 +1077,7 @@ fn test_pow_by_t_minus1_over2() {
 
 #[test]
 fn test_pow_vartime() {
-    use rand::SeedableRng;
+    use rand::{Rng, SeedableRng};
 
     // The classic square-and-multiply loop, as a reference for the fused
     // implementation.
@@ -1264,4 +1270,79 @@ fn test_from_u512() {
             0x26ebe27e262f471d
         ])
     );
+}
+
+#[cfg(all(
+    test,
+    feature = "aarch64-asm",
+    target_arch = "aarch64",
+    target_vendor = "apple"
+))]
+#[test]
+fn aarch64_asm_mul_unreduced_lhs_matches_portable() {
+    use rand::{Rng, SeedableRng};
+
+    // `from_u512` feeds raw (unreduced) 256-bit digits as the lhs of the
+    // inline `mul`, with `R2`/`R3` as the rhs. The five-limb accumulator
+    // tolerates an unreduced lhs only while every rhs limb is at most
+    // `2^64 - 4` (see the contract in `aarch64_asm.rs`); assert the
+    // constants keep that invariant, then pin the behaviour against the
+    // portable implementation on the most adversarial inputs known.
+    for by in [R2, R3] {
+        for limb in by.0 {
+            assert!(limb <= u64::MAX - 3);
+        }
+    }
+
+    // lhs values with the low limbs solved so the first two Montgomery
+    // quotients hit (or approach) their maximum `2^64 - 1` while the top
+    // limbs are all-ones: jointly the nearest known approach to the
+    // carry-chain wrap described in `aarch64_asm.rs`.
+    let forced_q_r2 = Fp([0x3cc9961eeeeeeeef, 0x907f42c685cc8a31, u64::MAX, u64::MAX]);
+    let forced_q_r3 = Fp([0x032c286da5f9b149, 0x3f747fab2d936552, u64::MAX, u64::MAX]);
+
+    let check = |lhs: Fp, by: Fp| {
+        // Inherent `Fp::mul` is the portable implementation; its classical
+        // 8-limb reduction is valid for any lhs when `by` is canonical.
+        assert_eq!(lhs.mul_runtime(&by), Fp::mul(&lhs, &by), "lhs {:x?}", lhs.0);
+    };
+
+    check(Fp([u64::MAX; 4]), R2);
+    check(Fp([u64::MAX; 4]), R3);
+    check(forced_q_r2, R2);
+    check(forced_q_r3, R3);
+
+    let mut rng = rand_xorshift::XorShiftRng::from_seed([0x9d; 16]);
+    for i in 0..20_000u32 {
+        let mut l = [0u64; 4];
+        for w in l.iter_mut() {
+            *w = rng.next_u64();
+        }
+        if i % 2 == 0 {
+            l[3] = u64::MAX;
+            l[2] = u64::MAX;
+        }
+        check(Fp(l), R2);
+        check(Fp(l), R3);
+    }
+
+    // End-to-end `from_u512` against a portable recomposition.
+    let portable_from_u512 = |l: [u64; 8]| {
+        let d0 = Fp([l[0], l[1], l[2], l[3]]);
+        let d1 = Fp([l[4], l[5], l[6], l[7]]);
+        Fp::mul(&d0, &R2).add(&Fp::mul(&d1, &R3))
+    };
+    assert_eq!(
+        Fp::from_u512([u64::MAX; 8]),
+        portable_from_u512([u64::MAX; 8])
+    );
+    for _ in 0..10_000u32 {
+        let mut l = [0u64; 8];
+        for w in l.iter_mut() {
+            *w = rng.next_u64();
+        }
+        l[3] |= 0xc000000000000000;
+        l[7] |= 0xc000000000000000;
+        assert_eq!(Fp::from_u512(l), portable_from_u512(l), "limbs {:x?}", l);
+    }
 }

--- a/src/fields/fp.rs
+++ b/src/fields/fp.rs
@@ -705,6 +705,18 @@ impl ff::PrimeField for Fp {
     fn to_repr(&self) -> Self::Repr {
         // Turn into canonical form by computing
         // (a.R) / R = a
+        #[cfg(all(
+            feature = "aarch64-asm",
+            target_arch = "aarch64",
+            target_vendor = "apple"
+        ))]
+        let tmp = Fp(super::aarch64_asm::from_mont(&self.0, &MODULUS.0, INV));
+
+        #[cfg(not(all(
+            feature = "aarch64-asm",
+            target_arch = "aarch64",
+            target_vendor = "apple"
+        )))]
         let tmp = Fp::montgomery_reduce(self.0[0], self.0[1], self.0[2], self.0[3], 0, 0, 0, 0);
 
         let mut res = [0; 32];
@@ -870,24 +882,71 @@ impl ec_gpu::GpuField for Fp {
     target_arch = "aarch64",
     target_vendor = "apple"
 ))]
+fn aarch64_asm_portable_repr(value: Fp) -> [u8; 32] {
+    let value = Fp::montgomery_reduce(value.0[0], value.0[1], value.0[2], value.0[3], 0, 0, 0, 0);
+    let mut repr = [0; 32];
+    for (bytes, limb) in repr.chunks_exact_mut(8).zip(value.0) {
+        bytes.copy_from_slice(&limb.to_le_bytes());
+    }
+    repr
+}
+
+#[cfg(all(
+    test,
+    feature = "aarch64-asm",
+    target_arch = "aarch64",
+    target_vendor = "apple"
+))]
+fn aarch64_asm_check_repr(value: Fp) {
+    let portable = aarch64_asm_portable_repr(value);
+    assert_eq!(value.to_repr(), portable);
+    assert_eq!(Fp::from_repr(portable).unwrap(), value);
+    assert_eq!(value.is_odd().unwrap_u8(), portable[0] & 1);
+}
+
+#[cfg(all(
+    test,
+    feature = "aarch64-asm",
+    target_arch = "aarch64",
+    target_vendor = "apple"
+))]
+fn aarch64_asm_portable_cmp(lhs: Fp, rhs: Fp) -> core::cmp::Ordering {
+    aarch64_asm_portable_repr(lhs)
+        .iter()
+        .zip(aarch64_asm_portable_repr(rhs).iter())
+        .rev()
+        .find_map(|(lhs, rhs)| match lhs.cmp(rhs) {
+            core::cmp::Ordering::Equal => None,
+            ordering => Some(ordering),
+        })
+        .unwrap_or(core::cmp::Ordering::Equal)
+}
+
+#[cfg(all(
+    test,
+    feature = "aarch64-asm",
+    target_arch = "aarch64",
+    target_vendor = "apple"
+))]
 #[test]
 fn aarch64_asm_matches_portable_arithmetic() {
     use rand::SeedableRng;
 
-    let modulus_minus_one =
-        Fp::from_raw([MODULUS.0[0] - 1, MODULUS.0[1], MODULUS.0[2], MODULUS.0[3]]);
+    let max_montgomery_residue = Fp([MODULUS.0[0] - 1, MODULUS.0[1], MODULUS.0[2], MODULUS.0[3]]);
     let boundaries = [
         Fp::zero(),
         Fp::one(),
         -Fp::one(),
         Fp::from_raw([1, 0, 0, 0]),
-        modulus_minus_one,
+        max_montgomery_residue,
         Fp::from_raw([u64::MAX; 4]),
     ];
 
     for lhs in boundaries {
+        aarch64_asm_check_repr(lhs);
         assert_eq!(<Fp as Field>::square(&lhs), Fp::square(&lhs));
         for rhs in boundaries {
+            assert_eq!(lhs.cmp(&rhs), aarch64_asm_portable_cmp(lhs, rhs));
             assert_eq!(&lhs * &rhs, Fp::mul(&lhs, &rhs));
         }
     }
@@ -907,6 +966,8 @@ fn aarch64_asm_matches_portable_arithmetic() {
             rng.next_u64(),
         ]);
 
+        aarch64_asm_check_repr(lhs);
+        assert_eq!(lhs.cmp(&rhs), aarch64_asm_portable_cmp(lhs, rhs));
         assert_eq!(&lhs * &rhs, Fp::mul(&lhs, &rhs));
         assert_eq!(<Fp as Field>::square(&lhs), Fp::square(&lhs));
     }

--- a/src/fields/fp.rs
+++ b/src/fields/fp.rs
@@ -168,7 +168,7 @@ impl Mul<&Fp> for &Fp {
 
     #[inline]
     fn mul(self, rhs: &Fp) -> Fp {
-        self.mul(rhs)
+        self.mul_runtime(rhs)
     }
 }
 
@@ -369,6 +369,48 @@ impl Fp {
         Fp::montgomery_reduce(u[0], u[1], u[2], u[3], u[4], u[5], u[6], u[7])
     }
 
+    #[inline]
+    fn mul_runtime(&self, rhs: &Self) -> Self {
+        #[cfg(all(
+            feature = "aarch64-asm",
+            target_arch = "aarch64",
+            target_vendor = "apple"
+        ))]
+        {
+            Fp(super::aarch64_asm::mul(&self.0, &rhs.0, &MODULUS.0, INV))
+        }
+
+        #[cfg(not(all(
+            feature = "aarch64-asm",
+            target_arch = "aarch64",
+            target_vendor = "apple"
+        )))]
+        {
+            self.mul(rhs)
+        }
+    }
+
+    #[inline]
+    fn square_runtime(&self) -> Self {
+        #[cfg(all(
+            feature = "aarch64-asm",
+            target_arch = "aarch64",
+            target_vendor = "apple"
+        ))]
+        {
+            Fp(super::aarch64_asm::square(&self.0, &MODULUS.0, INV))
+        }
+
+        #[cfg(not(all(
+            feature = "aarch64-asm",
+            target_arch = "aarch64",
+            target_vendor = "apple"
+        )))]
+        {
+            self.square()
+        }
+    }
+
     /// Subtracts `rhs` from `self`, returning the result.
     #[cfg_attr(not(feature = "uninline-portable"), inline)]
     pub const fn sub(&self, rhs: &Self) -> Self {
@@ -544,7 +586,7 @@ impl ff::Field for Fp {
 
     #[inline(always)]
     fn square(&self) -> Self {
-        self.square()
+        self.square_runtime()
     }
 
     fn sqrt_ratio(num: &Self, div: &Self) -> (Choice, Self) {
@@ -819,6 +861,54 @@ impl ec_gpu::GpuField for Fp {
 
     fn modulus() -> alloc::vec::Vec<u32> {
         crate::fields::u64_to_u32(&MODULUS.0[..])
+    }
+}
+
+#[cfg(all(
+    test,
+    feature = "aarch64-asm",
+    target_arch = "aarch64",
+    target_vendor = "apple"
+))]
+#[test]
+fn aarch64_asm_matches_portable_arithmetic() {
+    use rand::SeedableRng;
+
+    let modulus_minus_one =
+        Fp::from_raw([MODULUS.0[0] - 1, MODULUS.0[1], MODULUS.0[2], MODULUS.0[3]]);
+    let boundaries = [
+        Fp::zero(),
+        Fp::one(),
+        -Fp::one(),
+        Fp::from_raw([1, 0, 0, 0]),
+        modulus_minus_one,
+        Fp::from_raw([u64::MAX; 4]),
+    ];
+
+    for lhs in boundaries {
+        assert_eq!(<Fp as Field>::square(&lhs), Fp::square(&lhs));
+        for rhs in boundaries {
+            assert_eq!(&lhs * &rhs, Fp::mul(&lhs, &rhs));
+        }
+    }
+
+    let mut rng = rand_xorshift::XorShiftRng::from_seed([0x5a; 16]);
+    for _ in 0..1024 {
+        let lhs = Fp::from_raw([
+            rng.next_u64(),
+            rng.next_u64(),
+            rng.next_u64(),
+            rng.next_u64(),
+        ]);
+        let rhs = Fp::from_raw([
+            rng.next_u64(),
+            rng.next_u64(),
+            rng.next_u64(),
+            rng.next_u64(),
+        ]);
+
+        assert_eq!(&lhs * &rhs, Fp::mul(&lhs, &rhs));
+        assert_eq!(<Fp as Field>::square(&lhs), Fp::square(&lhs));
     }
 }
 

--- a/src/fields/fp.rs
+++ b/src/fields/fp.rs
@@ -411,6 +411,34 @@ impl Fp {
         }
     }
 
+    /// Squares `self` `n` times (`n` must be at least 1), then multiplies the
+    /// result by `by`. The assembly backend keeps the accumulator in
+    /// registers for the whole chain.
+    #[inline]
+    fn sqr_n_mul_runtime(&self, n: u32, by: &Self) -> Self {
+        assert!(n >= 1);
+
+        #[cfg(all(
+            feature = "aarch64-asm",
+            target_arch = "aarch64",
+            target_vendor = "apple"
+        ))]
+        {
+            Fp(super::aarch64_asm::sqr_n_mul(
+                &self.0, n as usize, &by.0, &MODULUS.0, INV,
+            ))
+        }
+
+        #[cfg(not(all(
+            feature = "aarch64-asm",
+            target_arch = "aarch64",
+            target_vendor = "apple"
+        )))]
+        {
+            (0..n).fold(*self, |acc, _| acc.square()).mul(by)
+        }
+    }
+
     /// Subtracts `rhs` from `self`, returning the result.
     #[cfg_attr(not(feature = "uninline-portable"), inline)]
     pub const fn sub(&self, rhs: &Self) -> Self {
@@ -630,19 +658,39 @@ impl ff::Field for Fp {
     }
 
     fn pow_vartime<S: AsRef<[u64]>>(&self, exp: S) -> Self {
-        let mut res = Self::one();
-        let mut found_one = false;
+        // Walk the exponent bits MSB-first, fusing each run of squarings with
+        // the multiplication that follows it. This performs exactly the same
+        // field operations as the classic square-and-multiply loop, but lets
+        // the assembly backend keep the accumulator in registers for the
+        // whole run.
+        let mut res: Option<Self> = None;
+        let mut squares = 0;
         for e in exp.as_ref().iter().rev() {
             for i in (0..64).rev() {
-                if found_one {
-                    res = res.square();
+                if res.is_some() {
+                    squares += 1;
                 }
 
                 if ((*e >> i) & 1) == 1 {
-                    found_one = true;
-                    res *= self;
+                    res = Some(match res {
+                        Some(res) => {
+                            let res = res.sqr_n_mul_runtime(squares, self);
+                            squares = 0;
+                            res
+                        }
+                        None => *self,
+                    });
                 }
             }
+        }
+
+        let mut res = match res {
+            Some(res) => res,
+            None => return Self::one(),
+        };
+        // Flush the squarings for any trailing zero bits.
+        for _ in 0..squares {
+            res = res.square_runtime();
         }
         res
     }
@@ -790,34 +838,32 @@ lazy_static! {
 
 impl SqrtTableHelpers for Fp {
     fn pow_by_t_minus1_over2(&self) -> Self {
-        let sqr = |x: Fp, i: u32| (0..i).fold(x, |x, _| x.square());
-
-        let r10 = self.square();
+        let r10 = self.square_runtime();
         let r11 = r10 * self;
-        let r110 = r11.square();
+        let r110 = r11.square_runtime();
         let r111 = r110 * self;
         let r1001 = r111 * r10;
         let r1101 = r111 * r110;
-        let ra = sqr(*self, 129) * self;
-        let rb = sqr(ra, 7) * r1001;
-        let rc = sqr(rb, 7) * r1101;
-        let rd = sqr(rc, 4) * r11;
-        let re = sqr(rd, 6) * r111;
-        let rf = sqr(re, 3) * r111;
-        let rg = sqr(rf, 10) * r1001;
-        let rh = sqr(rg, 5) * r1001;
-        let ri = sqr(rh, 4) * r1001;
-        let rj = sqr(ri, 3) * r111;
-        let rk = sqr(rj, 4) * r1001;
-        let rl = sqr(rk, 5) * r11;
-        let rm = sqr(rl, 4) * r111;
-        let rn = sqr(rm, 4) * r11;
-        let ro = sqr(rn, 6) * r1001;
-        let rp = sqr(ro, 5) * r1101;
-        let rq = sqr(rp, 4) * r11;
-        let rr = sqr(rq, 7) * r111;
-        let rs = sqr(rr, 3) * r11;
-        rs.square() // rt
+        let ra = self.sqr_n_mul_runtime(129, self);
+        let rb = ra.sqr_n_mul_runtime(7, &r1001);
+        let rc = rb.sqr_n_mul_runtime(7, &r1101);
+        let rd = rc.sqr_n_mul_runtime(4, &r11);
+        let re = rd.sqr_n_mul_runtime(6, &r111);
+        let rf = re.sqr_n_mul_runtime(3, &r111);
+        let rg = rf.sqr_n_mul_runtime(10, &r1001);
+        let rh = rg.sqr_n_mul_runtime(5, &r1001);
+        let ri = rh.sqr_n_mul_runtime(4, &r1001);
+        let rj = ri.sqr_n_mul_runtime(3, &r111);
+        let rk = rj.sqr_n_mul_runtime(4, &r1001);
+        let rl = rk.sqr_n_mul_runtime(5, &r11);
+        let rm = rl.sqr_n_mul_runtime(4, &r111);
+        let rn = rm.sqr_n_mul_runtime(4, &r11);
+        let ro = rn.sqr_n_mul_runtime(6, &r1001);
+        let rp = ro.sqr_n_mul_runtime(5, &r1101);
+        let rq = rp.sqr_n_mul_runtime(4, &r11);
+        let rr = rq.sqr_n_mul_runtime(7, &r111);
+        let rs = rr.sqr_n_mul_runtime(3, &r11);
+        rs.square_runtime() // rt
     }
 
     fn get_lower_32(&self) -> u32 {
@@ -942,12 +988,22 @@ fn aarch64_asm_matches_portable_arithmetic() {
         Fp::from_raw([u64::MAX; 4]),
     ];
 
+    fn portable_sqr_n_mul(value: Fp, n: u32, by: Fp) -> Fp {
+        (0..n).fold(value, |acc, _| Fp::square(&acc)).mul(&by)
+    }
+
     for lhs in boundaries {
         aarch64_asm_check_repr(lhs);
         assert_eq!(<Fp as Field>::square(&lhs), Fp::square(&lhs));
         for rhs in boundaries {
             assert_eq!(lhs.cmp(&rhs), aarch64_asm_portable_cmp(lhs, rhs));
             assert_eq!(&lhs * &rhs, Fp::mul(&lhs, &rhs));
+            for n in [1, 2, 7] {
+                assert_eq!(
+                    lhs.sqr_n_mul_runtime(n, &rhs),
+                    portable_sqr_n_mul(lhs, n, rhs)
+                );
+            }
         }
     }
 
@@ -970,6 +1026,12 @@ fn aarch64_asm_matches_portable_arithmetic() {
         assert_eq!(lhs.cmp(&rhs), aarch64_asm_portable_cmp(lhs, rhs));
         assert_eq!(&lhs * &rhs, Fp::mul(&lhs, &rhs));
         assert_eq!(<Fp as Field>::square(&lhs), Fp::square(&lhs));
+        for n in [1, 129] {
+            assert_eq!(
+                lhs.sqr_n_mul_runtime(n, &rhs),
+                portable_sqr_n_mul(lhs, n, rhs)
+            );
+        }
     }
 }
 
@@ -1005,6 +1067,76 @@ fn test_pow_by_t_minus1_over2() {
     // NB: TWO_INV is standing in as a "random" field element
     let v = (Fp::TWO_INV).pow_by_t_minus1_over2();
     assert!(v == ff::Field::pow_vartime(&Fp::TWO_INV, T_MINUS1_OVER2));
+}
+
+#[test]
+fn test_pow_vartime() {
+    use rand::SeedableRng;
+
+    // The classic square-and-multiply loop, as a reference for the fused
+    // implementation.
+    fn pow_vartime_reference(base: &Fp, exp: &[u64]) -> Fp {
+        let mut res = Fp::one();
+        let mut found_one = false;
+        for e in exp.iter().rev() {
+            for i in (0..64).rev() {
+                if found_one {
+                    res = Fp::square(&res);
+                }
+
+                if ((*e >> i) & 1) == 1 {
+                    found_one = true;
+                    res = Fp::mul(&res, base);
+                }
+            }
+        }
+        res
+    }
+
+    let mut rng = rand_xorshift::XorShiftRng::from_seed([0xa5; 16]);
+
+    let mut exponents = vec![
+        [0, 0, 0, 0],
+        [1, 0, 0, 0],
+        [2, 0, 0, 0],
+        // A single high bit exercises the trailing-squarings flush.
+        [0, 0, 0, 1 << 63],
+        [1 << 63, 0, 0, 0],
+        [u64::MAX; 4],
+        // The p - 2 exponent used by `invert`.
+        [
+            0x992d30ecffffffff,
+            0x224698fc094cf91b,
+            0x0,
+            0x4000000000000000,
+        ],
+    ];
+    for _ in 0..10 {
+        exponents.push([
+            rng.next_u64(),
+            rng.next_u64(),
+            rng.next_u64(),
+            rng.next_u64(),
+        ]);
+    }
+
+    for base in [
+        Fp::zero(),
+        Fp::one(),
+        -Fp::one(),
+        Fp::random(&mut rng),
+        Fp::random(&mut rng),
+    ] {
+        for exp in &exponents {
+            assert_eq!(base.pow_vartime(exp), pow_vartime_reference(&base, exp));
+        }
+        // Short and empty exponent slices behave like zero-padded ones.
+        assert_eq!(base.pow_vartime([7]), pow_vartime_reference(&base, &[7]));
+        assert_eq!(
+            base.pow_vartime([0u64; 0]),
+            pow_vartime_reference(&base, &[])
+        );
+    }
 }
 
 #[test]

--- a/src/fields/fp.rs
+++ b/src/fields/fp.rs
@@ -1077,7 +1077,7 @@ fn test_pow_by_t_minus1_over2() {
 
 #[test]
 fn test_pow_vartime() {
-    use rand::{Rng, SeedableRng};
+    use rand::SeedableRng;
 
     // The classic square-and-multiply loop, as a reference for the fused
     // implementation.
@@ -1280,7 +1280,7 @@ fn test_from_u512() {
 ))]
 #[test]
 fn aarch64_asm_mul_unreduced_lhs_matches_portable() {
-    use rand::{Rng, SeedableRng};
+    use rand::SeedableRng;
 
     // `from_u512` feeds raw (unreduced) 256-bit digits as the lhs of the
     // inline `mul`, with `R2`/`R3` as the rhs. The five-limb accumulator
@@ -1353,7 +1353,7 @@ fn aarch64_asm_mul_unreduced_lhs_matches_portable() {
         }
         l[3] |= 0xc000000000000000;
         l[7] |= 0xc000000000000000;
-        assert_eq!(Fp::from_u512(l), portable_from_u512(l), "limbs {:x?}", l);
+        assert_eq!(Fp::from_u512(l), portable_from_u512(l), "limbs {l:x?}");
     }
 }
 
@@ -1413,7 +1413,7 @@ fn constants_are_canonical() {
 ))]
 #[test]
 fn aarch64_asm_mul_canonical_sweep_matches_portable() {
-    use rand::{Rng, SeedableRng};
+    use rand::SeedableRng;
 
     // Random canonical operands: the inline `mul` must agree with the
     // portable implementation and return a canonical residue.
@@ -1442,7 +1442,7 @@ fn aarch64_asm_mul_canonical_sweep_matches_portable() {
 ))]
 #[test]
 fn aarch64_asm_mul_unreduced_lhs_near_modulus_rhs_matches_portable() {
-    use rand::{Rng, SeedableRng};
+    use rand::SeedableRng;
 
     // The inline `mul` omits the fifth candidate limb on the strength of
     // `(lhs * rhs + m * modulus) / R < 2 * modulus < R`, which holds for any

--- a/src/fields/fp.rs
+++ b/src/fields/fp.rs
@@ -1286,9 +1286,15 @@ fn aarch64_asm_mul_unreduced_lhs_matches_portable() {
     // inline `mul`, with `R2`/`R3` as the rhs. The five-limb accumulator
     // tolerates an unreduced lhs only while every rhs limb is at most
     // `2^64 - 4` (see the contract in `aarch64_asm.rs`); assert the
-    // constants keep that invariant, then pin the behaviour against the
-    // portable implementation on the most adversarial inputs known.
-    for by in [R2, R3] {
+    // selected rhs values keep that invariant, then pin the behaviour against
+    // the portable implementation on the most adversarial inputs known.
+    let mut max_canonical = MODULUS;
+    max_canonical.0[0] -= 1;
+    let dense_limb = u64::MAX - 3;
+    let mut dense_canonical = Fp([dense_limb; 4]);
+    dense_canonical.0[3] = MODULUS.0[3] - 1;
+    let canonical_rhs = [R2, R3, max_canonical, dense_canonical];
+    for by in canonical_rhs {
         for limb in by.0 {
             assert!(limb <= u64::MAX - 3);
         }
@@ -1311,6 +1317,10 @@ fn aarch64_asm_mul_unreduced_lhs_matches_portable() {
     check(Fp([u64::MAX; 4]), R3);
     check(forced_q_r2, R2);
     check(forced_q_r3, R3);
+    // These maximize the full 256-bit lhs while taking the canonical rhs
+    // close to p. They exercise the final candidate's `T < 2p < R` bound.
+    check(Fp([u64::MAX; 4]), max_canonical);
+    check(Fp([u64::MAX; 4]), dense_canonical);
 
     let mut rng = rand_xorshift::XorShiftRng::from_seed([0x9d; 16]);
     for i in 0..20_000u32 {
@@ -1345,4 +1355,141 @@ fn aarch64_asm_mul_unreduced_lhs_matches_portable() {
         l[7] |= 0xc000000000000000;
         assert_eq!(Fp::from_u512(l), portable_from_u512(l), "limbs {:x?}", l);
     }
+}
+
+/// Whether `x` holds a reduced residue (limbs below the modulus).
+#[cfg(test)]
+fn is_canonical(x: &Fp) -> bool {
+    for i in (0..4).rev() {
+        if x.0[i] != MODULUS.0[i] {
+            return x.0[i] < MODULUS.0[i];
+        }
+    }
+    false
+}
+
+#[test]
+fn constants_are_canonical() {
+    // Every named constant must be a reduced residue: the `aarch64-asm`
+    // multiplication requires a canonical rhs, and constants are the one
+    // class of values that bypass the reducing constructors.
+    assert!(
+        !is_canonical(&MODULUS),
+        "the modulus itself is not canonical"
+    );
+    let constants: [(&str, Fp); 11] = [
+        ("R", R),
+        ("R2", R2),
+        ("R3", R3),
+        ("GENERATOR", GENERATOR),
+        ("ROOT_OF_UNITY", ROOT_OF_UNITY),
+        ("DELTA", DELTA),
+        ("TWO_INV", <Fp as ff::PrimeField>::TWO_INV),
+        (
+            "MULTIPLICATIVE_GENERATOR",
+            <Fp as ff::PrimeField>::MULTIPLICATIVE_GENERATOR,
+        ),
+        (
+            "ROOT_OF_UNITY_INV",
+            <Fp as ff::PrimeField>::ROOT_OF_UNITY_INV,
+        ),
+        ("ZETA", <Fp as ff::WithSmallOrderMulGroup<3>>::ZETA),
+        ("zero", Fp::zero()),
+    ];
+    for (name, value) in constants {
+        assert!(
+            is_canonical(&value),
+            "{name} is not canonical: {:x?}",
+            value.0
+        );
+    }
+}
+
+#[cfg(all(
+    test,
+    feature = "aarch64-asm",
+    target_arch = "aarch64",
+    target_vendor = "apple"
+))]
+#[test]
+fn aarch64_asm_mul_canonical_sweep_matches_portable() {
+    use rand::{Rng, SeedableRng};
+
+    // Random canonical operands: the inline `mul` must agree with the
+    // portable implementation and return a canonical residue.
+    let mut rng = rand_xorshift::XorShiftRng::from_seed([0x42; 16]);
+    let mut random = || {
+        let mut l = [0u64; 4];
+        for w in l.iter_mut() {
+            *w = rng.next_u64();
+        }
+        Fp::from_raw(l)
+    };
+    for _ in 0..200_000u32 {
+        let a = random();
+        let b = random();
+        let asm = a.mul_runtime(&b);
+        assert_eq!(asm, Fp::mul(&a, &b), "lhs {:x?} rhs {:x?}", a.0, b.0);
+        assert!(is_canonical(&asm));
+    }
+}
+
+#[cfg(all(
+    test,
+    feature = "aarch64-asm",
+    target_arch = "aarch64",
+    target_vendor = "apple"
+))]
+#[test]
+fn aarch64_asm_mul_unreduced_lhs_near_modulus_rhs_matches_portable() {
+    use rand::{Rng, SeedableRng};
+
+    // The inline `mul` omits the fifth candidate limb on the strength of
+    // `(lhs * rhs + m * modulus) / R < 2 * modulus < R`, which holds for any
+    // 256-bit lhs once the rhs is canonical. Stress that bound where it is
+    // tightest: lhs with its top bit set, rhs within a few limbs of the
+    // modulus (kept canonical, and within the per-limb no-wrap condition
+    // that an unreduced lhs separately requires).
+    let mut rng = rand_xorshift::XorShiftRng::from_seed([0x17; 16]);
+    let mut n = 0u32;
+    while n < 100_000 {
+        let lhs = Fp([
+            rng.next_u64(),
+            rng.next_u64(),
+            rng.next_u64(),
+            rng.next_u64() | (1 << 63),
+        ]);
+        let mut rhs = MODULUS;
+        rhs.0[0] = rhs.0[0].wrapping_sub(rng.next_u64() >> (rng.next_u32() % 64));
+        if rng.next_u32() & 1 == 1 {
+            rhs.0[1] = rhs.0[1].wrapping_sub(rng.next_u64() >> 60);
+        }
+        if !is_canonical(&rhs) || rhs.0.iter().any(|&l| l > u64::MAX - 3) {
+            continue;
+        }
+        n += 1;
+        let asm = lhs.mul_runtime(&rhs);
+        assert_eq!(
+            asm,
+            Fp::mul(&lhs, &rhs),
+            "lhs {:x?} rhs {:x?}",
+            lhs.0,
+            rhs.0
+        );
+        assert!(is_canonical(&asm));
+    }
+}
+
+#[cfg(all(
+    test,
+    debug_assertions,
+    feature = "aarch64-asm",
+    target_arch = "aarch64",
+    target_vendor = "apple"
+))]
+#[test]
+#[should_panic(expected = "requires a canonical rhs")]
+fn aarch64_asm_mul_rejects_non_canonical_rhs_in_debug() {
+    // The modulus itself is the smallest non-canonical value.
+    let _ = Fp::one().mul_runtime(&MODULUS);
 }

--- a/src/fields/fq.rs
+++ b/src/fields/fq.rs
@@ -705,6 +705,18 @@ impl ff::PrimeField for Fq {
     fn to_repr(&self) -> Self::Repr {
         // Turn into canonical form by computing
         // (a.R) / R = a
+        #[cfg(all(
+            feature = "aarch64-asm",
+            target_arch = "aarch64",
+            target_vendor = "apple"
+        ))]
+        let tmp = Fq(super::aarch64_asm::from_mont(&self.0, &MODULUS.0, INV));
+
+        #[cfg(not(all(
+            feature = "aarch64-asm",
+            target_arch = "aarch64",
+            target_vendor = "apple"
+        )))]
         let tmp = Fq::montgomery_reduce(self.0[0], self.0[1], self.0[2], self.0[3], 0, 0, 0, 0);
 
         let mut res = [0; 32];
@@ -869,24 +881,71 @@ impl ec_gpu::GpuField for Fq {
     target_arch = "aarch64",
     target_vendor = "apple"
 ))]
+fn aarch64_asm_portable_repr(value: Fq) -> [u8; 32] {
+    let value = Fq::montgomery_reduce(value.0[0], value.0[1], value.0[2], value.0[3], 0, 0, 0, 0);
+    let mut repr = [0; 32];
+    for (bytes, limb) in repr.chunks_exact_mut(8).zip(value.0) {
+        bytes.copy_from_slice(&limb.to_le_bytes());
+    }
+    repr
+}
+
+#[cfg(all(
+    test,
+    feature = "aarch64-asm",
+    target_arch = "aarch64",
+    target_vendor = "apple"
+))]
+fn aarch64_asm_check_repr(value: Fq) {
+    let portable = aarch64_asm_portable_repr(value);
+    assert_eq!(value.to_repr(), portable);
+    assert_eq!(Fq::from_repr(portable).unwrap(), value);
+    assert_eq!(value.is_odd().unwrap_u8(), portable[0] & 1);
+}
+
+#[cfg(all(
+    test,
+    feature = "aarch64-asm",
+    target_arch = "aarch64",
+    target_vendor = "apple"
+))]
+fn aarch64_asm_portable_cmp(lhs: Fq, rhs: Fq) -> core::cmp::Ordering {
+    aarch64_asm_portable_repr(lhs)
+        .iter()
+        .zip(aarch64_asm_portable_repr(rhs).iter())
+        .rev()
+        .find_map(|(lhs, rhs)| match lhs.cmp(rhs) {
+            core::cmp::Ordering::Equal => None,
+            ordering => Some(ordering),
+        })
+        .unwrap_or(core::cmp::Ordering::Equal)
+}
+
+#[cfg(all(
+    test,
+    feature = "aarch64-asm",
+    target_arch = "aarch64",
+    target_vendor = "apple"
+))]
 #[test]
 fn aarch64_asm_matches_portable_arithmetic() {
     use rand::SeedableRng;
 
-    let modulus_minus_one =
-        Fq::from_raw([MODULUS.0[0] - 1, MODULUS.0[1], MODULUS.0[2], MODULUS.0[3]]);
+    let max_montgomery_residue = Fq([MODULUS.0[0] - 1, MODULUS.0[1], MODULUS.0[2], MODULUS.0[3]]);
     let boundaries = [
         Fq::zero(),
         Fq::one(),
         -Fq::one(),
         Fq::from_raw([1, 0, 0, 0]),
-        modulus_minus_one,
+        max_montgomery_residue,
         Fq::from_raw([u64::MAX; 4]),
     ];
 
     for lhs in boundaries {
+        aarch64_asm_check_repr(lhs);
         assert_eq!(<Fq as Field>::square(&lhs), Fq::square(&lhs));
         for rhs in boundaries {
+            assert_eq!(lhs.cmp(&rhs), aarch64_asm_portable_cmp(lhs, rhs));
             assert_eq!(&lhs * &rhs, Fq::mul(&lhs, &rhs));
         }
     }
@@ -906,6 +965,8 @@ fn aarch64_asm_matches_portable_arithmetic() {
             rng.next_u64(),
         ]);
 
+        aarch64_asm_check_repr(lhs);
+        assert_eq!(lhs.cmp(&rhs), aarch64_asm_portable_cmp(lhs, rhs));
         assert_eq!(&lhs * &rhs, Fq::mul(&lhs, &rhs));
         assert_eq!(<Fq as Field>::square(&lhs), Fq::square(&lhs));
     }

--- a/src/fields/fq.rs
+++ b/src/fields/fq.rs
@@ -411,6 +411,34 @@ impl Fq {
         }
     }
 
+    /// Squares `self` `n` times (`n` must be at least 1), then multiplies the
+    /// result by `by`. The assembly backend keeps the accumulator in
+    /// registers for the whole chain.
+    #[inline]
+    fn sqr_n_mul_runtime(&self, n: u32, by: &Self) -> Self {
+        assert!(n >= 1);
+
+        #[cfg(all(
+            feature = "aarch64-asm",
+            target_arch = "aarch64",
+            target_vendor = "apple"
+        ))]
+        {
+            Fq(super::aarch64_asm::sqr_n_mul(
+                &self.0, n as usize, &by.0, &MODULUS.0, INV,
+            ))
+        }
+
+        #[cfg(not(all(
+            feature = "aarch64-asm",
+            target_arch = "aarch64",
+            target_vendor = "apple"
+        )))]
+        {
+            (0..n).fold(*self, |acc, _| acc.square()).mul(by)
+        }
+    }
+
     /// Subtracts `rhs` from `self`, returning the result.
     #[cfg_attr(not(feature = "uninline-portable"), inline)]
     pub const fn sub(&self, rhs: &Self) -> Self {
@@ -630,19 +658,39 @@ impl ff::Field for Fq {
     }
 
     fn pow_vartime<S: AsRef<[u64]>>(&self, exp: S) -> Self {
-        let mut res = Self::one();
-        let mut found_one = false;
+        // Walk the exponent bits MSB-first, fusing each run of squarings with
+        // the multiplication that follows it. This performs exactly the same
+        // field operations as the classic square-and-multiply loop, but lets
+        // the assembly backend keep the accumulator in registers for the
+        // whole run.
+        let mut res: Option<Self> = None;
+        let mut squares = 0;
         for e in exp.as_ref().iter().rev() {
             for i in (0..64).rev() {
-                if found_one {
-                    res = res.square();
+                if res.is_some() {
+                    squares += 1;
                 }
 
                 if ((*e >> i) & 1) == 1 {
-                    found_one = true;
-                    res *= self;
+                    res = Some(match res {
+                        Some(res) => {
+                            let res = res.sqr_n_mul_runtime(squares, self);
+                            squares = 0;
+                            res
+                        }
+                        None => *self,
+                    });
                 }
             }
+        }
+
+        let mut res = match res {
+            Some(res) => res,
+            None => return Self::one(),
+        };
+        // Flush the squarings for any trailing zero bits.
+        for _ in 0..squares {
+            res = res.square_runtime();
         }
         res
     }
@@ -789,34 +837,32 @@ lazy_static! {
 
 impl SqrtTableHelpers for Fq {
     fn pow_by_t_minus1_over2(&self) -> Self {
-        let sqr = |x: Fq, i: u32| (0..i).fold(x, |x, _| x.square());
-
-        let s10 = self.square();
+        let s10 = self.square_runtime();
         let s11 = s10 * self;
-        let s111 = s11.square() * self;
+        let s111 = s11.sqr_n_mul_runtime(1, self);
         let s1001 = s111 * s10;
         let s1011 = s1001 * s10;
         let s1101 = s1011 * s10;
-        let sa = sqr(*self, 129) * self;
-        let sb = sqr(sa, 7) * s1001;
-        let sc = sqr(sb, 7) * s1101;
-        let sd = sqr(sc, 4) * s11;
-        let se = sqr(sd, 6) * s111;
-        let sf = sqr(se, 3) * s111;
-        let sg = sqr(sf, 10) * s1001;
-        let sh = sqr(sg, 4) * s1001;
-        let si = sqr(sh, 5) * s1001;
-        let sj = sqr(si, 5) * s1001;
-        let sk = sqr(sj, 3) * s1001;
-        let sl = sqr(sk, 4) * s1011;
-        let sm = sqr(sl, 4) * s1011;
-        let sn = sqr(sm, 5) * s11;
-        let so = sqr(sn, 4) * self;
-        let sp = sqr(so, 5) * s11;
-        let sq = sqr(sp, 4) * s111;
-        let sr = sqr(sq, 5) * s1011;
-        let ss = sqr(sr, 3) * self;
-        sqr(ss, 4) // st
+        let sa = self.sqr_n_mul_runtime(129, self);
+        let sb = sa.sqr_n_mul_runtime(7, &s1001);
+        let sc = sb.sqr_n_mul_runtime(7, &s1101);
+        let sd = sc.sqr_n_mul_runtime(4, &s11);
+        let se = sd.sqr_n_mul_runtime(6, &s111);
+        let sf = se.sqr_n_mul_runtime(3, &s111);
+        let sg = sf.sqr_n_mul_runtime(10, &s1001);
+        let sh = sg.sqr_n_mul_runtime(4, &s1001);
+        let si = sh.sqr_n_mul_runtime(5, &s1001);
+        let sj = si.sqr_n_mul_runtime(5, &s1001);
+        let sk = sj.sqr_n_mul_runtime(3, &s1001);
+        let sl = sk.sqr_n_mul_runtime(4, &s1011);
+        let sm = sl.sqr_n_mul_runtime(4, &s1011);
+        let sn = sm.sqr_n_mul_runtime(5, &s11);
+        let so = sn.sqr_n_mul_runtime(4, self);
+        let sp = so.sqr_n_mul_runtime(5, &s11);
+        let sq = sp.sqr_n_mul_runtime(4, &s111);
+        let sr = sq.sqr_n_mul_runtime(5, &s1011);
+        let ss = sr.sqr_n_mul_runtime(3, self);
+        (0..4).fold(ss, |x, _| x.square_runtime()) // st
     }
 
     fn get_lower_32(&self) -> u32 {
@@ -941,12 +987,22 @@ fn aarch64_asm_matches_portable_arithmetic() {
         Fq::from_raw([u64::MAX; 4]),
     ];
 
+    fn portable_sqr_n_mul(value: Fq, n: u32, by: Fq) -> Fq {
+        (0..n).fold(value, |acc, _| Fq::square(&acc)).mul(&by)
+    }
+
     for lhs in boundaries {
         aarch64_asm_check_repr(lhs);
         assert_eq!(<Fq as Field>::square(&lhs), Fq::square(&lhs));
         for rhs in boundaries {
             assert_eq!(lhs.cmp(&rhs), aarch64_asm_portable_cmp(lhs, rhs));
             assert_eq!(&lhs * &rhs, Fq::mul(&lhs, &rhs));
+            for n in [1, 2, 7] {
+                assert_eq!(
+                    lhs.sqr_n_mul_runtime(n, &rhs),
+                    portable_sqr_n_mul(lhs, n, rhs)
+                );
+            }
         }
     }
 
@@ -969,6 +1025,12 @@ fn aarch64_asm_matches_portable_arithmetic() {
         assert_eq!(lhs.cmp(&rhs), aarch64_asm_portable_cmp(lhs, rhs));
         assert_eq!(&lhs * &rhs, Fq::mul(&lhs, &rhs));
         assert_eq!(<Fq as Field>::square(&lhs), Fq::square(&lhs));
+        for n in [1, 129] {
+            assert_eq!(
+                lhs.sqr_n_mul_runtime(n, &rhs),
+                portable_sqr_n_mul(lhs, n, rhs)
+            );
+        }
     }
 }
 
@@ -997,6 +1059,76 @@ fn test_sqrt() {
 #[test]
 fn test_sqrt_32bit_overflow() {
     assert!((Fq::from(5)).sqrt().is_none().unwrap_u8() == 1);
+}
+
+#[test]
+fn test_pow_vartime() {
+    use rand::SeedableRng;
+
+    // The classic square-and-multiply loop, as a reference for the fused
+    // implementation.
+    fn pow_vartime_reference(base: &Fq, exp: &[u64]) -> Fq {
+        let mut res = Fq::one();
+        let mut found_one = false;
+        for e in exp.iter().rev() {
+            for i in (0..64).rev() {
+                if found_one {
+                    res = Fq::square(&res);
+                }
+
+                if ((*e >> i) & 1) == 1 {
+                    found_one = true;
+                    res = Fq::mul(&res, base);
+                }
+            }
+        }
+        res
+    }
+
+    let mut rng = rand_xorshift::XorShiftRng::from_seed([0xa5; 16]);
+
+    let mut exponents = vec![
+        [0, 0, 0, 0],
+        [1, 0, 0, 0],
+        [2, 0, 0, 0],
+        // A single high bit exercises the trailing-squarings flush.
+        [0, 0, 0, 1 << 63],
+        [1 << 63, 0, 0, 0],
+        [u64::MAX; 4],
+        // The q - 2 exponent used by `invert`.
+        [
+            0x8c46eb20ffffffff,
+            0x224698fc0994a8dd,
+            0x0,
+            0x4000000000000000,
+        ],
+    ];
+    for _ in 0..10 {
+        exponents.push([
+            rng.next_u64(),
+            rng.next_u64(),
+            rng.next_u64(),
+            rng.next_u64(),
+        ]);
+    }
+
+    for base in [
+        Fq::zero(),
+        Fq::one(),
+        -Fq::one(),
+        Fq::random(&mut rng),
+        Fq::random(&mut rng),
+    ] {
+        for exp in &exponents {
+            assert_eq!(base.pow_vartime(exp), pow_vartime_reference(&base, exp));
+        }
+        // Short and empty exponent slices behave like zero-padded ones.
+        assert_eq!(base.pow_vartime([7]), pow_vartime_reference(&base, &[7]));
+        assert_eq!(
+            base.pow_vartime([0u64; 0]),
+            pow_vartime_reference(&base, &[])
+        );
+    }
 }
 
 #[test]

--- a/src/fields/fq.rs
+++ b/src/fields/fq.rs
@@ -297,8 +297,14 @@ impl Fq {
         // constant `R2` or `R3`.
         let d0 = Fq([limbs[0], limbs[1], limbs[2], limbs[3]]);
         let d1 = Fq([limbs[4], limbs[5], limbs[6], limbs[7]]);
-        // Convert to Montgomery form
-        d0 * R2 + d1 * R3
+        // Convert to Montgomery form. `d0` and `d1` are unreduced, so use the
+        // portable multiplication: its classical 8-limb reduction is valid for
+        // any 256-bit value times a canonical constant, with no precondition
+        // on the constant's limbs. The inline-assembly `mul` tolerates an
+        // unreduced lhs only while every rhs limb stays at most `2^64 - 4`
+        // (see `aarch64_asm.rs`); this cold path is not worth carrying that
+        // coupling, and hashing dominates its callers anyway.
+        Fq::mul(&d0, &R2).add(&Fq::mul(&d1, &R3))
     }
 
     /// Converts from an integer represented in little endian
@@ -1063,7 +1069,7 @@ fn test_sqrt_32bit_overflow() {
 
 #[test]
 fn test_pow_vartime() {
-    use rand::SeedableRng;
+    use rand::{Rng, SeedableRng};
 
     // The classic square-and-multiply loop, as a reference for the fused
     // implementation.
@@ -1262,4 +1268,80 @@ fn test_from_u512() {
             0x52ea589e69712cc0
         ])
     );
+}
+
+#[cfg(all(
+    test,
+    feature = "aarch64-asm",
+    target_arch = "aarch64",
+    target_vendor = "apple"
+))]
+#[test]
+fn aarch64_asm_mul_unreduced_lhs_matches_portable() {
+    use rand::{Rng, SeedableRng};
+
+    // `from_u512` feeds raw (unreduced) 256-bit digits as the lhs of the
+    // inline `mul`, with `R2`/`R3` as the rhs. The five-limb accumulator
+    // tolerates an unreduced lhs only while every rhs limb is at most
+    // `2^64 - 4` (see the contract in `aarch64_asm.rs`); assert the
+    // constants keep that invariant, then pin the behaviour against the
+    // portable implementation on the most adversarial inputs known.
+    for by in [R2, R3] {
+        for limb in by.0 {
+            assert!(limb <= u64::MAX - 3);
+        }
+    }
+
+    // lhs values with the low limbs solved so the first two Montgomery
+    // quotients hit (R2) or approach (R3, whose low limb is even) their
+    // maximum `2^64 - 1` while the top
+    // limbs are all-ones: jointly the nearest known approach to the
+    // carry-chain wrap described in `aarch64_asm.rs`.
+    let forced_q_r2 = Fq([0xf3bfcadeeeeeeeef, 0x27fa6352b2545d71, u64::MAX, u64::MAX]);
+    let forced_q_r3 = Fq([0x0000000000000d24, 0x00000000000007c2, u64::MAX, u64::MAX]);
+
+    let check = |lhs: Fq, by: Fq| {
+        // Inherent `Fq::mul` is the portable implementation; its classical
+        // 8-limb reduction is valid for any lhs when `by` is canonical.
+        assert_eq!(lhs.mul_runtime(&by), Fq::mul(&lhs, &by), "lhs {:x?}", lhs.0);
+    };
+
+    check(Fq([u64::MAX; 4]), R2);
+    check(Fq([u64::MAX; 4]), R3);
+    check(forced_q_r2, R2);
+    check(forced_q_r3, R3);
+
+    let mut rng = rand_xorshift::XorShiftRng::from_seed([0x6b; 16]);
+    for i in 0..20_000u32 {
+        let mut l = [0u64; 4];
+        for w in l.iter_mut() {
+            *w = rng.next_u64();
+        }
+        if i % 2 == 0 {
+            l[3] = u64::MAX;
+            l[2] = u64::MAX;
+        }
+        check(Fq(l), R2);
+        check(Fq(l), R3);
+    }
+
+    // End-to-end `from_u512` against a portable recomposition.
+    let portable_from_u512 = |l: [u64; 8]| {
+        let d0 = Fq([l[0], l[1], l[2], l[3]]);
+        let d1 = Fq([l[4], l[5], l[6], l[7]]);
+        Fq::mul(&d0, &R2).add(&Fq::mul(&d1, &R3))
+    };
+    assert_eq!(
+        Fq::from_u512([u64::MAX; 8]),
+        portable_from_u512([u64::MAX; 8])
+    );
+    for _ in 0..10_000u32 {
+        let mut l = [0u64; 8];
+        for w in l.iter_mut() {
+            *w = rng.next_u64();
+        }
+        l[3] |= 0xc000000000000000;
+        l[7] |= 0xc000000000000000;
+        assert_eq!(Fq::from_u512(l), portable_from_u512(l), "limbs {:x?}", l);
+    }
 }

--- a/src/fields/fq.rs
+++ b/src/fields/fq.rs
@@ -1069,7 +1069,7 @@ fn test_sqrt_32bit_overflow() {
 
 #[test]
 fn test_pow_vartime() {
-    use rand::{Rng, SeedableRng};
+    use rand::SeedableRng;
 
     // The classic square-and-multiply loop, as a reference for the fused
     // implementation.
@@ -1278,7 +1278,7 @@ fn test_from_u512() {
 ))]
 #[test]
 fn aarch64_asm_mul_unreduced_lhs_matches_portable() {
-    use rand::{Rng, SeedableRng};
+    use rand::SeedableRng;
 
     // `from_u512` feeds raw (unreduced) 256-bit digits as the lhs of the
     // inline `mul`, with `R2`/`R3` as the rhs. The five-limb accumulator
@@ -1352,7 +1352,7 @@ fn aarch64_asm_mul_unreduced_lhs_matches_portable() {
         }
         l[3] |= 0xc000000000000000;
         l[7] |= 0xc000000000000000;
-        assert_eq!(Fq::from_u512(l), portable_from_u512(l), "limbs {:x?}", l);
+        assert_eq!(Fq::from_u512(l), portable_from_u512(l), "limbs {l:x?}");
     }
 }
 
@@ -1412,7 +1412,7 @@ fn constants_are_canonical() {
 ))]
 #[test]
 fn aarch64_asm_mul_canonical_sweep_matches_portable() {
-    use rand::{Rng, SeedableRng};
+    use rand::SeedableRng;
 
     // Random canonical operands: the inline `mul` must agree with the
     // portable implementation and return a canonical residue.
@@ -1441,7 +1441,7 @@ fn aarch64_asm_mul_canonical_sweep_matches_portable() {
 ))]
 #[test]
 fn aarch64_asm_mul_unreduced_lhs_near_modulus_rhs_matches_portable() {
-    use rand::{Rng, SeedableRng};
+    use rand::SeedableRng;
 
     // The inline `mul` omits the fifth candidate limb on the strength of
     // `(lhs * rhs + m * modulus) / R < 2 * modulus < R`, which holds for any

--- a/src/fields/fq.rs
+++ b/src/fields/fq.rs
@@ -168,7 +168,7 @@ impl Mul<&Fq> for &Fq {
 
     #[inline]
     fn mul(self, rhs: &Fq) -> Fq {
-        self.mul(rhs)
+        self.mul_runtime(rhs)
     }
 }
 
@@ -369,6 +369,48 @@ impl Fq {
         Fq::montgomery_reduce(u[0], u[1], u[2], u[3], u[4], u[5], u[6], u[7])
     }
 
+    #[inline]
+    fn mul_runtime(&self, rhs: &Self) -> Self {
+        #[cfg(all(
+            feature = "aarch64-asm",
+            target_arch = "aarch64",
+            target_vendor = "apple"
+        ))]
+        {
+            Fq(super::aarch64_asm::mul(&self.0, &rhs.0, &MODULUS.0, INV))
+        }
+
+        #[cfg(not(all(
+            feature = "aarch64-asm",
+            target_arch = "aarch64",
+            target_vendor = "apple"
+        )))]
+        {
+            self.mul(rhs)
+        }
+    }
+
+    #[inline]
+    fn square_runtime(&self) -> Self {
+        #[cfg(all(
+            feature = "aarch64-asm",
+            target_arch = "aarch64",
+            target_vendor = "apple"
+        ))]
+        {
+            Fq(super::aarch64_asm::square(&self.0, &MODULUS.0, INV))
+        }
+
+        #[cfg(not(all(
+            feature = "aarch64-asm",
+            target_arch = "aarch64",
+            target_vendor = "apple"
+        )))]
+        {
+            self.square()
+        }
+    }
+
     /// Subtracts `rhs` from `self`, returning the result.
     #[cfg_attr(not(feature = "uninline-portable"), inline)]
     pub const fn sub(&self, rhs: &Self) -> Self {
@@ -544,7 +586,7 @@ impl ff::Field for Fq {
 
     #[inline(always)]
     fn square(&self) -> Self {
-        self.square()
+        self.square_runtime()
     }
 
     fn sqrt_ratio(num: &Self, div: &Self) -> (Choice, Self) {
@@ -818,6 +860,54 @@ impl ec_gpu::GpuField for Fq {
 
     fn modulus() -> alloc::vec::Vec<u32> {
         crate::fields::u64_to_u32(&MODULUS.0[..])
+    }
+}
+
+#[cfg(all(
+    test,
+    feature = "aarch64-asm",
+    target_arch = "aarch64",
+    target_vendor = "apple"
+))]
+#[test]
+fn aarch64_asm_matches_portable_arithmetic() {
+    use rand::SeedableRng;
+
+    let modulus_minus_one =
+        Fq::from_raw([MODULUS.0[0] - 1, MODULUS.0[1], MODULUS.0[2], MODULUS.0[3]]);
+    let boundaries = [
+        Fq::zero(),
+        Fq::one(),
+        -Fq::one(),
+        Fq::from_raw([1, 0, 0, 0]),
+        modulus_minus_one,
+        Fq::from_raw([u64::MAX; 4]),
+    ];
+
+    for lhs in boundaries {
+        assert_eq!(<Fq as Field>::square(&lhs), Fq::square(&lhs));
+        for rhs in boundaries {
+            assert_eq!(&lhs * &rhs, Fq::mul(&lhs, &rhs));
+        }
+    }
+
+    let mut rng = rand_xorshift::XorShiftRng::from_seed([0xa5; 16]);
+    for _ in 0..1024 {
+        let lhs = Fq::from_raw([
+            rng.next_u64(),
+            rng.next_u64(),
+            rng.next_u64(),
+            rng.next_u64(),
+        ]);
+        let rhs = Fq::from_raw([
+            rng.next_u64(),
+            rng.next_u64(),
+            rng.next_u64(),
+            rng.next_u64(),
+        ]);
+
+        assert_eq!(&lhs * &rhs, Fq::mul(&lhs, &rhs));
+        assert_eq!(<Fq as Field>::square(&lhs), Fq::square(&lhs));
     }
 }
 

--- a/src/fields/fq.rs
+++ b/src/fields/fq.rs
@@ -1284,9 +1284,15 @@ fn aarch64_asm_mul_unreduced_lhs_matches_portable() {
     // inline `mul`, with `R2`/`R3` as the rhs. The five-limb accumulator
     // tolerates an unreduced lhs only while every rhs limb is at most
     // `2^64 - 4` (see the contract in `aarch64_asm.rs`); assert the
-    // constants keep that invariant, then pin the behaviour against the
-    // portable implementation on the most adversarial inputs known.
-    for by in [R2, R3] {
+    // selected rhs values keep that invariant, then pin the behaviour against
+    // the portable implementation on the most adversarial inputs known.
+    let mut max_canonical = MODULUS;
+    max_canonical.0[0] -= 1;
+    let dense_limb = u64::MAX - 3;
+    let mut dense_canonical = Fq([dense_limb; 4]);
+    dense_canonical.0[3] = MODULUS.0[3] - 1;
+    let canonical_rhs = [R2, R3, max_canonical, dense_canonical];
+    for by in canonical_rhs {
         for limb in by.0 {
             assert!(limb <= u64::MAX - 3);
         }
@@ -1310,6 +1316,10 @@ fn aarch64_asm_mul_unreduced_lhs_matches_portable() {
     check(Fq([u64::MAX; 4]), R3);
     check(forced_q_r2, R2);
     check(forced_q_r3, R3);
+    // These maximize the full 256-bit lhs while taking the canonical rhs
+    // close to q. They exercise the final candidate's `T < 2q < R` bound.
+    check(Fq([u64::MAX; 4]), max_canonical);
+    check(Fq([u64::MAX; 4]), dense_canonical);
 
     let mut rng = rand_xorshift::XorShiftRng::from_seed([0x6b; 16]);
     for i in 0..20_000u32 {
@@ -1344,4 +1354,141 @@ fn aarch64_asm_mul_unreduced_lhs_matches_portable() {
         l[7] |= 0xc000000000000000;
         assert_eq!(Fq::from_u512(l), portable_from_u512(l), "limbs {:x?}", l);
     }
+}
+
+/// Whether `x` holds a reduced residue (limbs below the modulus).
+#[cfg(test)]
+fn is_canonical(x: &Fq) -> bool {
+    for i in (0..4).rev() {
+        if x.0[i] != MODULUS.0[i] {
+            return x.0[i] < MODULUS.0[i];
+        }
+    }
+    false
+}
+
+#[test]
+fn constants_are_canonical() {
+    // Every named constant must be a reduced residue: the `aarch64-asm`
+    // multiplication requires a canonical rhs, and constants are the one
+    // class of values that bypass the reducing constructors.
+    assert!(
+        !is_canonical(&MODULUS),
+        "the modulus itself is not canonical"
+    );
+    let constants: [(&str, Fq); 11] = [
+        ("R", R),
+        ("R2", R2),
+        ("R3", R3),
+        ("GENERATOR", GENERATOR),
+        ("ROOT_OF_UNITY", ROOT_OF_UNITY),
+        ("DELTA", DELTA),
+        ("TWO_INV", <Fq as ff::PrimeField>::TWO_INV),
+        (
+            "MULTIPLICATIVE_GENERATOR",
+            <Fq as ff::PrimeField>::MULTIPLICATIVE_GENERATOR,
+        ),
+        (
+            "ROOT_OF_UNITY_INV",
+            <Fq as ff::PrimeField>::ROOT_OF_UNITY_INV,
+        ),
+        ("ZETA", <Fq as ff::WithSmallOrderMulGroup<3>>::ZETA),
+        ("zero", Fq::zero()),
+    ];
+    for (name, value) in constants {
+        assert!(
+            is_canonical(&value),
+            "{name} is not canonical: {:x?}",
+            value.0
+        );
+    }
+}
+
+#[cfg(all(
+    test,
+    feature = "aarch64-asm",
+    target_arch = "aarch64",
+    target_vendor = "apple"
+))]
+#[test]
+fn aarch64_asm_mul_canonical_sweep_matches_portable() {
+    use rand::{Rng, SeedableRng};
+
+    // Random canonical operands: the inline `mul` must agree with the
+    // portable implementation and return a canonical residue.
+    let mut rng = rand_xorshift::XorShiftRng::from_seed([0x42; 16]);
+    let mut random = || {
+        let mut l = [0u64; 4];
+        for w in l.iter_mut() {
+            *w = rng.next_u64();
+        }
+        Fq::from_raw(l)
+    };
+    for _ in 0..200_000u32 {
+        let a = random();
+        let b = random();
+        let asm = a.mul_runtime(&b);
+        assert_eq!(asm, Fq::mul(&a, &b), "lhs {:x?} rhs {:x?}", a.0, b.0);
+        assert!(is_canonical(&asm));
+    }
+}
+
+#[cfg(all(
+    test,
+    feature = "aarch64-asm",
+    target_arch = "aarch64",
+    target_vendor = "apple"
+))]
+#[test]
+fn aarch64_asm_mul_unreduced_lhs_near_modulus_rhs_matches_portable() {
+    use rand::{Rng, SeedableRng};
+
+    // The inline `mul` omits the fifth candidate limb on the strength of
+    // `(lhs * rhs + m * modulus) / R < 2 * modulus < R`, which holds for any
+    // 256-bit lhs once the rhs is canonical. Stress that bound where it is
+    // tightest: lhs with its top bit set, rhs within a few limbs of the
+    // modulus (kept canonical, and within the per-limb no-wrap condition
+    // that an unreduced lhs separately requires).
+    let mut rng = rand_xorshift::XorShiftRng::from_seed([0x17; 16]);
+    let mut n = 0u32;
+    while n < 100_000 {
+        let lhs = Fq([
+            rng.next_u64(),
+            rng.next_u64(),
+            rng.next_u64(),
+            rng.next_u64() | (1 << 63),
+        ]);
+        let mut rhs = MODULUS;
+        rhs.0[0] = rhs.0[0].wrapping_sub(rng.next_u64() >> (rng.next_u32() % 64));
+        if rng.next_u32() & 1 == 1 {
+            rhs.0[1] = rhs.0[1].wrapping_sub(rng.next_u64() >> 60);
+        }
+        if !is_canonical(&rhs) || rhs.0.iter().any(|&l| l > u64::MAX - 3) {
+            continue;
+        }
+        n += 1;
+        let asm = lhs.mul_runtime(&rhs);
+        assert_eq!(
+            asm,
+            Fq::mul(&lhs, &rhs),
+            "lhs {:x?} rhs {:x?}",
+            lhs.0,
+            rhs.0
+        );
+        assert!(is_canonical(&asm));
+    }
+}
+
+#[cfg(all(
+    test,
+    debug_assertions,
+    feature = "aarch64-asm",
+    target_arch = "aarch64",
+    target_vendor = "apple"
+))]
+#[test]
+#[should_panic(expected = "requires a canonical rhs")]
+fn aarch64_asm_mul_rejects_non_canonical_rhs_in_debug() {
+    // The modulus itself is the smallest non-canonical value.
+    let _ = Fq::one().mul_runtime(&MODULUS);
 }


### PR DESCRIPTION
Upstreams the Apple AArch64 assembly backend for the Pasta field arithmetic
from https://github.com/zakura-core/libraries.

> **Stacked on #102.** The base of this pull request is
> `dw/zizmor-and-pin-actions`, not `main`, so review #102 first and merge it
> first; this one then retargets to `main` automatically. Stacking was chosen
> over rebasing because both branches add jobs to `ci.yml` and
> `lints-stable.yml`, and this way the new jobs are written against the pinned,
> hardened versions of those files rather than being pinned after the fact.

**This pull request has been reduced in scope.** It previously carried eleven
commits; it now carries seven, stopping at "Document AArch64 Pasta field assembly",
plus a CHANGELOG entry and a CI job. The later assembly work is deferred to a follow-up so that
this one can be reviewed on a much smaller and lower-risk surface. Three of the
four concerns the earlier description raised no longer apply; see "What was
dropped" below.

The backend is behind an opt-in `aarch64-asm` feature and compiles assembly
only on `target_arch = "aarch64"` plus `target_vendor = "apple"`. A default
build is unchanged in what it computes.

Four of the seven commits are ports and keep their original author, date and
message, with an upstreaming block appended carrying the `format-patch` command
that reproduces each one and its `Source-Commit:` trailer. One is written here:
the manifest change, because the standard exclusions drop `Cargo.toml`. A
CHANGELOG entry is in its own commit.

## What a reviewer should look at

**1. A build script now runs for every consumer.** The manifest gains
`build = "build.rs"` and an optional `cc` build dependency. With the feature
off, `build.rs` compiles to a single `rerun-if-changed` line and `cc` is not in
the graph, but the build script itself runs unconditionally. That is a change
to the build surface of a widely depended on crate, and it is worth deciding on
deliberately rather than by patch review. It is the one concern from the
original description that survives the reduction.

**2. Assembly and `unsafe`.** `src/fields/aarch64_asm.rs` has three `unsafe`
blocks and one `extern "C"` declaration against the vendored
`src/asm/pasta_mul-armv8.S`. The FFI boundary is private to the crate. The
constant-time claim is stated in the module docs.

**3. `src/curves.rs` routes curve squaring through the field backend.** A
mechanical change, 18 lines each way, and the only file here that is not
AArch64-specific.

**4. The final commit documents the assembly and changes no instruction.**
"Document AArch64 Pasta field assembly" shows as 418 insertions and 373
deletions in the `.S`, which looks alarming for a comment change. It is not.
Normalising both revisions by stripping `//` comments and collapsing
whitespace leaves 329 instruction lines on each side, and the only four
differences are a space after a comma (`ldr x9, [x2]` against `ldr x9,[x2]`).
The assembler sees the same program. It is included because the assembly is
the part of this pull request that is hardest to review, and the comments are
what make it reviewable.

## What was dropped, and why it matters to the review

These were the largest risks in the original eleven commits, and none of them
is in this pull request any more:

* **`pow_vartime` is no longer touched at all.** The earlier series rewrote it
  for every target, not just Apple, so an error would have been a wrong field
  inverse on every platform. `git diff` against `main` now contains zero
  occurrences of `pow_vartime`.
* **The canonical-operand precondition is gone.** "Drop dead Montgomery carry
  limb" made the inline multiply depend on its right-hand operand already being
  canonical, checked only by `debug_assert!`. That commit is not here.
* **The move of multiplication and squaring into inline `asm!` is deferred**,
  which is what takes `unsafe` from five blocks to three and `extern "C"` from
  three declarations to one.
The CI job for the assembly backend is NOT dropped; see below.

## CI coverage for the new feature

Nothing outside a macOS arm64 runner compiles this assembly, so two jobs are
added against #102's already-pinned workflows:

* `aarch64-asm` in `ci.yml` builds and tests with the feature pinned on, and
  joins the required status checks.
* `clippy-aarch64-asm` in `lints-stable.yml`, because a lint inside gated code
  is invisible to the existing Linux clippy job.

Both guard against passing VACUOUSLY, which is the real risk with a
cfg-gated backend:

* the job asserts `uname -sm` is `Darwin arm64`, so if `macos-latest` ever
  moves back to x86_64 the job fails instead of going green without compiling
  any assembly;
* it re-runs the two differential tests by exact name and requires the output
  to say `2 passed`, because a test that compiles out still reports success.

Verified locally that the exact invocation reports `2 passed` with the feature
on, and does not report it with the feature off. `zizmor --offline` reports no
findings on the resulting workflows.

## Verification

On `aarch64-apple-darwin`, all green: `cargo build`; `cargo test`;
`cargo test --all-features`; `cargo test --no-default-features`;
`cargo test --features aarch64-asm`;
`cargo clippy --all-targets --all-features -- -D warnings`;
`cargo clippy --all-targets --features aarch64-asm -- -D warnings`;
`cargo fmt --check`.

The feature is genuinely exercised rather than merely compiled: enabling
`aarch64-asm` takes the unit tests from 29 to 31, and the build script emits
the assembled `pasta_mul-armv8.o`.
