### PR TITLE
Add batched same-scalar multiplication hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `CurveExt::batch_mul_same_scalar_vartime`, for component-wise
+  multiplication of affine points by the same public scalar. Pallas and Vesta
+  use batched GLV multiplication when the `glv` feature is enabled.
+
 ### Changed
 - MSRV is now 1.88.0.
 

--- a/benches/glv.rs
+++ b/benches/glv.rs
@@ -1,10 +1,24 @@
 //! Benchmarks for GLV scalar multiplication.
 
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 
 use ff::Field;
 use pasta_curves::glv::{Decomposed, GlvParams, Table};
 use pasta_curves::{pallas, vesta};
+use rand::SeedableRng;
+use rand_xorshift::XorShiftRng;
+
+// A k = 13 Halo generator collapse calls batches from 2^12 down to 2^0.
+const SAME_SCALAR_BATCH_SIZES: [usize; 13] =
+    [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096];
+const SAME_SCALAR_CORPUS_SIZE: usize = 8;
+
+fn same_scalar_corpus<C: GlvParams>() -> Vec<C::ScalarExt> {
+    let mut rng = XorShiftRng::from_seed([0x42; 16]);
+    (0..SAME_SCALAR_CORPUS_SIZE)
+        .map(|_| C::ScalarExt::random(&mut rng))
+        .collect()
+}
 
 fn criterion_benchmark(c: &mut Criterion) {
     glv_bench::<pallas::Point>(c, "Pallas");
@@ -38,6 +52,43 @@ fn glv_bench<C: GlvParams>(c: &mut Criterion, name: &str) {
         b.iter(|| table.mul_decomposed(&decomposed));
     });
 
+    group.finish();
+
+    let mut group = c.benchmark_group(format!("{name}/same-scalar batch"));
+    group.sample_size(10);
+    // This measures the multiplication kernel. The caller's addition and
+    // final batch normalization are common to both implementations.
+    let scalars = same_scalar_corpus::<C>();
+    for size in SAME_SCALAR_BATCH_SIZES {
+        group.throughput(Throughput::Elements((size * scalars.len()) as u64));
+        let points: Vec<C::AffineExt> = (0..size)
+            .map(|i| C::AffineExt::from(C::generator() * (k + C::ScalarExt::from(i as u64 + 1))))
+            .collect();
+        let mut output = vec![C::identity(); size];
+
+        group.bench_with_input(BenchmarkId::new("native loop", size), &size, |b, _| {
+            b.iter(|| {
+                let points = black_box(points.as_slice());
+                let scalars = black_box(scalars.as_slice());
+                for scalar in scalars {
+                    for (point, output) in points.iter().zip(output.iter_mut()) {
+                        *output = *point * scalar;
+                    }
+                    black_box(output.as_slice());
+                }
+            });
+        });
+        group.bench_with_input(BenchmarkId::new("batch hook", size), &size, |b, _| {
+            b.iter(|| {
+                let points = black_box(points.as_slice());
+                let scalars = black_box(scalars.as_slice());
+                for scalar in scalars {
+                    C::batch_mul_same_scalar_vartime(points, scalar, &mut output);
+                    black_box(output.as_slice());
+                }
+            });
+        });
+    }
     group.finish();
 }
 

--- a/src/arithmetic/curves.rs
+++ b/src/arithmetic/curves.rs
@@ -80,6 +80,33 @@ pub trait CurveExt:
     /// Obtains a point given Jacobian coordinates $X : Y : Z$, failing
     /// if the coordinates are not on the curve.
     fn new_jacobian(x: Self::Base, y: Self::Base, z: Self::Base) -> CtOption<Self>;
+
+    /// Multiplies every point in `points` by the same `scalar`, writing the
+    /// corresponding products to `output`.
+    ///
+    /// The default implementation performs the native scalar multiplication
+    /// independently for each point. Implementations may batch work shared by
+    /// these component-wise scalar multiplications.
+    ///
+    /// # Security
+    ///
+    /// This method may run in variable time with respect to `scalar`. **The
+    /// scalar must be public.** Do not use this method with secret scalar
+    /// material.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `points` and `output` have different lengths.
+    fn batch_mul_same_scalar_vartime(
+        points: &[Self::AffineExt],
+        scalar: &Self::ScalarExt,
+        output: &mut [Self],
+    ) {
+        assert_eq!(points.len(), output.len());
+        for (point, output) in points.iter().zip(output.iter_mut()) {
+            *output = *point * scalar;
+        }
+    }
 }
 
 /// This trait is the affine counterpart to `Curve` and is used for
@@ -178,5 +205,78 @@ impl<C: CurveAffine> ConditionallySelectable for Coordinates<C> {
             x: C::Base::conditional_select(&a.x, &b.x, choice),
             y: C::Base::conditional_select(&a.y, &b.y, choice),
         }
+    }
+}
+
+#[cfg(all(test, feature = "alloc"))]
+mod tests {
+    use super::*;
+    use crate::{pallas, vesta};
+    use ff::{Field, PrimeField, WithSmallOrderMulGroup};
+
+    const BATCH_SIZES: [usize; 15] = [0, 1, 2, 3, 7, 8, 15, 16, 17, 63, 64, 65, 127, 128, 129];
+
+    fn batch_mul_same_scalar_matches_native<C: CurveExt>() {
+        let full_width = (C::ScalarExt::from(0x9E37_79B9_7F4A_7C15u64).square()
+            + C::ScalarExt::from(0x0123_4567_89AB_CDEFu64))
+        .square();
+        let scalars = [
+            C::ScalarExt::ZERO,
+            C::ScalarExt::ONE,
+            -C::ScalarExt::ONE,
+            C::ScalarExt::from(2),
+            C::ScalarExt::ZETA,
+            -C::ScalarExt::ZETA,
+            C::ScalarExt::ZETA + C::ScalarExt::ONE,
+            C::ScalarExt::from(u64::MAX),
+            C::ScalarExt::from_u128((1u128 << 127) - 1),
+            C::ScalarExt::from_u128(1u128 << 127),
+            full_width,
+        ];
+
+        for size in BATCH_SIZES {
+            let projective: alloc::vec::Vec<C> = (0..size)
+                .map(|i| {
+                    if size > 2 && i == size / 2 {
+                        C::identity()
+                    } else {
+                        C::generator()
+                            * (C::ScalarExt::from(i as u64 + 1).square()
+                                + C::ScalarExt::from(0xDEAD_BEEFu64))
+                    }
+                })
+                .collect();
+            let points: alloc::vec::Vec<C::AffineExt> =
+                projective.iter().copied().map(C::AffineExt::from).collect();
+            let mut output = alloc::vec![C::identity(); size];
+
+            for scalar in scalars {
+                C::batch_mul_same_scalar_vartime(&points, &scalar, &mut output);
+                for ((point, output), expected) in
+                    points.iter().zip(output.iter()).zip(projective.iter())
+                {
+                    assert_eq!(*output, *point * scalar);
+                    assert_eq!(*output, *expected * scalar);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn batch_mul_same_scalar_pallas() {
+        batch_mul_same_scalar_matches_native::<pallas::Point>();
+    }
+
+    #[test]
+    fn batch_mul_same_scalar_vesta() {
+        batch_mul_same_scalar_matches_native::<vesta::Point>();
+    }
+
+    #[test]
+    #[should_panic]
+    fn batch_mul_same_scalar_length_mismatch_panics() {
+        let points = [pallas::Affine::generator()];
+        let mut output = [];
+        pallas::Point::batch_mul_same_scalar_vartime(&points, &pallas::Scalar::ONE, &mut output);
     }
 }

--- a/src/curves.rs
+++ b/src/curves.rs
@@ -26,9 +26,35 @@ use super::{Fp, Fq};
 #[cfg(feature = "alloc")]
 use crate::arithmetic::{Coordinates, CurveAffine, CurveExt};
 
+#[cfg(feature = "alloc")]
+macro_rules! impl_batch_mul_same_scalar_vartime {
+    (glv, $name:ident) => {
+        #[cfg(feature = "glv")]
+        fn batch_mul_same_scalar_vartime(
+            points: &[Self::AffineExt],
+            scalar: &Self::ScalarExt,
+            output: &mut [Self],
+        ) {
+            assert_eq!(points.len(), output.len());
+            if points.is_empty() {
+                return;
+            }
+            for (point, output) in points.iter().zip(output.iter_mut()) {
+                *output = PrimeCurveAffine::to_curve(point);
+            }
+            let scalar = crate::glv::Decomposed::<$name>::new(scalar);
+            let tables = crate::glv::Table::batch(output);
+            for (output, table) in output.iter_mut().zip(tables) {
+                *output = table.mul_decomposed(&scalar);
+            }
+        }
+    };
+    (native, $name:ident) => {};
+}
+
 macro_rules! new_curve_impl {
     (($($privacy:tt)*), $name:ident, $name_affine:ident, $iso:ident, $base:ident, $scalar:ident,
-     $curve_id:literal, $a_raw:expr, $b_raw:expr, $curve_type:ident) => {
+     $curve_id:literal, $a_raw:expr, $b_raw:expr, $curve_type:ident, $same_scalar_mul:ident) => {
         /// Represents a point in the projective coordinate space.
         #[derive(Copy, Clone, Debug)]
         #[cfg_attr(feature = "repr-c", repr(C))]
@@ -165,6 +191,8 @@ macro_rules! new_curve_impl {
                     .ct_eq(&(z6 * $name::curve_constant_b()))
                     | self.z.is_zero()
             }
+
+            impl_batch_mul_same_scalar_vartime!($same_scalar_mul, $name);
         }
 
         impl group::Curve for $name {
@@ -955,7 +983,8 @@ new_curve_impl!(
     "pallas",
     [0, 0, 0, 0],
     [5, 0, 0, 0],
-    special_a0_b5
+    special_a0_b5,
+    glv
 );
 new_curve_impl!(
     (pub),
@@ -967,7 +996,8 @@ new_curve_impl!(
     "vesta",
     [0, 0, 0, 0],
     [5, 0, 0, 0],
-    special_a0_b5
+    special_a0_b5,
+    glv
 );
 new_curve_impl!(
     (pub(crate)),
@@ -984,7 +1014,8 @@ new_curve_impl!(
         0x18354a2eb0ea8c9c,
     ],
     [1265, 0, 0, 0],
-    general
+    general,
+    native
 );
 new_curve_impl!(
     (pub(crate)),
@@ -1001,7 +1032,8 @@ new_curve_impl!(
         0x267f9b2ee592271a,
     ],
     [1265, 0, 0, 0],
-    general
+    general,
+    native
 );
 
 impl Ep {


### PR DESCRIPTION
## What this adds

`CurveExt::batch_mul_same_scalar_vartime(points, scalar, output)`: multiply a
slice of affine points by one shared scalar, writing the products into
`output`. The point of the hook is that an implementation is allowed to do the
work shared across those multiplications once instead of once per point.

The trait method ships with a **default implementation** that is the plain
loop (`*output = *point * scalar`), so this is a purely additive,
non-breaking trait change: every existing implementor of `CurveExt` keeps
compiling untouched.

Pallas and Vesta then override it, **only under the existing `glv` feature**,
with a shared `glv::Decomposed` and a batched `glv::Table::batch`, so the
scalar is decomposed once and the per-point tables are built in one batch.
The two internal iso curves keep the default loop. With `glv` off, everything
uses the default implementation.

The method is documented as variable time in the scalar and the doc comment
says the scalar must be public, matching the rest of the `glv` module.

## Why it matters beyond its size

This is an enabling primitive rather than an optimisation in itself. It is a
hard prerequisite for downstream work: the IPA generator-collapse speedup in
`halo2_proofs` (`d5f4036` in the source monorepo) calls this method and cannot
compile without it.

## Provenance

This is a port, not new work. It is
[`4b767d3`](https://github.com/zakura-core/libraries/commit/4b767d3dd6d7badea2779b346ee7ccefd88de1dd)
from https://github.com/zakura-core/libraries, applied with `git am --3way`.
The original author, date and message are preserved; the commit message gains
only an appended provenance block with the exact `format-patch` command to
reproduce it and a `Source-Commit:` line.

It applied **cleanly, with no rejects and no hunks re-sited by hand.** The
only path dropped from the patch is `CHANGELOG.md`, which is excluded because
this repository requires changelog changes in their own commit; it is here as
the second commit. The source commit did not touch `Cargo.toml`, so nothing
had to be reapplied by hand.

## Tests

The commit brings its own tests, in a new `#[cfg(all(test, feature =
"alloc"))]` module in `src/arithmetic/curves.rs`:

- `batch_mul_same_scalar_pallas` and `batch_mul_same_scalar_vesta` check the
  hook against the native `point * scalar` for 15 batch sizes (0, 1, 2, 3, 7,
  8, 15, 16, 17, 63, 64, 65, 127, 128, 129, so both sides of every power of
  two), each against 11 scalars including zero, one, minus one, `ZETA`,
  `-ZETA`, `ZETA + 1`, `u64::MAX`, both sides of `2^127` and a full-width
  scalar, and with the identity planted mid-batch;
- `batch_mul_same_scalar_length_mismatch_panics` pins the documented panic.

These run under default features, where the **default implementation** is what
is exercised, and again under `--all-features`, where `glv` is on and the same
tests cover the Pallas and Vesta overrides.

`benches/glv.rs` gains a `same-scalar batch` group comparing the native loop
against the hook over the batch sizes a k = 13 Halo generator collapse
actually produces (2^0 through 2^12).

## Verification

Run on this branch:

- `cargo build`
- `cargo test` (32 passed)
- `cargo test --all-features` (84 passed)
- `cargo test --no-default-features` (22 passed)
- `cargo build --benches --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings` (clean)
- `cargo fmt --check` (clean)

The ported commit's file list matches the source commit exactly apart from
`CHANGELOG.md`.
