### PR TITLE
Optimize Pasta squaring across portable targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to Rust's notion of
 ## [Unreleased]
 ### Changed
 - MSRV is now 1.88.0.
+- The portable (pure Rust) `Fp` and `Fq` wide-squaring routine moved into a
+  shared internal `fields::portable` module. Both fields delegate to the same
+  limb-array implementation; the algorithm and its results are unchanged.
+- Portable squaring on x86-64 now reduces the low half of its product first
+  and adds the high half once, keeping four limbs live through the
+  cancellation rounds instead of eight. Other targets retain their existing
+  classical reduction, and multiplication is unchanged.
+- Portable squaring chains driven by the square-root tables no longer
+  canonicalize after every squaring; the accumulator is kept below twice the
+  modulus and canonicalized once at the end of the chain.
 
 ## [0.5.2] - 2026-07-23
 ### Added

--- a/src/arithmetic/fields.rs
+++ b/src/arithmetic/fields.rs
@@ -23,6 +23,22 @@ pub(crate) trait SqrtTableHelpers: ff::PrimeField {
     /// Field implementations may override this to use an efficient addition chain.
     fn pow_by_t_minus1_over2(&self) -> Self;
 
+    /// Squares this element `n` times. `n` must be at least 1.
+    ///
+    /// Implementations may leave the accumulator unreduced between squarings
+    /// and canonicalize once at the end.
+    fn sqr_n(&self, n: u32) -> Self {
+        assert!(n >= 1);
+        (0..n).fold(*self, |acc, _| acc.square())
+    }
+
+    /// Squares this element `n` times, then multiplies by `by`. `n` must be
+    /// at least 1. The closing multiplication lets implementations skip the
+    /// per-squaring correction entirely.
+    fn sqr_n_mul(&self, n: u32, by: &Self) -> Self {
+        self.sqr_n(n) * by
+    }
+
     /// Gets the lower 32 bits of this field element when expressed
     /// canonically.
     fn get_lower_32(&self) -> u32;
@@ -152,13 +168,11 @@ impl<F: SqrtTableHelpers> SqrtTables<F> {
         // The overall cost of this part is similar to a single full-width exponentiation,
         // regardless of S.
 
-        let sqr = |x: F, i: u32| (0..i).fold(x, |x, _| x.square());
-
         // s = div^(2^S - 1)
-        let s = (0..5).fold(*div, |d: F, i| sqr(d, 1 << i) * d);
+        let s = (0..5).fold(*div, |d: F, i| d.sqr_n_mul(1 << i, &d));
 
         // t == div^(2^(S+1) - 1)
-        let t = s.square() * div;
+        let t = s.sqr_n_mul(1, div);
 
         // w = (num * t)^((T-1)/2) * s
         let w = (t * num).pow_by_t_minus1_over2() * s;
@@ -198,13 +212,12 @@ impl<F: SqrtTableHelpers> SqrtTables<F> {
 
     /// Common part of sqrt_ratio and sqrt_alt: return their result given v = u^((T-1)/2) and uv = u * v.
     fn sqrt_common(&self, uv: &F, v: &F) -> F {
-        let sqr = |x: F, i: u32| (0..i).fold(x, |x, _| x.square());
         let inv = |x: F| self.inv[self.hasher.hash(&x)] as usize;
 
         let x3 = *uv * v;
-        let x2 = sqr(x3, 8);
-        let x1 = sqr(x2, 8);
-        let x0 = sqr(x1, 8);
+        let x2 = x3.sqr_n(8);
+        let x1 = x2.sqr_n(8);
+        let x0 = x1.sqr_n(8);
 
         // i = 0, 1
         let mut t_ = inv(x0); // = t >> 16

--- a/src/fields.rs
+++ b/src/fields.rs
@@ -3,6 +3,7 @@
 
 mod fp;
 mod fq;
+mod portable;
 
 pub use fp::*;
 pub use fq::*;

--- a/src/fields/fp.rs
+++ b/src/fields/fp.rs
@@ -11,6 +11,7 @@ use lazy_static::lazy_static;
 #[cfg(feature = "bits")]
 use ff::{FieldBits, PrimeFieldBits};
 
+use super::portable;
 use crate::arithmetic::{adc, mac, sbb, SqrtTableHelpers};
 #[cfg(feature = "deferred")]
 use crate::deferred::{DeferredField, Product};
@@ -310,8 +311,16 @@ impl Fp {
     /// Squares this element.
     #[cfg_attr(not(feature = "uninline-portable"), inline)]
     pub const fn square(&self) -> Fp {
-        let u = self.square_unreduced();
-        Fp::montgomery_reduce(u[0], u[1], u[2], u[3], u[4], u[5], u[6], u[7])
+        #[cfg(target_arch = "x86_64")]
+        {
+            Fp(portable::square(&self.0, &MODULUS.0, INV))
+        }
+
+        #[cfg(not(target_arch = "x86_64"))]
+        {
+            let u = self.square_unreduced();
+            Fp::montgomery_reduce(u[0], u[1], u[2], u[3], u[4], u[5], u[6], u[7])
+        }
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -447,35 +456,15 @@ impl Fp {
     }
 
     /// Squares this element, returning the unreduced 512-bit product.
+    /// On x86-64, `square` reduces the product's halves separately, so this
+    /// only feeds the `deferred` accumulator and the tests on that target.
+    #[cfg_attr(
+        all(target_arch = "x86_64", not(feature = "deferred")),
+        allow(dead_code)
+    )]
     #[cfg_attr(not(feature = "uninline-portable"), inline)]
     pub(crate) const fn square_unreduced(&self) -> [u64; 8] {
-        let (r1, carry) = mac(0, self.0[0], self.0[1], 0);
-        let (r2, carry) = mac(0, self.0[0], self.0[2], carry);
-        let (r3, r4) = mac(0, self.0[0], self.0[3], carry);
-
-        let (r3, carry) = mac(r3, self.0[1], self.0[2], 0);
-        let (r4, r5) = mac(r4, self.0[1], self.0[3], carry);
-
-        let (r5, r6) = mac(r5, self.0[2], self.0[3], 0);
-
-        let r7 = r6 >> 63;
-        let r6 = (r6 << 1) | (r5 >> 63);
-        let r5 = (r5 << 1) | (r4 >> 63);
-        let r4 = (r4 << 1) | (r3 >> 63);
-        let r3 = (r3 << 1) | (r2 >> 63);
-        let r2 = (r2 << 1) | (r1 >> 63);
-        let r1 = r1 << 1;
-
-        let (r0, carry) = mac(0, self.0[0], self.0[0], 0);
-        let (r1, carry) = adc(0, r1, carry);
-        let (r2, carry) = mac(r2, self.0[1], self.0[1], carry);
-        let (r3, carry) = adc(0, r3, carry);
-        let (r4, carry) = mac(r4, self.0[2], self.0[2], carry);
-        let (r5, carry) = adc(0, r5, carry);
-        let (r6, carry) = mac(r6, self.0[3], self.0[3], carry);
-        let (r7, _) = adc(0, r7, carry);
-
-        [r0, r1, r2, r3, r4, r5, r6, r7]
+        portable::square_wide(&self.0)
     }
 }
 
@@ -766,6 +755,23 @@ impl SqrtTableHelpers for Fp {
         rs.square() // rt
     }
 
+    fn sqr_n(&self, n: u32) -> Self {
+        assert!(n >= 1);
+        // Leave the accumulator unreduced between squarings and canonicalize
+        // once at the end of the chain.
+        Fp(portable::canonicalize(
+            &portable::sqr_n_lazy(&self.0, n, &MODULUS.0, INV),
+            &MODULUS.0,
+        ))
+    }
+
+    fn sqr_n_mul(&self, n: u32, by: &Self) -> Self {
+        assert!(n >= 1);
+        // Leave the accumulator unreduced between squarings. The closing
+        // multiplication canonicalizes its result.
+        Fp(portable::sqr_n_lazy(&self.0, n, &MODULUS.0, INV)).mul(by)
+    }
+
     fn get_lower_32(&self) -> u32 {
         // TODO: don't reduce, just hash the Montgomery form. (Requires rebuilding perfect hash table.)
         let tmp = Fp::montgomery_reduce(self.0[0], self.0[1], self.0[2], self.0[3], 0, 0, 0, 0);
@@ -854,6 +860,124 @@ fn test_pow_by_t_minus1_over2() {
     // NB: TWO_INV is standing in as a "random" field element
     let v = (Fp::TWO_INV).pow_by_t_minus1_over2();
     assert!(v == ff::Field::pow_vartime(&Fp::TWO_INV, T_MINUS1_OVER2));
+}
+
+#[test]
+fn low_half_reduction_matches_classical() {
+    use rand::SeedableRng;
+
+    let mut rng = rand_xorshift::XorShiftRng::from_seed([0x3c; 16]);
+    let classical =
+        |t: [u64; 8]| Fp::montgomery_reduce(t[0], t[1], t[2], t[3], t[4], t[5], t[6], t[7]);
+    let low_half = |t: [u64; 8]| {
+        Fp(super::portable::canonicalize(
+            &super::portable::montgomery_reduce_low_lazy(&t, &MODULUS.0, INV),
+            &MODULUS.0,
+        ))
+    };
+    // Any `t_lo + R * t_hi` with canonical `t_hi` is below `R * p`, the whole
+    // domain both reductions accept; squares and products are a subset.
+    for _ in 0..20_000 {
+        let hi = <Fp as ff::Field>::random(&mut rng);
+        let lo = <Fp as ff::Field>::random(&mut rng);
+        let t = [
+            lo.0[0], lo.0[1], lo.0[2], lo.0[3], hi.0[0], hi.0[1], hi.0[2], hi.0[3],
+        ];
+        assert_eq!(low_half(t), classical(t));
+        let a = <Fp as ff::Field>::random(&mut rng);
+        let u = a.square_unreduced();
+        assert_eq!(a.square(), classical(u));
+        assert_eq!(a.square(), low_half(u));
+    }
+
+    // Boundary values: zero, `R * (p - 1)`, an all-ones low half under both
+    // the largest canonical and a zero high half, and `(p - 1)^2`.
+    let max = -Fp::one();
+    let ones = [u64::MAX; 4];
+    for t in [
+        [0u64; 8],
+        [0, 0, 0, 0, max.0[0], max.0[1], max.0[2], max.0[3]],
+        [
+            ones[0], ones[1], ones[2], ones[3], max.0[0], max.0[1], max.0[2], max.0[3],
+        ],
+        [ones[0], ones[1], ones[2], ones[3], 0, 0, 0, 0],
+        max.square_unreduced(),
+    ] {
+        assert_eq!(low_half(t), classical(t));
+    }
+    assert_eq!(max.square(), classical(max.square_unreduced()));
+}
+
+#[test]
+fn sqr_n_chains_match_eager_squaring() {
+    use rand::SeedableRng;
+
+    let mut rng = rand_xorshift::XorShiftRng::from_seed([0x71; 16]);
+
+    // Test chains much longer than any production caller uses.
+    for _ in 0..100 {
+        let a = <Fp as ff::Field>::random(&mut rng);
+        let by = <Fp as ff::Field>::random(&mut rng);
+
+        let mut eager = a;
+        for n in 1..=512u32 {
+            eager = eager.square();
+            assert_eq!(a.sqr_n(n), eager, "sqr_n, n = {n}");
+            assert_eq!(a.sqr_n_mul(n, &by), eager * by, "sqr_n_mul, n = {n}");
+        }
+    }
+
+    assert_eq!(Fp::zero().sqr_n(7), Fp::zero());
+    assert_eq!(Fp::one().sqr_n_mul(7, &Fp::one()), Fp::one());
+}
+
+#[test]
+fn sqr_n_lazy_accumulator_stays_below_two_p() {
+    use rand::SeedableRng;
+
+    let mut rng = rand_xorshift::XorShiftRng::from_seed([0x9d; 16]);
+
+    let two_p = {
+        let (d0, c0) = MODULUS.0[0].overflowing_add(MODULUS.0[0]);
+        let (d1, c1) = MODULUS.0[1].overflowing_add(MODULUS.0[1]);
+        let (d1, c2) = d1.overflowing_add(c0 as u64);
+        let (d2, c3) = MODULUS.0[2].overflowing_add(MODULUS.0[2]);
+        let (d2, c4) = d2.overflowing_add((c1 | c2) as u64);
+        let d3 = MODULUS.0[3]
+            .wrapping_add(MODULUS.0[3])
+            .wrapping_add((c3 | c4) as u64);
+        [d0, d1, d2, d3]
+    };
+    let below_two_p = |x: &[u64; 4]| {
+        let mut i = 4;
+        while i > 0 {
+            i -= 1;
+            if x[i] != two_p[i] {
+                return x[i] < two_p[i];
+            }
+        }
+        false
+    };
+
+    // Exercise random starts and the largest canonical value.
+    for i in 0..51 {
+        let start = if i < 50 {
+            <Fp as ff::Field>::random(&mut rng).0
+        } else {
+            (-Fp::one()).0
+        };
+        let mut acc = start;
+        for n in 1..=2048u32 {
+            acc = portable::sqr_n_lazy(&acc, 1, &MODULUS.0, INV);
+            assert!(below_two_p(&acc), "accumulator reached 2p at step {n}");
+            if n.is_power_of_two() {
+                assert_eq!(
+                    Fp(portable::canonicalize(&acc, &MODULUS.0)),
+                    Fp(start).sqr_n(n)
+                );
+            }
+        }
+    }
 }
 
 #[test]

--- a/src/fields/fq.rs
+++ b/src/fields/fq.rs
@@ -11,6 +11,7 @@ use lazy_static::lazy_static;
 #[cfg(feature = "bits")]
 use ff::{FieldBits, PrimeFieldBits};
 
+use super::portable;
 use crate::arithmetic::{adc, mac, sbb, SqrtTableHelpers};
 #[cfg(feature = "deferred")]
 use crate::deferred::{DeferredField, Product};
@@ -310,8 +311,16 @@ impl Fq {
     /// Squares this element.
     #[cfg_attr(not(feature = "uninline-portable"), inline)]
     pub const fn square(&self) -> Fq {
-        let u = self.square_unreduced();
-        Fq::montgomery_reduce(u[0], u[1], u[2], u[3], u[4], u[5], u[6], u[7])
+        #[cfg(target_arch = "x86_64")]
+        {
+            Fq(portable::square(&self.0, &MODULUS.0, INV))
+        }
+
+        #[cfg(not(target_arch = "x86_64"))]
+        {
+            let u = self.square_unreduced();
+            Fq::montgomery_reduce(u[0], u[1], u[2], u[3], u[4], u[5], u[6], u[7])
+        }
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -447,35 +456,15 @@ impl Fq {
     }
 
     /// Squares this element, returning the unreduced 512-bit product.
+    /// On x86-64, `square` reduces the product's halves separately, so this
+    /// only feeds the `deferred` accumulator and the tests on that target.
+    #[cfg_attr(
+        all(target_arch = "x86_64", not(feature = "deferred")),
+        allow(dead_code)
+    )]
     #[cfg_attr(not(feature = "uninline-portable"), inline)]
     pub(crate) const fn square_unreduced(&self) -> [u64; 8] {
-        let (r1, carry) = mac(0, self.0[0], self.0[1], 0);
-        let (r2, carry) = mac(0, self.0[0], self.0[2], carry);
-        let (r3, r4) = mac(0, self.0[0], self.0[3], carry);
-
-        let (r3, carry) = mac(r3, self.0[1], self.0[2], 0);
-        let (r4, r5) = mac(r4, self.0[1], self.0[3], carry);
-
-        let (r5, r6) = mac(r5, self.0[2], self.0[3], 0);
-
-        let r7 = r6 >> 63;
-        let r6 = (r6 << 1) | (r5 >> 63);
-        let r5 = (r5 << 1) | (r4 >> 63);
-        let r4 = (r4 << 1) | (r3 >> 63);
-        let r3 = (r3 << 1) | (r2 >> 63);
-        let r2 = (r2 << 1) | (r1 >> 63);
-        let r1 = r1 << 1;
-
-        let (r0, carry) = mac(0, self.0[0], self.0[0], 0);
-        let (r1, carry) = adc(0, r1, carry);
-        let (r2, carry) = mac(r2, self.0[1], self.0[1], carry);
-        let (r3, carry) = adc(0, r3, carry);
-        let (r4, carry) = mac(r4, self.0[2], self.0[2], carry);
-        let (r5, carry) = adc(0, r5, carry);
-        let (r6, carry) = mac(r6, self.0[3], self.0[3], carry);
-        let (r7, _) = adc(0, r7, carry);
-
-        [r0, r1, r2, r3, r4, r5, r6, r7]
+        portable::square_wide(&self.0)
     }
 }
 
@@ -762,7 +751,24 @@ impl SqrtTableHelpers for Fq {
         let sq = sqr(sp, 4) * s111;
         let sr = sqr(sq, 5) * s1011;
         let ss = sqr(sr, 3) * self;
-        sqr(ss, 4) // st
+        ss.sqr_n(4) // st
+    }
+
+    fn sqr_n(&self, n: u32) -> Self {
+        assert!(n >= 1);
+        // Leave the accumulator unreduced between squarings and canonicalize
+        // once at the end of the chain.
+        Fq(portable::canonicalize(
+            &portable::sqr_n_lazy(&self.0, n, &MODULUS.0, INV),
+            &MODULUS.0,
+        ))
+    }
+
+    fn sqr_n_mul(&self, n: u32, by: &Self) -> Self {
+        assert!(n >= 1);
+        // Leave the accumulator unreduced between squarings. The closing
+        // multiplication canonicalizes its result.
+        Fq(portable::sqr_n_lazy(&self.0, n, &MODULUS.0, INV)).mul(by)
     }
 
     fn get_lower_32(&self) -> u32 {
@@ -846,6 +852,124 @@ fn test_sqrt() {
 #[test]
 fn test_sqrt_32bit_overflow() {
     assert!((Fq::from(5)).sqrt().is_none().unwrap_u8() == 1);
+}
+
+#[test]
+fn low_half_reduction_matches_classical() {
+    use rand::SeedableRng;
+
+    let mut rng = rand_xorshift::XorShiftRng::from_seed([0x3c; 16]);
+    let classical =
+        |t: [u64; 8]| Fq::montgomery_reduce(t[0], t[1], t[2], t[3], t[4], t[5], t[6], t[7]);
+    let low_half = |t: [u64; 8]| {
+        Fq(super::portable::canonicalize(
+            &super::portable::montgomery_reduce_low_lazy(&t, &MODULUS.0, INV),
+            &MODULUS.0,
+        ))
+    };
+    // Any `t_lo + R * t_hi` with canonical `t_hi` is below `R * q`, the whole
+    // domain both reductions accept; squares and products are a subset.
+    for _ in 0..20_000 {
+        let hi = <Fq as ff::Field>::random(&mut rng);
+        let lo = <Fq as ff::Field>::random(&mut rng);
+        let t = [
+            lo.0[0], lo.0[1], lo.0[2], lo.0[3], hi.0[0], hi.0[1], hi.0[2], hi.0[3],
+        ];
+        assert_eq!(low_half(t), classical(t));
+        let a = <Fq as ff::Field>::random(&mut rng);
+        let u = a.square_unreduced();
+        assert_eq!(a.square(), classical(u));
+        assert_eq!(a.square(), low_half(u));
+    }
+
+    // Boundary values: zero, `R * (q - 1)`, an all-ones low half under both
+    // the largest canonical and a zero high half, and `(q - 1)^2`.
+    let max = -Fq::one();
+    let ones = [u64::MAX; 4];
+    for t in [
+        [0u64; 8],
+        [0, 0, 0, 0, max.0[0], max.0[1], max.0[2], max.0[3]],
+        [
+            ones[0], ones[1], ones[2], ones[3], max.0[0], max.0[1], max.0[2], max.0[3],
+        ],
+        [ones[0], ones[1], ones[2], ones[3], 0, 0, 0, 0],
+        max.square_unreduced(),
+    ] {
+        assert_eq!(low_half(t), classical(t));
+    }
+    assert_eq!(max.square(), classical(max.square_unreduced()));
+}
+
+#[test]
+fn sqr_n_chains_match_eager_squaring() {
+    use rand::SeedableRng;
+
+    let mut rng = rand_xorshift::XorShiftRng::from_seed([0x71; 16]);
+
+    // Test chains much longer than any production caller uses.
+    for _ in 0..100 {
+        let a = <Fq as ff::Field>::random(&mut rng);
+        let by = <Fq as ff::Field>::random(&mut rng);
+
+        let mut eager = a;
+        for n in 1..=512u32 {
+            eager = eager.square();
+            assert_eq!(a.sqr_n(n), eager, "sqr_n, n = {n}");
+            assert_eq!(a.sqr_n_mul(n, &by), eager * by, "sqr_n_mul, n = {n}");
+        }
+    }
+
+    assert_eq!(Fq::zero().sqr_n(7), Fq::zero());
+    assert_eq!(Fq::one().sqr_n_mul(7, &Fq::one()), Fq::one());
+}
+
+#[test]
+fn sqr_n_lazy_accumulator_stays_below_two_q() {
+    use rand::SeedableRng;
+
+    let mut rng = rand_xorshift::XorShiftRng::from_seed([0x9d; 16]);
+
+    let two_q = {
+        let (d0, c0) = MODULUS.0[0].overflowing_add(MODULUS.0[0]);
+        let (d1, c1) = MODULUS.0[1].overflowing_add(MODULUS.0[1]);
+        let (d1, c2) = d1.overflowing_add(c0 as u64);
+        let (d2, c3) = MODULUS.0[2].overflowing_add(MODULUS.0[2]);
+        let (d2, c4) = d2.overflowing_add((c1 | c2) as u64);
+        let d3 = MODULUS.0[3]
+            .wrapping_add(MODULUS.0[3])
+            .wrapping_add((c3 | c4) as u64);
+        [d0, d1, d2, d3]
+    };
+    let below_two_q = |x: &[u64; 4]| {
+        let mut i = 4;
+        while i > 0 {
+            i -= 1;
+            if x[i] != two_q[i] {
+                return x[i] < two_q[i];
+            }
+        }
+        false
+    };
+
+    // Exercise random starts and the largest canonical value.
+    for i in 0..51 {
+        let start = if i < 50 {
+            <Fq as ff::Field>::random(&mut rng).0
+        } else {
+            (-Fq::one()).0
+        };
+        let mut acc = start;
+        for n in 1..=2048u32 {
+            acc = portable::sqr_n_lazy(&acc, 1, &MODULUS.0, INV);
+            assert!(below_two_q(&acc), "accumulator reached 2q at step {n}");
+            if n.is_power_of_two() {
+                assert_eq!(
+                    Fq(portable::canonicalize(&acc, &MODULUS.0)),
+                    Fq(start).sqr_n(n)
+                );
+            }
+        }
+    }
 }
 
 #[test]

--- a/src/fields/portable.rs
+++ b/src/fields/portable.rs
@@ -1,0 +1,307 @@
+//! Shared portable squaring for the Pasta fields.
+//!
+//! `Fp` and `Fq` have the same representation (four little-endian `u64`
+//! limbs in Montgomery form with `R = 2^256`), so their pure-Rust squaring
+//! routines are written once here over limb arrays. Each field keeps its own
+//! modulus and Montgomery reduction wrapper.
+
+use crate::arithmetic::{adc, mac, sbb};
+
+#[cfg_attr(not(feature = "sqrt-table"), allow(dead_code))]
+#[cfg(target_arch = "x86_64")]
+const PASTA_MODULUS_TOP_SHIFT: u32 = 62;
+#[cfg_attr(not(feature = "sqrt-table"), allow(dead_code))]
+#[cfg(target_arch = "x86_64")]
+const PASTA_MODULUS_TOP_OVERFLOW_SHIFT: u32 = u64::BITS - PASTA_MODULUS_TOP_SHIFT;
+
+/// Squares a canonical element, returning the canonical square.
+#[cfg(target_arch = "x86_64")]
+#[cfg_attr(not(feature = "uninline-portable"), inline)]
+pub(super) const fn square(value: &[u64; 4], modulus: &[u64; 4], inv: u64) -> [u64; 4] {
+    canonicalize(
+        &montgomery_reduce_low_lazy(&square_wide(value), modulus, inv),
+        modulus,
+    )
+}
+
+/// Squares `value`, returning the unreduced 512-bit product.
+#[cfg_attr(not(feature = "uninline-portable"), inline)]
+pub(super) const fn square_wide(value: &[u64; 4]) -> [u64; 8] {
+    let (r1, carry) = mac(0, value[0], value[1], 0);
+    let (r2, carry) = mac(0, value[0], value[2], carry);
+    let (r3, r4) = mac(0, value[0], value[3], carry);
+
+    let (r3, carry) = mac(r3, value[1], value[2], 0);
+    let (r4, r5) = mac(r4, value[1], value[3], carry);
+
+    let (r5, r6) = mac(r5, value[2], value[3], 0);
+
+    let r7 = r6 >> 63;
+    let r6 = (r6 << 1) | (r5 >> 63);
+    let r5 = (r5 << 1) | (r4 >> 63);
+    let r4 = (r4 << 1) | (r3 >> 63);
+    let r3 = (r3 << 1) | (r2 >> 63);
+    let r2 = (r2 << 1) | (r1 >> 63);
+    let r1 = r1 << 1;
+
+    let (r0, carry) = mac(0, value[0], value[0], 0);
+    let (r1, carry) = adc(0, r1, carry);
+    let (r2, carry) = mac(r2, value[1], value[1], carry);
+    let (r3, carry) = adc(0, r3, carry);
+    let (r4, carry) = mac(r4, value[2], value[2], carry);
+    let (r5, carry) = adc(0, r5, carry);
+    let (r6, carry) = mac(r6, value[3], value[3], carry);
+    let (r7, _) = adc(0, r7, carry);
+
+    [r0, r1, r2, r3, r4, r5, r6, r7]
+}
+
+/// The four cancellation rounds of the Montgomery reduction of a 512-bit
+/// value `t < R * modulus`, yielding a value below `2 * modulus`.
+///
+/// This is a macro rather than a helper function on purpose: an extra
+/// function layer here, even an `inline(always)` one, changes LLVM's
+/// inlining decisions for the multiplication that expands it.
+#[cfg(not(target_arch = "x86_64"))]
+macro_rules! montgomery_rounds {
+    ($t:expr, $modulus:expr, $inv:expr) => {{
+        let [r0, r1, r2, r3, r4, r5, r6, r7] = *$t;
+        let modulus: &[u64; 4] = $modulus;
+        let inv: u64 = $inv;
+
+        let k = r0.wrapping_mul(inv);
+        let (_, carry) = mac(r0, k, modulus[0], 0);
+        let (r1, carry) = mac(r1, k, modulus[1], carry);
+        let (r2, carry) = mac(r2, k, modulus[2], carry);
+        let (r3, carry) = mac(r3, k, modulus[3], carry);
+        let (r4, carry2) = adc(r4, 0, carry);
+
+        let k = r1.wrapping_mul(inv);
+        let (_, carry) = mac(r1, k, modulus[0], 0);
+        let (r2, carry) = mac(r2, k, modulus[1], carry);
+        let (r3, carry) = mac(r3, k, modulus[2], carry);
+        let (r4, carry) = mac(r4, k, modulus[3], carry);
+        let (r5, carry2) = adc(r5, carry2, carry);
+
+        let k = r2.wrapping_mul(inv);
+        let (_, carry) = mac(r2, k, modulus[0], 0);
+        let (r3, carry) = mac(r3, k, modulus[1], carry);
+        let (r4, carry) = mac(r4, k, modulus[2], carry);
+        let (r5, carry) = mac(r5, k, modulus[3], carry);
+        let (r6, carry2) = adc(r6, carry2, carry);
+
+        let k = r3.wrapping_mul(inv);
+        let (_, carry) = mac(r3, k, modulus[0], 0);
+        let (r4, carry) = mac(r4, k, modulus[1], carry);
+        let (r5, carry) = mac(r5, k, modulus[2], carry);
+        let (r6, carry) = mac(r6, k, modulus[3], carry);
+        let (r7, _) = adc(r7, carry2, carry);
+
+        [r4, r5, r6, r7]
+    }};
+}
+
+/// Montgomery-reduces a 512-bit value `t < R * modulus` by cancelling its low
+/// half first, returning a result below `2 * modulus`.
+///
+/// The Montgomery quotient `Q` depends only on the low 256 bits of `t`, and
+/// `(t + Q * modulus) / R == (t_lo + Q * modulus) / R + t_hi` exactly, so the
+/// four cancellation rounds can run over four live limbs instead of eight and
+/// the high half is added once at the end. This is how the assembly backend's
+/// squaring and its `mul_by_1` helper are structured. The value produced is
+/// the same as the classical reduction's, limb for limb; only the dependency
+/// graph differs.
+///
+/// `(t_lo + Q * modulus) / R <= modulus` and `t_hi < modulus`, so the sum is
+/// below `2 * modulus` and fits in four limbs.
+#[cfg(any(target_arch = "x86_64", test))]
+#[cfg_attr(not(feature = "uninline-portable"), inline(always))]
+pub(super) const fn montgomery_reduce_low_lazy(
+    t: &[u64; 8],
+    modulus: &[u64; 4],
+    inv: u64,
+) -> [u64; 4] {
+    debug_assert!(modulus[2] == 0);
+
+    let [r0, r1, r2, r3, t4, t5, t6, t7] = *t;
+
+    // Each round chooses k so that the lowest live limb plus k * modulus[0]
+    // vanishes modulo 2^64, adds k * modulus, and drops that limb. The
+    // carry out of the top limb becomes the new top limb. Both Pasta moduli
+    // have a zero third limb, so that product is only a carry propagation.
+    let k = r0.wrapping_mul(inv);
+    let (_, carry) = mac(r0, k, modulus[0], 0);
+    let (r0, carry) = mac(r1, k, modulus[1], carry);
+    let (r1, carry) = adc(r2, 0, carry);
+    let (r2, r3) = mac(r3, k, modulus[3], carry);
+
+    let k = r0.wrapping_mul(inv);
+    let (_, carry) = mac(r0, k, modulus[0], 0);
+    let (r0, carry) = mac(r1, k, modulus[1], carry);
+    let (r1, carry) = adc(r2, 0, carry);
+    let (r2, r3) = mac(r3, k, modulus[3], carry);
+
+    let k = r0.wrapping_mul(inv);
+    let (_, carry) = mac(r0, k, modulus[0], 0);
+    let (r0, carry) = mac(r1, k, modulus[1], carry);
+    let (r1, carry) = adc(r2, 0, carry);
+    let (r2, r3) = mac(r3, k, modulus[3], carry);
+
+    let k = r0.wrapping_mul(inv);
+    let (_, carry) = mac(r0, k, modulus[0], 0);
+    let (r0, carry) = mac(r1, k, modulus[1], carry);
+    let (r1, carry) = adc(r2, 0, carry);
+    let (r2, r3) = mac(r3, k, modulus[3], carry);
+
+    // Add the high half; the sum is below 2 * modulus, so no carry out.
+    let (r0, carry) = adc(r0, t4, 0);
+    let (r1, carry) = adc(r1, t5, carry);
+    let (r2, carry) = adc(r2, t6, carry);
+    let (r3, _) = adc(r3, t7, carry);
+
+    [r0, r1, r2, r3]
+}
+
+/// Adds `k * 2^62` to `value` and `carry`, returning the low and high limbs.
+#[cfg_attr(not(feature = "sqrt-table"), allow(dead_code))]
+#[cfg(target_arch = "x86_64")]
+#[inline(always)]
+const fn mac_pasta_modulus_top(value: u64, k: u64, carry: u64) -> (u64, u64) {
+    let (low, carry) = adc(value, k << PASTA_MODULUS_TOP_SHIFT, carry);
+    (low, (k >> PASTA_MODULUS_TOP_OVERFLOW_SHIFT) + carry)
+}
+
+/// Squares and lazily reduces while interleaving independent upper-half work.
+#[cfg_attr(not(feature = "sqrt-table"), allow(dead_code))]
+#[cfg(target_arch = "x86_64")]
+#[inline(always)]
+const fn square_reduce_lazy_pasta(value: &[u64; 4], modulus: &[u64; 4], inv: u64) -> [u64; 4] {
+    debug_assert!(modulus[2] == 0);
+    debug_assert!(modulus[3] == 1 << PASTA_MODULUS_TOP_SHIFT);
+
+    let [a0, a1, a2, a3] = *value;
+
+    // Form the low off-diagonal limbs first. The remaining two products do
+    // not affect the low half, so LLVM can overlap them with its reduction.
+    let (r1, carry) = mac(0, a0, a1, 0);
+    let (r2, carry) = mac(0, a0, a2, carry);
+    let (r3, r4) = mac(0, a0, a3, carry);
+    let (r3, cross_carry) = mac(r3, a1, a2, 0);
+
+    let d3 = (r3 << 1) | (r2 >> 63);
+    let d2 = (r2 << 1) | (r1 >> 63);
+    let d1 = r1 << 1;
+
+    let (t0, carry) = mac(0, a0, a0, 0);
+    let (t1, carry) = adc(0, d1, carry);
+    let (t2, carry) = mac(d2, a1, a1, carry);
+    let (t3, square_carry) = adc(0, d3, carry);
+
+    let k = t0.wrapping_mul(inv);
+    let (_, carry) = mac(t0, k, modulus[0], 0);
+    let (q0, carry) = mac(t1, k, modulus[1], carry);
+    let (q1, carry) = adc(t2, 0, carry);
+    let (q2, q3) = mac_pasta_modulus_top(t3, k, carry);
+
+    let k = q0.wrapping_mul(inv);
+    let (_, carry) = mac(q0, k, modulus[0], 0);
+    let (q0, carry) = mac(q1, k, modulus[1], carry);
+    let (q1, carry) = adc(q2, 0, carry);
+    let (q2, q3) = mac_pasta_modulus_top(q3, k, carry);
+
+    let k = q0.wrapping_mul(inv);
+    let (_, carry) = mac(q0, k, modulus[0], 0);
+    let (q0, carry) = mac(q1, k, modulus[1], carry);
+    let (q1, carry) = adc(q2, 0, carry);
+    let (q2, q3) = mac_pasta_modulus_top(q3, k, carry);
+
+    let k = q0.wrapping_mul(inv);
+    let (_, carry) = mac(q0, k, modulus[0], 0);
+    let (q0, carry) = mac(q1, k, modulus[1], carry);
+    let (q1, carry) = adc(q2, 0, carry);
+    let (q2, q3) = mac_pasta_modulus_top(q3, k, carry);
+
+    // Complete the upper off-diagonal limbs and add the diagonal products.
+    let (r4, r5) = mac(r4, a1, a3, cross_carry);
+    let (r5, r6) = mac(r5, a2, a3, 0);
+    let r7 = r6 >> 63;
+    let r6 = (r6 << 1) | (r5 >> 63);
+    let r5 = (r5 << 1) | (r4 >> 63);
+    let r4 = (r4 << 1) | (r3 >> 63);
+
+    let (t4, carry) = mac(r4, a2, a2, square_carry);
+    let (t5, carry) = adc(0, r5, carry);
+    let (t6, carry) = mac(r6, a3, a3, carry);
+    let (t7, _) = adc(0, r7, carry);
+
+    let (q0, carry) = adc(q0, t4, 0);
+    let (q1, carry) = adc(q1, t5, carry);
+    let (q2, carry) = adc(q2, t6, carry);
+    let (q3, _) = adc(q3, t7, carry);
+
+    [q0, q1, q2, q3]
+}
+
+/// Reduces the product of a squaring to a value below `2 * modulus`.
+#[cfg_attr(not(feature = "uninline-portable"), inline(always))]
+#[cfg_attr(not(feature = "sqrt-table"), allow(dead_code))]
+#[cfg(not(target_arch = "x86_64"))]
+const fn reduce_square_lazy(t: &[u64; 8], modulus: &[u64; 4], inv: u64) -> [u64; 4] {
+    montgomery_rounds!(t, modulus, inv)
+}
+
+/// Subtracts `modulus` from a value below `2 * modulus` if that does not
+/// underflow, which makes the value canonical.
+#[cfg_attr(
+    all(not(target_arch = "x86_64"), not(feature = "sqrt-table")),
+    allow(dead_code)
+)]
+#[cfg_attr(not(feature = "uninline-portable"), inline(always))]
+pub(super) const fn canonicalize(value: &[u64; 4], modulus: &[u64; 4]) -> [u64; 4] {
+    let (d0, borrow) = sbb(value[0], modulus[0], 0);
+    let (d1, borrow) = sbb(value[1], modulus[1], borrow);
+    let (d2, borrow) = sbb(value[2], modulus[2], borrow);
+    let (d3, borrow) = sbb(value[3], modulus[3], borrow);
+
+    let (d0, carry) = adc(d0, modulus[0] & borrow, 0);
+    let (d1, carry) = adc(d1, modulus[1] & borrow, carry);
+    let (d2, carry) = adc(d2, modulus[2] & borrow, carry);
+    let (d3, _) = adc(d3, modulus[3] & borrow, carry);
+
+    [d0, d1, d2, d3]
+}
+
+/// Squares `value` `n` times while keeping the accumulator below
+/// `2 * modulus`, instead of canonicalizing after every squaring.
+///
+/// A Montgomery reduction accepts an input below `R * m`. If an accumulator
+/// is below `c * m`, the next one is below `(1 + c^2 * m / R) * m`. Starting
+/// from a canonical value, this bound approaches `2 * m` from below. For both
+/// Pasta moduli, reaching the reduction's limit would require more than
+/// `2^131` squarings, while `n` is a `u32`.
+///
+/// The result must be canonicalized by the caller, either with
+/// [`canonicalize`] or by multiplying it by a canonical value. The latter
+/// product is below `2 * m^2 < R * m`, so the multiplication's reduction
+/// accepts it and returns a canonical result.
+#[cfg_attr(not(feature = "sqrt-table"), allow(dead_code))]
+#[cfg_attr(target_arch = "x86_64", inline(never))]
+#[cfg_attr(
+    all(not(target_arch = "x86_64"), not(feature = "uninline-portable")),
+    inline
+)]
+pub(super) fn sqr_n_lazy(value: &[u64; 4], n: u32, modulus: &[u64; 4], inv: u64) -> [u64; 4] {
+    let mut acc = *value;
+    for _ in 0..n {
+        #[cfg(target_arch = "x86_64")]
+        {
+            acc = square_reduce_lazy_pasta(&acc, modulus, inv);
+        }
+
+        #[cfg(not(target_arch = "x86_64"))]
+        {
+            acc = reduce_square_lazy(&square_wide(&acc), modulus, inv);
+        }
+    }
+    acc
+}


### PR DESCRIPTION
Ports one commit from the public fork at
https://github.com/zakura-core/libraries, `d2419d5`, which optimises
squaring on the portable (pure Rust) Pasta field paths.

Source commit:
https://github.com/zakura-core/libraries/commit/d2419d50b1499922f24c10f3d751d47969b0e8de

## What it does

Three related changes, in the order the source commit made them.

1. **Share the wide-squaring routine.** `Fp::square_unreduced` and
   `Fq::square_unreduced` held byte-identical schoolbook squaring code.
   Both now delegate to a new private `fields::portable` module that works
   over `[u64; 4]` limb arrays. The two fields have the same
   representation (four little-endian limbs, Montgomery form, `R = 2^256`)
   and each keeps its own modulus and reduction wrapper. No arithmetic
   changes.

2. **Low-half reduction for squaring on x86-64.** The Montgomery quotient
   depends only on the low 256 bits of the product, and
   `(t + Q * m) / R == (t_lo + Q * m) / R + t_hi` holds exactly. So the
   four cancellation rounds can run over four live limbs instead of eight,
   with the high half added once at the end. Selected only on
   `target_arch = "x86_64"`; every other target keeps the classical
   reduction. Multiplication is untouched.

3. **Skip corrections inside squaring chains.** A Montgomery reduction
   accepts any input below `R * m`. An accumulator below `c * m` produces
   a next one below `(1 + c^2 * m / R) * m`, so starting canonical the
   bound approaches `2 * m` from below and never reaches it: for both
   Pasta moduli that would need more than `2^131` squarings, and the count
   is a `u32`. A repeated-squaring chain can therefore leave the
   accumulator unreduced throughout and canonicalize once at the end, or
   not at all when a multiplication by a canonical value closes it (the
   product is below `2 * m^2 < R * m`).

   This is exposed as two new default methods on the internal
   `SqrtTableHelpers` trait, `sqr_n` and `sqr_n_mul`, with a naive
   fold as the default; `Fp` and `Fq` override them with the lazy
   version. The square-root table code (`sqrt_ratio`, `sqrt_common`, and
   `Fq::pow_by_t_minus1_over2`'s tail) calls them in place of its
   hand-rolled `sqr` closures.

Nothing in the public API changes. All three are internal.

## This is a port, and what was adapted

`git am --3way` cannot apply the patch, since the fork's preimage blobs do
not exist here. It was applied with `git apply --reject`, leaving ten
rejected hunks. The commit message records each one; in summary:

* `src/fields.rs` and `src/arithmetic/fields.rs`, one hunk each, rejected
  only because the fork's module list and trait carry members this
  repository does not have. Both re-sited verbatim.
* `src/fields/fp.rs` and `src/fields/fq.rs`, four hunks each. The fork
  routes these chains through inherent `sqr_n_runtime` and
  `sqr_n_mul_runtime` helpers whose only job is to switch between an
  Apple AArch64 assembly backend and the portable path. That backend is
  not in this repository, so the portable bodies were placed directly in
  the `SqrtTableHelpers` impls, as the overrides the fork forwards to them
  from. The bodies themselves are unchanged.
* One hunk per field is **dropped**: it edits a `pow_vartime` that batches
  consecutive squarings into a single chain, which comes from a different
  commit in the fork and is not here. This repository's `pow_vartime`
  squares once per exponent bit, so it has no run of squarings to hand to
  `sqr_n`. Nothing else depends on it.
* `src/fields/portable.rs` is new and landed whole, then was edited twice:
  its `allow(dead_code)` guards keyed on an `aarch64-asm` feature were
  removed, since this repository declares no such feature and
  `cfg(feature = "aarch64-asm")` would trip `unexpected_cfgs`; and guards
  keyed on `sqrt-table` were added, because without that feature nothing
  calls `sqr_n_lazy` and `--no-default-features` would warn about dead
  code.

## Verification

The source commit brings six tests, three per field, and they are the
substance of the review here rather than an afterthought:

* `low_half_reduction_matches_classical` is a differential test of change
  2 against the existing classical `montgomery_reduce`. 20,000 random
  `t_lo + R * t_hi` inputs spanning the whole domain both reductions
  accept, plus the boundary set: zero, `R * (m - 1)`, an all-ones low half
  under both the largest canonical and a zero high half, and `(m - 1)^2`.
* `sqr_n_chains_match_eager_squaring` is a differential test of change 3
  against eager per-step squaring, over chains of length 1 to 512, which
  is far longer than any caller uses, for 100 random starts, plus zero and
  one.
* `sqr_n_lazy_accumulator_stays_below_two_p` (`_two_q`) asserts the
  bound the optimisation rests on directly: 2048 successive lazy squarings
  from 50 random starts and from `m - 1`, checking after every step that
  the accumulator is below `2 * m`, and checking at each power of two that
  canonicalizing it agrees with `sqr_n`.

`montgomery_reduce_low_lazy` is compiled under `cfg(any(target_arch =
"x86_64", test))` precisely so the first of those runs everywhere.

Ran locally, all green, on **both** an x86-64 and an AArch64 target, in
debug and release, so the x86-64-only paths introduced by change 2 and by
the specialised lazy reducer are actually executed and not merely
type-checked:

```
cargo test [--release] --target {x86_64-apple-darwin,aarch64-apple-darwin} \
    [--all-features | --no-default-features]
```

Also `cargo check --target i686-unknown-linux-gnu --all-targets` (the
32-bit job), `cargo build --no-default-features` for `thumbv6m-none-eabi`,
`wasm32-unknown-unknown` and `wasm32-wasip1`, `cargo build --benches
--all-features`, `cargo doc --all-features --document-private-items`,
`cargo fmt -- --check`, and `cargo clippy --all-targets --all-features --
-D warnings`.

The warning set is unchanged from `main` in every one of those
configurations; the change adds none. (`--no-default-features` has four
pre-existing dead-code and unused-import warnings on `main`, unrelated to
this.)

Benchmark numbers are not claimed here. The change is argued from the
dependency shape and the reduction bound, and pinned by the differential
tests above.

## Relationship to #100

#100 (the AArch64 assembly backend) has a `sqr_n_runtime` whose non-Apple
arm is a semantically equivalent but slower fold, written that way only
because this module was not upstream yet. Once this lands, that fold
becomes a call to `portable::sqr_n_lazy` and `portable::canonicalize`, a
three-line follow-up on that branch, with #100's existing differential
test proving the two agree. The two pull requests are deliberately
separate: #100 already carries the risk of rewriting `pow_vartime` for
every target, and this one changes non-Apple squaring, so bundling them
would compound the same dimension for the same reviewer.

The changelog entry is in its own commit, as CI requires.
