### PR TITLE
Extend the AArch64 Pasta field backend to Unix targets, and to addition, subtraction and doubling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
     strategy:
       matrix:
         target:
+          - aarch64-unknown-none
           - thumbv6m-none-eabi
           - wasm32-unknown-unknown
           - wasm32-wasip1
@@ -70,12 +71,7 @@ jobs:
           --no-default-features
 
   aarch64-asm:
-    name: Apple AArch64 assembly backend
-    # macos-latest is Apple silicon, which is the only target the
-    # `aarch64-asm` feature actually compiles assembly for. The `test`
-    # matrix reaches this code through `--all-features`; this job pins the
-    # feature on its own, so a break is attributed rather than buried in a
-    # combined run, and so the backend's tests are known to have run.
+    name: AArch64 assembly backend (Apple, Mach-O)
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -98,6 +94,34 @@ jobs:
             fields::fq::aarch64_asm_matches_portable_arithmetic)
           echo "$out"
           echo "$out" | grep -q '2 passed'
+      - name: Verify working directory is clean
+        run: git diff --exit-code
+
+  aarch64-asm-linux:
+    name: AArch64 assembly backend (Linux, ELF)
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Confirm the runner is AArch64 Linux
+        run: test "$(uname -sm)" = "Linux aarch64"
+      - name: Build with the assembly backend
+        run: cargo build --verbose --features aarch64-asm
+      - name: Run tests with the assembly backend
+        run: cargo test --verbose --release --features aarch64-asm
+      - name: Confirm the backend's own tests ran
+        run: |
+          out=$(cargo test --release --features aarch64-asm -- --exact \
+            fields::fp::aarch64_asm_matches_portable_arithmetic \
+            fields::fq::aarch64_asm_matches_portable_arithmetic)
+          echo "$out"
+          echo "$out" | grep -q '2 passed'
+      - name: Build the assembly backend for bare-metal AArch64
+        run: |
+          rustup target add aarch64-unknown-none
+          cargo build --verbose --no-default-features \
+            --features aarch64-asm --target aarch64-unknown-none
       - name: Verify working directory is clean
         run: git diff --exit-code
 
@@ -173,6 +197,7 @@ jobs:
       - test-32-bit
       - no-std
       - aarch64-asm
+      - aarch64-asm-linux
       - bitrot
     # `always()` is load-bearing: without it this job is skipped when a
     # needed job fails, and GitHub treats a skipped required check as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to Rust's notion of
 
 ## [Unreleased]
 ### Added
+- Assembly-backed field addition, subtraction and doubling for the
+  `aarch64-asm` backend, alongside the existing multiplication and squaring.
+  The `Add`, `Sub` and `ff::Field::double` operators route through inline
+  assembly; the inherent `const` methods are unchanged.
 - An assembly implementation of Pallas and Vesta base and scalar field
   multiplication, squaring and Montgomery reduction for Apple AArch64, behind
   the new `aarch64-asm` feature flag. The feature is opt-in and has no effect
@@ -27,6 +31,27 @@ and this project adheres to Rust's notion of
   the simplified SWU and isogeny formulas, which produce on-curve points by
   construction; the debug assertions are retained. About 5% faster for Vesta
   hash-to-curve on Apple AArch64.
+- The `aarch64-asm` backend now builds on 64-bit little-endian Unix AArch64
+  targets, not only Apple ones, emitting Mach-O or ELF symbol directives as
+  the target requires. The gate is a conjunction of the properties the
+  assembly actually depends on, so ILP32 and big-endian AArch64
+  configurations continue to use the portable implementation, as does every
+  non-AArch64 target. Performance was measured on Apple M4; other cores are
+  expected, but not verified, to benefit.
+- Portable squaring chains no longer canonicalize after every squaring,
+  including the trailing squarings in variable-time exponentiation. The
+  square-root tables use the chains on every architecture. The x86-64 path
+  additionally reduces the low half of its product first and adds the high
+  half once, as the assembly backend does, keeping four limbs live through
+  the cancellation rounds instead of eight. Other targets retain their
+  existing classical reduction, and multiplication is unchanged.
+- The portable wide-squaring routine for `Fp` and `Fq` now lives in a shared
+  `fields::portable` module. Both fields delegate to the same limb-array
+  implementation; the algorithm and the generated operations are unchanged.
+- The `aarch64-asm` repeated-squaring chains keep their lazy accumulator in
+  registers and canonicalize only once. On Apple M4, chains of 2 to 128
+  squares are 6 to 13 percent faster; the fused square-and-multiply chains
+  are unchanged.
 - `Fp::pow_vartime` and `Fq::pow_vartime` now fuse each run of squarings with
   the following multiplication. The sequence of field operations (and thus
   the variable-time profile, which depends only on the exponent) is
@@ -45,6 +70,10 @@ and this project adheres to Rust's notion of
   supplies); the assembly wrappers now debug-assert it, since a violation
   would yield an incorrect residue rather than a merely non-canonical one.
 - MSRV is now 1.88.0.
+
+### Security
+- The `aarch64-asm` backend preserves BTI hardening metadata and declares a
+  non-executable stack when linked into ELF applications.
 
 ## [0.5.2] - 2026-07-23
 ### Added

--- a/benches/point.rs
+++ b/benches/point.rs
@@ -1,6 +1,6 @@
 //! Benchmarks for point operations.
 
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
 use pasta_curves::arithmetic::CurveExt;
 use pasta_curves::{pallas, vesta};
@@ -21,6 +21,23 @@ fn point_bench<C: CurveExt>(c: &mut Criterion, name: &str) {
     group.bench_function("point addition", |bencher| bencher.iter(|| a + b));
 
     group.bench_function("point subtraction", |bencher| bencher.iter(|| a - b));
+
+    // Dependent operations exercise changing projective coordinates and keep
+    // the arithmetic inside the timed loop even under aggressive inlining.
+    group.bench_function("point doubling serial", |bencher| {
+        let mut point = a;
+        bencher.iter(|| {
+            point = black_box(point).double();
+            black_box(point)
+        });
+    });
+    group.bench_function("point addition serial", |bencher| {
+        let mut point = a;
+        bencher.iter(|| {
+            point = black_box(point) + black_box(b);
+            black_box(point)
+        });
+    });
 
     group.bench_function("point to_bytes", |bencher| bencher.iter(|| a.to_bytes()));
 

--- a/build.rs
+++ b/build.rs
@@ -11,10 +11,15 @@ fn main() {
 #[cfg(feature = "aarch64-asm")]
 fn build_aarch64_asm() {
     let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+    let target_endian = env::var("CARGO_CFG_TARGET_ENDIAN").unwrap();
     let target_family = env::var("CARGO_CFG_TARGET_FAMILY").unwrap();
     let target_pointer_width = env::var("CARGO_CFG_TARGET_POINTER_WIDTH").unwrap();
 
-    if target_arch == "aarch64" && target_family == "unix" && target_pointer_width == "64" {
+    if target_arch == "aarch64"
+        && target_endian == "little"
+        && target_family == "unix"
+        && target_pointer_width == "64"
+    {
         cc::Build::new()
             .file("src/asm/pasta_mul-armv8.S")
             .compile("pasta_curves_aarch64");

--- a/build.rs
+++ b/build.rs
@@ -11,9 +11,9 @@ fn main() {
 #[cfg(feature = "aarch64-asm")]
 fn build_aarch64_asm() {
     let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
-    let target_vendor = env::var("CARGO_CFG_TARGET_VENDOR").unwrap();
+    let target_family = env::var("CARGO_CFG_TARGET_FAMILY").unwrap();
 
-    if target_arch == "aarch64" && target_vendor == "apple" {
+    if target_arch == "aarch64" && target_family == "unix" {
         cc::Build::new()
             .file("src/asm/pasta_mul-armv8.S")
             .compile("pasta_curves_aarch64");

--- a/build.rs
+++ b/build.rs
@@ -12,8 +12,9 @@ fn main() {
 fn build_aarch64_asm() {
     let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
     let target_family = env::var("CARGO_CFG_TARGET_FAMILY").unwrap();
+    let target_pointer_width = env::var("CARGO_CFG_TARGET_POINTER_WIDTH").unwrap();
 
-    if target_arch == "aarch64" && target_family == "unix" {
+    if target_arch == "aarch64" && target_family == "unix" && target_pointer_width == "64" {
         cc::Build::new()
             .file("src/asm/pasta_mul-armv8.S")
             .compile("pasta_curves_aarch64");

--- a/build.rs
+++ b/build.rs
@@ -12,12 +12,16 @@ fn main() {
 fn build_aarch64_asm() {
     let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
     let target_endian = env::var("CARGO_CFG_TARGET_ENDIAN").unwrap();
-    let target_family = env::var("CARGO_CFG_TARGET_FAMILY").unwrap();
+    let target_family = env::var("CARGO_CFG_TARGET_FAMILY").ok();
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
     let target_pointer_width = env::var("CARGO_CFG_TARGET_POINTER_WIDTH").unwrap();
+    let target_is_unix = target_family
+        .as_deref()
+        .is_some_and(|families| families.split(',').any(|family| family == "unix"));
 
     if target_arch == "aarch64"
         && target_endian == "little"
-        && target_family == "unix"
+        && (target_is_unix || target_os == "none")
         && target_pointer_width == "64"
     {
         cc::Build::new()

--- a/src/arithmetic/fields.rs
+++ b/src/arithmetic/fields.rs
@@ -37,6 +37,22 @@ pub(crate) trait SqrtTableHelpers: ff::PrimeField {
     /// chain.
     fn pow_by_t_minus1_over2(&self) -> Self;
 
+    /// Squares this element `n` times. `n` must be at least 1.
+    ///
+    /// Implementations may leave the accumulator unreduced between squarings
+    /// and canonicalize once at the end.
+    fn sqr_n(&self, n: u32) -> Self {
+        assert!(n >= 1);
+        (0..n).fold(*self, |acc, _| acc.square())
+    }
+
+    /// Squares this element `n` times, then multiplies by `by`. `n` must be
+    /// at least 1. The closing multiplication lets implementations skip the
+    /// per-squaring correction entirely.
+    fn sqr_n_mul(&self, n: u32, by: &Self) -> Self {
+        self.sqr_n(n) * by
+    }
+
     /// Returns the representation-derived key for the square-root hash table.
     ///
     /// The key need not have meaning outside the table lookup. It must be
@@ -203,13 +219,11 @@ impl<F: SqrtTableHelpers> SqrtTables<F> {
         // The overall cost of this part is similar to a single full-width exponentiation,
         // regardless of S.
 
-        let sqr = |x: F, i: u32| (0..i).fold(x, |x, _| x.square());
-
         // s = div^(2^S - 1)
-        let s = (0..5).fold(*div, |d: F, i| sqr(d, 1 << i) * d);
+        let s = (0..5).fold(*div, |d: F, i| d.sqr_n_mul(1 << i, &d));
 
         // t == div^(2^(S+1) - 1)
-        let t = s.square() * div;
+        let t = s.sqr_n_mul(1, div);
 
         // w = (num * t)^((T-1)/2) * s
         let w = (t * num).pow_by_t_minus1_over2() * s;
@@ -249,13 +263,12 @@ impl<F: SqrtTableHelpers> SqrtTables<F> {
 
     /// Common part of sqrt_ratio and sqrt_alt: return their result given v = u^((T-1)/2) and uv = u * v.
     fn sqrt_common(&self, uv: &F, v: &F) -> F {
-        let sqr = |x: F, i: u32| (0..i).fold(x, |x, _| x.square());
         let inv = |x: F| self.inv[self.hasher.hash(&x)] as usize;
 
         let x3 = *uv * v;
-        let x2 = sqr(x3, 8);
-        let x1 = sqr(x2, 8);
-        let x0 = sqr(x1, 8);
+        let x2 = x3.sqr_n(8);
+        let x1 = x2.sqr_n(8);
+        let x0 = x1.sqr_n(8);
 
         // i = 0, 1
         let mut t_ = inv(x0); // = t >> 16

--- a/src/asm/pasta_mul-armv8.S
+++ b/src/asm/pasta_mul-armv8.S
@@ -18,7 +18,7 @@
 // R = 2^256. Registers named as limbs below always list the least-significant
 // limb first.
 //
-// Apple AArch64 argument registers:
+// AArch64 procedure-call argument registers:
 //
 // - sqr_n:      x0 = out, x1 = value, x2 = count, x3 = modulus, x4 = inv
 // - sqr_n_mul:  x0 = out, x1 = value, x2 = count, x3 = rhs, x4 = modulus,
@@ -31,11 +31,19 @@
 
 .text
 
-.globl _pasta_curves_from_mont_pasta
-.private_extern _pasta_curves_from_mont_pasta
+#ifdef __APPLE__
+#define C_SYMBOL(name) _##name
+#define PRIVATE_SYMBOL(name) .private_extern C_SYMBOL(name)
+#else
+#define C_SYMBOL(name) name
+#define PRIVATE_SYMBOL(name) .hidden C_SYMBOL(name)
+#endif
+
+.globl C_SYMBOL(pasta_curves_from_mont_pasta)
+PRIVATE_SYMBOL(pasta_curves_from_mont_pasta)
 
 .align 5
-_pasta_curves_from_mont_pasta:
+C_SYMBOL(pasta_curves_from_mont_pasta):
     .long 3573752639        // `paciasp`: sign LR with the entry stack pointer.
     stp x29,x30,[sp,#-16]! // Allocate frame; save frame pointer and signed LR.
     add x29,sp,#0           // Set the frame pointer to the new stack top.
@@ -161,8 +169,8 @@ L$pasta_curves_mul_by_1_mont_pasta:
 
     ret                     // Return to from_mont through x30.
 
-.globl _pasta_curves_sqr_n_mul_mont_pasta
-.private_extern _pasta_curves_sqr_n_mul_mont_pasta
+.globl C_SYMBOL(pasta_curves_sqr_n_mul_mont_pasta)
+PRIVATE_SYMBOL(pasta_curves_sqr_n_mul_mont_pasta)
 
 // Squares the input `count` times (count must be at least 1), then multiplies
 // by `rhs`, keeping the accumulator in registers throughout. Intermediate
@@ -177,7 +185,7 @@ L$pasta_curves_mul_by_1_mont_pasta:
 // wrap; callers must pass at least 1.
 
 .align 5
-_pasta_curves_sqr_n_mul_mont_pasta:
+C_SYMBOL(pasta_curves_sqr_n_mul_mont_pasta):
     stp x29,x30,[sp,#-80]! // Allocate frame; save frame pointer and LR.
     add x29,sp,#0           // Set the frame pointer to the new stack top.
     stp x19,x20,[sp,#16]    // Preserve callee-saved scratch x19 and x20.
@@ -529,8 +537,8 @@ L$pasta_curves_sqr_n_canonicalize:
     ldr x29,[sp],#80        // Restore frame pointer and release the frame.
     ret                     // Return; x30 still holds the caller's address.
 
-.globl _pasta_curves_sqr_n_mont_pasta
-.private_extern _pasta_curves_sqr_n_mont_pasta
+.globl C_SYMBOL(pasta_curves_sqr_n_mont_pasta)
+PRIVATE_SYMBOL(pasta_curves_sqr_n_mont_pasta)
 
 // Squares the input `count` times (count must be at least 1), retaining the
 // lazy accumulator in registers across the entire chain and canonicalizing
@@ -538,7 +546,7 @@ L$pasta_curves_sqr_n_canonicalize:
 // square-and-multiply path remains instruction-for-instruction unchanged.
 
 .align 5
-_pasta_curves_sqr_n_mont_pasta:
+C_SYMBOL(pasta_curves_sqr_n_mont_pasta):
     stp x29,x30,[sp,#-80]! // Allocate frame; save frame pointer and LR.
     add x29,sp,#0           // Set the frame pointer to the new stack top.
     stp x19,x20,[sp,#16]    // Preserve callee-saved scratch x19 and x20.

--- a/src/asm/pasta_mul-armv8.S
+++ b/src/asm/pasta_mul-armv8.S
@@ -5,8 +5,8 @@
 // Adapted from the pre-generated Mach-O assembly in Semolina v0.1.4:
 // https://github.com/supranational/semolina/blob/v0.1.4/src/mach-o/pasta_mul-armv8.S
 //
-// Only the fused repeated-squaring multiplication, the conversion out of
-// Montgomery form, and their shared reduction helper are retained here.
+// Only the fused repeated-squaring chains, the conversion out of Montgomery
+// form, and their shared reduction helper are retained here.
 // Single Montgomery multiplication and squaring live as inline `asm!`
 // transcriptions of the same upstream routines in
 // src/fields/aarch64_asm.rs. Symbols are renamed for this crate. The
@@ -20,12 +20,14 @@
 //
 // Apple AArch64 argument registers:
 //
+// - sqr_n:      x0 = out, x1 = value, x2 = count, x3 = modulus, x4 = inv
 // - sqr_n_mul:  x0 = out, x1 = value, x2 = count, x3 = rhs, x4 = modulus,
 //               x5 = inv
 // - from_mont:  x0 = out, x1 = value, x2 = modulus, x3 = inv
 //
-// The code has no secret-dependent branches or memory accesses. Conditional
-// reductions use `csel` after a full-width subtraction.
+// The code has no secret-dependent branches or memory accesses. The chains
+// branch only on their public counts. Conditional reductions use `csel`
+// after a full-width subtraction.
 
 .text
 
@@ -504,6 +506,7 @@ L$pasta_curves_sqr_n_mul_loop:
     adcs x12,x13,xzr        // Final candidate limb 2.
     adc x13,x14,x22         // Final candidate limb 3.
 
+L$pasta_curves_sqr_n_canonicalize:
     // Subtract p = [p0,p1,0,2^62]; the upper limbs are materialized inline.
     subs x19,x10,x23        // Tentative result limb 0 = candidate - p[0].
     mov x22,#1<<62          // Materialize p[3] = 2^62.
@@ -525,3 +528,186 @@ L$pasta_curves_sqr_n_mul_loop:
     ldp x23,x24,[x29,#48]   // Restore callee-saved x23 and x24.
     ldr x29,[sp],#80        // Restore frame pointer and release the frame.
     ret                     // Return; x30 still holds the caller's address.
+
+.globl _pasta_curves_sqr_n_mont_pasta
+.private_extern _pasta_curves_sqr_n_mont_pasta
+
+// Squares the input `count` times (count must be at least 1), retaining the
+// lazy accumulator in registers across the entire chain and canonicalizing
+// only once. This is a separate emitted loop so the existing fused
+// square-and-multiply path remains instruction-for-instruction unchanged.
+
+.align 5
+_pasta_curves_sqr_n_mont_pasta:
+    stp x29,x30,[sp,#-80]! // Allocate frame; save frame pointer and LR.
+    add x29,sp,#0           // Set the frame pointer to the new stack top.
+    stp x19,x20,[sp,#16]    // Preserve callee-saved scratch x19 and x20.
+    stp x21,x22,[sp,#32]    // Preserve callee-saved scratch x21 and x22.
+    stp x23,x24,[sp,#48]    // Preserve callee-saved modulus limbs 0 and 1.
+
+    mov x5,x4               // Move inv into the loop's expected register.
+    mov x4,x3               // Move modulus into the expected register.
+
+    ldp x6,x7,[x1]          // Load value limbs a[0] and a[1].
+    ldp x8,x9,[x1,#16]      // Load value limbs a[2] and a[3].
+
+    ldp x23,x24,[x4]        // Keep p[0] and p[1] resident across the loop.
+    // p[2] = 0 and p[3] = 2^62 are implicit throughout.
+
+L$pasta_curves_sqr_n_loop:
+    sub x2,x2,#1            // Consume one squaring from the count.
+
+    // Square a (in x6..x9) exactly as the inline `square` in
+    // src/fields/aarch64_asm.rs does; the 512-bit
+    // product limbs A0..A7 map to x10,x11,x12,x13,x14,x15,x16,x17.
+
+    mul x11,x7,x6           // x11 = low(a[1] * a[0]).
+    umulh x20,x7,x6         // x20 = high(a[1] * a[0]).
+    mul x12,x8,x6           // x12 = low(a[2] * a[0]).
+    umulh x21,x8,x6         // x21 = high(a[2] * a[0]).
+    mul x13,x9,x6           // x13 = low(a[3] * a[0]).
+    umulh x14,x9,x6         // x14 = high(a[3] * a[0]).
+
+    adds x12,x12,x20        // Fold high(a[1] * a[0]) into product limb 2.
+    mul x19,x8,x7           // x19 = low(a[2] * a[1]).
+    umulh x20,x8,x7         // x20 = high(a[2] * a[1]).
+    adcs x13,x13,x21        // Fold high(a[2] * a[0]) into product limb 3.
+    mul x21,x9,x7           // x21 = low(a[3] * a[1]).
+    umulh x22,x9,x7         // x22 = high(a[3] * a[1]).
+    adc x14,x14,xzr         // Propagate carry into product limb 4.
+
+    mul x15,x9,x8           // x15 = low(a[3] * a[2]).
+    umulh x16,x9,x8         // x16 = high(a[3] * a[2]).
+
+    adds x20,x20,x21        // Combine terms contributing to product limb 4.
+    mul x10,x6,x6           // x10 = low(a[0]^2), product limb 0.
+    adc x21,x22,xzr         // Combine terms contributing to product limb 5.
+
+    adds x13,x13,x19        // Add low(a[2] * a[1]) into product limb 3.
+    umulh x6,x6,x6          // x6 = high(a[0]^2).
+    adcs x14,x14,x20        // Accumulate cross terms into product limb 4.
+    mul x20,x7,x7           // x20 = low(a[1]^2).
+    adcs x15,x15,x21        // Accumulate cross terms into product limb 5.
+    umulh x7,x7,x7          // x7 = high(a[1]^2).
+    adc x16,x16,xzr         // Propagate carry into product limb 6.
+
+    adds x11,x11,x11        // Double cross-term product limb 1.
+    mul x21,x8,x8           // x21 = low(a[2]^2).
+    adcs x12,x12,x12        // Double cross-term product limb 2.
+    umulh x8,x8,x8          // x8 = high(a[2]^2).
+    adcs x13,x13,x13        // Double cross-term product limb 3.
+    mul x22,x9,x9           // x22 = low(a[3]^2).
+    adcs x14,x14,x14        // Double cross-term product limb 4.
+    umulh x9,x9,x9          // x9 = high(a[3]^2).
+    adcs x15,x15,x15        // Double cross-term product limb 5.
+    adcs x16,x16,x16        // Double cross-term product limb 6.
+    adc x17,xzr,xzr         // Capture the doubled cross-term carry in limb 7.
+
+    mul x4,x5,x10           // q = product limb 0 * inv mod 2^64.
+
+    // Add diagonal squares to obtain a^2 in x10..x17.
+    adds x11,x11,x6         // Add high(a[0]^2) to product limb 1.
+    adcs x12,x12,x20        // Add low(a[1]^2) to product limb 2.
+    adcs x13,x13,x7         // Add high(a[1]^2) to product limb 3.
+    adcs x14,x14,x21        // Add low(a[2]^2) to product limb 4.
+    adcs x15,x15,x8         // Add high(a[2]^2) to product limb 5.
+    adcs x16,x16,x22        // Add low(a[3]^2) to product limb 6.
+    adc x17,x17,x9          // Add high(a[3]^2) to product limb 7.
+
+    // Montgomery cancellation 0 on the low half, as in the shared helper.
+    // low(q * p[0]) cancels x10 and is discarded by the limb shift.
+    mul x20,x24,x4          // x20 = low(q * p[1]).
+    // q * p[2] is zero because p[2] = 0.
+    lsl x22,x4,#62          // x22 = low(q * p[3]).
+    // Carry from x10 + low(q*p[0]) is one exactly when x10 is nonzero.
+    subs xzr,x10,#1         // Set that cancellation carry.
+    umulh x19,x23,x4        // x19 = high(q * p[0]).
+    adcs x11,x11,x20        // Add low(q * p[1]) and cancellation carry.
+    umulh x20,x24,x4        // x20 = high(q * p[1]).
+    adcs x12,x12,xzr        // Propagate carry across zero p[2].
+    // high(q * p[2]) is zero.
+    adcs x13,x13,x22        // Add low(q * p[3]) and carry.
+    lsr x22,x4,#2           // x22 = high(q * p[3]).
+    adc x1,xzr,xzr          // Save the carry above limb 3.
+
+    // Shift out cancelled limb 0 and start cancellation 1.
+    adds x10,x11,x19        // New limb 0 includes high(q * p[0]).
+    adcs x11,x12,x20        // New limb 1 includes high(q * p[1]).
+    adcs x12,x13,xzr        // New limb 2; p[2] contributes zero.
+    mul x4,x5,x10           // Next q = new limb 0 * inv mod 2^64.
+    adc x13,x1,x22          // New limb 3 includes high(q * p[3]).
+    // low(q * p[0]) cancels x10 and is discarded.
+    mul x20,x24,x4          // x20 = low(next q * p[1]).
+    // next q * p[2] is zero.
+    lsl x22,x4,#62          // x22 = low(next q * p[3]).
+    subs xzr,x10,#1         // Set the low-limb cancellation carry.
+    umulh x19,x23,x4        // x19 = high(next q * p[0]).
+    adcs x11,x11,x20        // Add low(next q * p[1]) and carry.
+    umulh x20,x24,x4        // x20 = high(next q * p[1]).
+    adcs x12,x12,xzr        // Propagate carry across zero p[2].
+    // high(next q * p[2]) is zero.
+    adcs x13,x13,x22        // Add low(next q * p[3]) and carry.
+    lsr x22,x4,#2           // x22 = high(next q * p[3]).
+    adc x1,xzr,xzr          // Save the carry above limb 3.
+
+    // Shift out cancelled limb 1 and start cancellation 2.
+    adds x10,x11,x19        // New limb 0 includes high(q * p[0]).
+    adcs x11,x12,x20        // New limb 1 includes high(q * p[1]).
+    adcs x12,x13,xzr        // New limb 2; p[2] contributes zero.
+    mul x4,x5,x10           // Next q = new limb 0 * inv mod 2^64.
+    adc x13,x1,x22          // New limb 3 includes high(q * p[3]).
+    // low(q * p[0]) cancels x10 and is discarded.
+    mul x20,x24,x4          // x20 = low(next q * p[1]).
+    // next q * p[2] is zero.
+    lsl x22,x4,#62          // x22 = low(next q * p[3]).
+    subs xzr,x10,#1         // Set the low-limb cancellation carry.
+    umulh x19,x23,x4        // x19 = high(next q * p[0]).
+    adcs x11,x11,x20        // Add low(next q * p[1]) and carry.
+    umulh x20,x24,x4        // x20 = high(next q * p[1]).
+    adcs x12,x12,xzr        // Propagate carry across zero p[2].
+    // high(next q * p[2]) is zero.
+    adcs x13,x13,x22        // Add low(next q * p[3]) and carry.
+    lsr x22,x4,#2           // x22 = high(next q * p[3]).
+    adc x1,xzr,xzr          // Save the carry above limb 3.
+
+    // Shift out cancelled limb 2 and start cancellation 3.
+    adds x10,x11,x19        // New limb 0 includes high(q * p[0]).
+    adcs x11,x12,x20        // New limb 1 includes high(q * p[1]).
+    adcs x12,x13,xzr        // New limb 2; p[2] contributes zero.
+    mul x4,x5,x10           // Final q = new limb 0 * inv mod 2^64.
+    adc x13,x1,x22          // New limb 3 includes high(q * p[3]).
+    // low(q * p[0]) cancels x10 and is discarded.
+    mul x20,x24,x4          // x20 = low(final q * p[1]).
+    // final q * p[2] is zero.
+    lsl x22,x4,#62          // x22 = low(final q * p[3]).
+    subs xzr,x10,#1         // Set the low-limb cancellation carry.
+    umulh x19,x23,x4        // x19 = high(final q * p[0]).
+    adcs x11,x11,x20        // Add low(final q * p[1]) and carry.
+    umulh x20,x24,x4        // x20 = high(final q * p[1]).
+    adcs x12,x12,xzr        // Propagate carry across zero p[2].
+    // high(final q * p[2]) is zero.
+    adcs x13,x13,x22        // Add low(final q * p[3]) and carry.
+    lsr x22,x4,#2           // x22 = high(final q * p[3]).
+    adc x1,xzr,xzr          // Save the carry above limb 3.
+
+    // Shift out cancelled limb 3 to finish dividing the low half by R.
+    adds x10,x11,x19        // Reduced limb 0 includes high(q * p[0]).
+    adcs x11,x12,x20        // Reduced limb 1 includes high(q * p[1]).
+    adcs x12,x13,xzr        // Reduced limb 2; p[2] contributes zero.
+    adc x13,x1,x22          // Reduced limb 3 includes high(q * p[3]).
+    // Add the upper product half; the sum stays below 2p (see above), so no
+    // carry escapes and no conditional subtraction is needed mid-loop.
+    adds x6,x10,x14         // Next-iteration a[0].
+    adcs x7,x11,x15         // Next-iteration a[1].
+    adcs x8,x12,x16         // Next-iteration a[2].
+    adc x9,x13,x17          // Next-iteration a[3].
+
+    cbnz x2,L$pasta_curves_sqr_n_loop // Square again if count remains.
+
+    // The loop leaves the lazy accumulator in x6..x9. Move it into the
+    // shared canonicalization/output registers without a dummy multiply.
+    mov x10,x6
+    mov x11,x7
+    mov x12,x8
+    mov x13,x9
+    b L$pasta_curves_sqr_n_canonicalize

--- a/src/asm/pasta_mul-armv8.S
+++ b/src/asm/pasta_mul-armv8.S
@@ -39,11 +39,18 @@
 #define PRIVATE_SYMBOL(name) .hidden C_SYMBOL(name)
 #endif
 
+#ifdef __ELF__
+#define AARCH64_VALID_CALL_TARGET hint #34
+#else
+#define AARCH64_VALID_CALL_TARGET
+#endif
+
 .globl C_SYMBOL(pasta_curves_from_mont_pasta)
 PRIVATE_SYMBOL(pasta_curves_from_mont_pasta)
 
 .align 5
 C_SYMBOL(pasta_curves_from_mont_pasta):
+    // `paciasp` is also a BTI-compatible call landing pad.
     .long 3573752639        // `paciasp`: sign LR with the entry stack pointer.
     stp x29,x30,[sp,#-16]! // Allocate frame; save frame pointer and signed LR.
     add x29,sp,#0           // Set the frame pointer to the new stack top.
@@ -186,6 +193,7 @@ PRIVATE_SYMBOL(pasta_curves_sqr_n_mul_mont_pasta)
 
 .align 5
 C_SYMBOL(pasta_curves_sqr_n_mul_mont_pasta):
+    AARCH64_VALID_CALL_TARGET // `bti c` for ELF indirect-call targets.
     stp x29,x30,[sp,#-80]! // Allocate frame; save frame pointer and LR.
     add x29,sp,#0           // Set the frame pointer to the new stack top.
     stp x19,x20,[sp,#16]    // Preserve callee-saved scratch x19 and x20.
@@ -547,6 +555,7 @@ PRIVATE_SYMBOL(pasta_curves_sqr_n_mont_pasta)
 
 .align 5
 C_SYMBOL(pasta_curves_sqr_n_mont_pasta):
+    AARCH64_VALID_CALL_TARGET // `bti c` for ELF indirect-call targets.
     stp x29,x30,[sp,#-80]! // Allocate frame; save frame pointer and LR.
     add x29,sp,#0           // Set the frame pointer to the new stack top.
     stp x19,x20,[sp,#16]    // Preserve callee-saved scratch x19 and x20.
@@ -719,3 +728,16 @@ L$pasta_curves_sqr_n_loop:
     mov x12,x8
     mov x13,x9
     b L$pasta_curves_sqr_n_canonicalize
+
+#ifdef __ELF__
+// Mark the stack non-executable and preserve BTI marking when this object is
+// linked into a hardened ELF image.
+.section .note.GNU-stack,"",@progbits
+.section .note.gnu.property,"a",@note
+    .long 4,2f-1f,5
+    .byte 0x47,0x4e,0x55,0
+    // GNU_PROPERTY_AARCH64_FEATURE_1_AND: BTI.
+1:  .long 0xc0000000,4,1
+.align 3
+2:
+#endif

--- a/src/fields.rs
+++ b/src/fields.rs
@@ -11,7 +11,8 @@ mod portable;
 #[cfg(all(
     feature = "aarch64-asm",
     target_arch = "aarch64",
-    target_family = "unix"
+    target_family = "unix",
+    target_pointer_width = "64"
 ))]
 mod aarch64_asm;
 

--- a/src/fields.rs
+++ b/src/fields.rs
@@ -12,7 +12,8 @@ mod portable;
     feature = "aarch64-asm",
     target_arch = "aarch64",
     target_family = "unix",
-    target_pointer_width = "64"
+    target_pointer_width = "64",
+    target_endian = "little"
 ))]
 mod aarch64_asm;
 

--- a/src/fields.rs
+++ b/src/fields.rs
@@ -11,7 +11,7 @@ mod portable;
 #[cfg(all(
     feature = "aarch64-asm",
     target_arch = "aarch64",
-    target_family = "unix",
+    any(target_family = "unix", target_os = "none"),
     target_pointer_width = "64",
     target_endian = "little"
 ))]

--- a/src/fields.rs
+++ b/src/fields.rs
@@ -3,6 +3,7 @@
 
 mod fp;
 mod fq;
+mod portable;
 
 // Keep the assembly FFI exception contained within a private module whose
 // public interface consists only of safe wrappers.

--- a/src/fields.rs
+++ b/src/fields.rs
@@ -11,7 +11,7 @@ mod portable;
 #[cfg(all(
     feature = "aarch64-asm",
     target_arch = "aarch64",
-    target_vendor = "apple"
+    target_family = "unix"
 ))]
 mod aarch64_asm;
 

--- a/src/fields/aarch64_asm.rs
+++ b/src/fields/aarch64_asm.rs
@@ -1,4 +1,4 @@
-//! Private Unix AArch64 backend for the Pasta fields.
+//! Private 64-bit-pointer Unix AArch64 backend for the Pasta fields.
 //!
 //! Montgomery multiplication and squaring are implemented as inline `asm!`
 //! blocks below; the fused repeated-squaring chains and the canonical-form

--- a/src/fields/aarch64_asm.rs
+++ b/src/fields/aarch64_asm.rs
@@ -1,4 +1,5 @@
-//! Private 64-bit-pointer Unix AArch64 backend for the Pasta fields.
+//! Private little-endian, 64-bit-pointer Unix AArch64 backend for the Pasta
+//! fields.
 //!
 //! Montgomery multiplication and squaring are implemented as inline `asm!`
 //! blocks below; the fused repeated-squaring chains and the canonical-form

--- a/src/fields/aarch64_asm.rs
+++ b/src/fields/aarch64_asm.rs
@@ -1,7 +1,7 @@
 //! Private Apple AArch64 backend for the Pasta fields.
 //!
 //! Montgomery multiplication and squaring are implemented as inline `asm!`
-//! blocks below; the fused repeated-squaring chain and the canonical-form
+//! blocks below; the fused repeated-squaring chains and the canonical-form
 //! conversion remain in `src/asm/pasta_mul-armv8.S` and are reached through
 //! `extern "C"`.
 //!
@@ -58,14 +58,22 @@
 //! construction; `mul` and `square` debug-assert the precondition so a future
 //! caller that breaks it fails loudly under test instead of silently.
 //!
-//! There are no branches and no memory accesses inside the blocks, so the
-//! code is constant-time.
+//! The inline blocks have no branches or memory accesses. The out-of-line
+//! repeated-squaring chains branch only on their public counts, so the code
+//! is constant-time.
 
 use core::arch::asm;
 
 type Limbs = [u64; 4];
 
 extern "C" {
+    fn pasta_curves_sqr_n_mont_pasta(
+        out: *mut Limbs,
+        value: *const Limbs,
+        count: usize,
+        modulus: *const Limbs,
+        inv: u64,
+    );
     fn pasta_curves_sqr_n_mul_mont_pasta(
         out: *mut Limbs,
         value: *const Limbs,
@@ -512,6 +520,26 @@ pub(super) fn square(value: &Limbs, modulus: &Limbs, inv: u64) -> Limbs {
     [a0, a1, a2, a3]
 }
 
+/// Squares a canonical Montgomery residue `count` times, keeping the lazy
+/// accumulator in registers and canonicalizing it once at the end.
+#[inline]
+pub(super) fn sqr_n(value: &Limbs, count: usize, modulus: &Limbs, inv: u64) -> Limbs {
+    // The assembly decrements the count before testing it, so a zero count
+    // would wrap around and effectively never terminate.
+    assert!(count >= 1);
+    debug_assert!(
+        is_canonical(value, modulus),
+        "aarch64_asm::sqr_n requires a canonical starting value"
+    );
+    let mut out = Limbs::default();
+    // SAFETY: All pointers refer to four initialized `u64` limbs for the
+    // duration of the call. The backend writes exactly four limbs to `out`.
+    unsafe {
+        pasta_curves_sqr_n_mont_pasta(&mut out, value, count, modulus, inv);
+    }
+    out
+}
+
 /// Squares a canonical Montgomery residue `count` times, then multiplies the
 /// result by the canonical Montgomery residue `rhs`, keeping the accumulator
 /// in registers throughout.
@@ -526,6 +554,14 @@ pub(super) fn sqr_n_mul(
     // The assembly decrements the count before testing it, so a zero count
     // would wrap around and effectively never terminate.
     assert!(count >= 1);
+    debug_assert!(
+        is_canonical(value, modulus),
+        "aarch64_asm::sqr_n_mul requires a canonical starting value"
+    );
+    debug_assert!(
+        is_canonical(rhs, modulus),
+        "aarch64_asm::sqr_n_mul requires a canonical multiplier"
+    );
     let mut out = Limbs::default();
     // SAFETY: All pointers refer to four initialized `u64` limbs for the
     // duration of the call. The backend writes exactly four limbs to `out`.

--- a/src/fields/aarch64_asm.rs
+++ b/src/fields/aarch64_asm.rs
@@ -1,4 +1,4 @@
-//! Private Apple AArch64 backend for the Pasta fields.
+//! Private Unix AArch64 backend for the Pasta fields.
 //!
 //! Montgomery multiplication and squaring are implemented as inline `asm!`
 //! blocks below; the fused repeated-squaring chains and the canonical-form

--- a/src/fields/aarch64_asm.rs
+++ b/src/fields/aarch64_asm.rs
@@ -1,5 +1,5 @@
-//! Private little-endian, 64-bit-pointer Unix AArch64 backend for the Pasta
-//! fields.
+//! Private little-endian, 64-bit-pointer AArch64 backend for Unix and
+//! bare-metal targets.
 //!
 //! Modular addition and subtraction also use inline blocks.
 //! Montgomery multiplication and squaring are implemented as inline `asm!`

--- a/src/fields/aarch64_asm.rs
+++ b/src/fields/aarch64_asm.rs
@@ -1,7 +1,7 @@
 //! Private little-endian, 64-bit-pointer Unix AArch64 backend for the Pasta
 //! fields.
 //!
-//! On Apple targets, modular addition also uses an inline assembly block.
+//! On Apple targets, modular addition and subtraction also use inline blocks.
 //! Montgomery multiplication and squaring are implemented as inline `asm!`
 //! blocks below; the fused repeated-squaring chains and the canonical-form
 //! conversion remain in `src/asm/pasta_mul-armv8.S` and are reached through
@@ -159,6 +159,62 @@ fn is_canonical(value: &Limbs, modulus: &Limbs) -> bool {
         }
     }
     false
+}
+
+/// Subtracts two residues for a Pasta modulus, adding the modulus back on
+/// underflow. Like [`add`] and [`mul`], the block hardcodes the Pasta
+/// modulus shape (`modulus[2] == 0`). Canonical inputs (debug-asserted)
+/// guarantee a canonical result: the difference lies strictly between `-p`
+/// and `p`, so one conditional addition suffices, and the final carry is
+/// discarded after wrapping modulo `2^256`. Unlike [`add`], this computes
+/// the same function as the inherent portable `sub` on all inputs — both
+/// drop the top borrow and mask-add the modulus — so the contract is not
+/// narrower than the portable path.
+#[cfg(target_vendor = "apple")]
+#[inline(always)]
+pub(super) fn sub(lhs: &Limbs, rhs: &Limbs, modulus: &Limbs) -> Limbs {
+    debug_assert!(
+        is_canonical(lhs, modulus),
+        "aarch64_asm::sub requires a canonical lhs"
+    );
+    debug_assert!(
+        is_canonical(rhs, modulus),
+        "aarch64_asm::sub requires a canonical rhs"
+    );
+    let [mut r0, mut r1, mut r2, mut r3] = *lhs;
+    // SAFETY: register-only arithmetic with declared inputs and outputs;
+    // no memory or stack access and no data-dependent control flow.
+    unsafe {
+        asm!(
+            "subs {r0}, {r0}, {b0}",
+            "sbcs {r1}, {r1}, {b1}",
+            "sbcs {r2}, {r2}, {b2}",
+            "sbcs {r3}, {r3}, {b3}",
+            "csel {t0}, {p0}, xzr, cc",
+            "csel {t1}, {p1}, xzr, cc",
+            "csel {t3}, {p3}, xzr, cc",
+            "adds {r0}, {r0}, {t0}",
+            "adcs {r1}, {r1}, {t1}",
+            "adcs {r2}, {r2}, xzr",
+            "adc {r3}, {r3}, {t3}",
+            r0 = inout(reg) r0,
+            r1 = inout(reg) r1,
+            r2 = inout(reg) r2,
+            r3 = inout(reg) r3,
+            b0 = in(reg) rhs[0],
+            b1 = in(reg) rhs[1],
+            b2 = in(reg) rhs[2],
+            b3 = in(reg) rhs[3],
+            p0 = in(reg) modulus[0],
+            p1 = in(reg) modulus[1],
+            p3 = in(reg) modulus[3],
+            t0 = out(reg) _,
+            t1 = out(reg) _,
+            t3 = out(reg) _,
+            options(pure, nomem, nostack),
+        );
+    }
+    [r0, r1, r2, r3]
 }
 
 /// Multiplies two Montgomery residues for a Pasta modulus. `rhs` must be

--- a/src/fields/aarch64_asm.rs
+++ b/src/fields/aarch64_asm.rs
@@ -1,6 +1,7 @@
 //! Private little-endian, 64-bit-pointer Unix AArch64 backend for the Pasta
 //! fields.
 //!
+//! On Apple targets, modular addition also uses an inline assembly block.
 //! Montgomery multiplication and squaring are implemented as inline `asm!`
 //! blocks below; the fused repeated-squaring chains and the canonical-form
 //! conversion remain in `src/asm/pasta_mul-armv8.S` and are reached through
@@ -66,6 +67,64 @@
 use core::arch::asm;
 
 type Limbs = [u64; 4];
+
+/// Adds two residues for a Pasta modulus and conditionally subtracts the
+/// modulus. Like [`mul`], the block hardcodes the Pasta modulus shape
+/// (`modulus[2] == 0`). Both inputs must be canonical (debug-asserted; a
+/// violation yields an incorrect residue): the top carry of the addition is
+/// dropped and only one subtraction is attempted, both justified by
+/// `2p < 2^256`. This contract is narrower than the inherent portable `add`,
+/// which carries into a fifth limb; unreduced values (such as `mul`'s lazy
+/// `lhs`) must be reduced before reaching this path. Keeping both carry
+/// chains in one block avoids materializing carries between Rust operations.
+#[cfg(target_vendor = "apple")]
+#[inline(always)]
+pub(super) fn add(lhs: &Limbs, rhs: &Limbs, modulus: &Limbs) -> Limbs {
+    debug_assert!(
+        is_canonical(lhs, modulus),
+        "aarch64_asm::add requires a canonical lhs"
+    );
+    debug_assert!(
+        is_canonical(rhs, modulus),
+        "aarch64_asm::add requires a canonical rhs"
+    );
+    let [mut r0, mut r1, mut r2, mut r3] = *lhs;
+    // SAFETY: register-only arithmetic with declared inputs and outputs;
+    // no memory or stack access and no data-dependent control flow.
+    unsafe {
+        asm!(
+            "adds {r0}, {r0}, {b0}",
+            "adcs {r1}, {r1}, {b1}",
+            "adcs {r2}, {r2}, {b2}",
+            "adc {r3}, {r3}, {b3}",
+            "subs {t0}, {r0}, {p0}",
+            "sbcs {t1}, {r1}, {p1}",
+            "sbcs {t2}, {r2}, xzr",
+            "sbcs {t3}, {r3}, {p3}",
+            "csel {r0}, {t0}, {r0}, cs",
+            "csel {r1}, {t1}, {r1}, cs",
+            "csel {r2}, {t2}, {r2}, cs",
+            "csel {r3}, {t3}, {r3}, cs",
+            r0 = inout(reg) r0,
+            r1 = inout(reg) r1,
+            r2 = inout(reg) r2,
+            r3 = inout(reg) r3,
+            b0 = in(reg) rhs[0],
+            b1 = in(reg) rhs[1],
+            b2 = in(reg) rhs[2],
+            b3 = in(reg) rhs[3],
+            p0 = in(reg) modulus[0],
+            p1 = in(reg) modulus[1],
+            p3 = in(reg) modulus[3],
+            t0 = out(reg) _,
+            t1 = out(reg) _,
+            t2 = out(reg) _,
+            t3 = out(reg) _,
+            options(pure, nomem, nostack),
+        );
+    }
+    [r0, r1, r2, r3]
+}
 
 extern "C" {
     fn pasta_curves_sqr_n_mont_pasta(

--- a/src/fields/aarch64_asm.rs
+++ b/src/fields/aarch64_asm.rs
@@ -1,7 +1,7 @@
 //! Private little-endian, 64-bit-pointer Unix AArch64 backend for the Pasta
 //! fields.
 //!
-//! On Apple targets, modular addition and subtraction also use inline blocks.
+//! Modular addition and subtraction also use inline blocks.
 //! Montgomery multiplication and squaring are implemented as inline `asm!`
 //! blocks below; the fused repeated-squaring chains and the canonical-form
 //! conversion remain in `src/asm/pasta_mul-armv8.S` and are reached through
@@ -77,7 +77,6 @@ type Limbs = [u64; 4];
 /// which carries into a fifth limb; unreduced values (such as `mul`'s lazy
 /// `lhs`) must be reduced before reaching this path. Keeping both carry
 /// chains in one block avoids materializing carries between Rust operations.
-#[cfg(target_vendor = "apple")]
 #[inline(always)]
 pub(super) fn add(lhs: &Limbs, rhs: &Limbs, modulus: &Limbs) -> Limbs {
     debug_assert!(
@@ -170,7 +169,6 @@ fn is_canonical(value: &Limbs, modulus: &Limbs) -> bool {
 /// the same function as the inherent portable `sub` on all inputs — both
 /// drop the top borrow and mask-add the modulus — so the contract is not
 /// narrower than the portable path.
-#[cfg(target_vendor = "apple")]
 #[inline(always)]
 pub(super) fn sub(lhs: &Limbs, rhs: &Limbs, modulus: &Limbs) -> Limbs {
     debug_assert!(

--- a/src/fields/fp.rs
+++ b/src/fields/fp.rs
@@ -154,7 +154,7 @@ impl Sub<&Fp> for &Fp {
         #[cfg(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_vendor = "apple",
+            target_family = "unix",
             target_pointer_width = "64",
             target_endian = "little",
         ))]
@@ -164,7 +164,7 @@ impl Sub<&Fp> for &Fp {
         #[cfg(not(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_vendor = "apple",
+            target_family = "unix",
             target_pointer_width = "64",
             target_endian = "little",
         )))]
@@ -182,7 +182,7 @@ impl Add<&Fp> for &Fp {
         #[cfg(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_vendor = "apple",
+            target_family = "unix",
             target_pointer_width = "64",
             target_endian = "little",
         ))]
@@ -192,7 +192,7 @@ impl Add<&Fp> for &Fp {
         #[cfg(not(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_vendor = "apple",
+            target_family = "unix",
             target_pointer_width = "64",
             target_endian = "little",
         )))]

--- a/src/fields/fp.rs
+++ b/src/fields/fp.rs
@@ -469,7 +469,15 @@ impl Fp {
             target_vendor = "apple"
         ))]
         {
-            (0..n).fold(*self, |acc, _| acc.square_runtime())
+            // Calling the dedicated single-square routine is faster than
+            // entering the repeated-squaring loop for a one-element chain.
+            if n == 1 {
+                self.square_runtime()
+            } else {
+                Fp(super::aarch64_asm::sqr_n(
+                    &self.0, n as usize, &MODULUS.0, INV,
+                ))
+            }
         }
 
         #[cfg(not(all(
@@ -1025,9 +1033,16 @@ fn aarch64_asm_matches_portable_arithmetic() {
         (0..n).fold(value, |acc, _| Fp::square(&acc)).mul(&by)
     }
 
+    fn portable_sqr_n(value: Fp, n: u32) -> Fp {
+        (0..n).fold(value, |acc, _| Fp::square(&acc))
+    }
+
     for lhs in boundaries {
         aarch64_asm_check_repr(lhs);
         assert_eq!(<Fp as Field>::square(&lhs), Fp::square(&lhs));
+        for n in [1, 2, 7, 129] {
+            assert_eq!(lhs.sqr_n_runtime(n), portable_sqr_n(lhs, n));
+        }
         for rhs in boundaries {
             assert_eq!(lhs.cmp(&rhs), aarch64_asm_portable_cmp(lhs, rhs));
             assert_eq!(&lhs * &rhs, Fp::mul(&lhs, &rhs));
@@ -1060,6 +1075,7 @@ fn aarch64_asm_matches_portable_arithmetic() {
         assert_eq!(&lhs * &rhs, Fp::mul(&lhs, &rhs));
         assert_eq!(<Fp as Field>::square(&lhs), Fp::square(&lhs));
         for n in [1, 129] {
+            assert_eq!(lhs.sqr_n_runtime(n), portable_sqr_n(lhs, n));
             assert_eq!(
                 lhs.sqr_n_mul_runtime(n, &rhs),
                 portable_sqr_n_mul(lhs, n, rhs)

--- a/src/fields/fp.rs
+++ b/src/fields/fp.rs
@@ -11,6 +11,7 @@ use lazy_static::lazy_static;
 #[cfg(feature = "bits")]
 use ff::{FieldBits, PrimeFieldBits};
 
+use super::portable;
 use crate::arithmetic::{adc, mac, sbb, SqrtTableHelpers};
 #[cfg(feature = "deferred")]
 use crate::deferred::{DeferredField, Product};
@@ -316,8 +317,16 @@ impl Fp {
     /// Squares this element.
     #[cfg_attr(not(feature = "uninline-portable"), inline)]
     pub const fn square(&self) -> Fp {
-        let u = self.square_unreduced();
-        Fp::montgomery_reduce(u[0], u[1], u[2], u[3], u[4], u[5], u[6], u[7])
+        #[cfg(target_arch = "x86_64")]
+        {
+            Fp(portable::square(&self.0, &MODULUS.0, INV))
+        }
+
+        #[cfg(not(target_arch = "x86_64"))]
+        {
+            let u = self.square_unreduced();
+            Fp::montgomery_reduce(u[0], u[1], u[2], u[3], u[4], u[5], u[6], u[7])
+        }
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -441,7 +450,38 @@ impl Fp {
             target_vendor = "apple"
         )))]
         {
-            (0..n).fold(*self, |acc, _| acc.square()).mul(by)
+            // Leave the accumulator unreduced between squarings. The closing
+            // multiplication canonicalizes its result.
+            Fp(portable::sqr_n_lazy(&self.0, n, &MODULUS.0, INV)).mul(by)
+        }
+    }
+
+    /// Squares `self` `n` times (`n` must be at least 1). Reached through
+    /// [`SqrtTableHelpers`], which nothing uses without `sqrt-table`.
+    #[cfg_attr(not(feature = "sqrt-table"), allow(dead_code))]
+    #[inline]
+    fn sqr_n_runtime(&self, n: u32) -> Self {
+        assert!(n >= 1);
+
+        #[cfg(all(
+            feature = "aarch64-asm",
+            target_arch = "aarch64",
+            target_vendor = "apple"
+        ))]
+        {
+            (0..n).fold(*self, |acc, _| acc.square_runtime())
+        }
+
+        #[cfg(not(all(
+            feature = "aarch64-asm",
+            target_arch = "aarch64",
+            target_vendor = "apple"
+        )))]
+        {
+            Fp(portable::canonicalize(
+                &portable::sqr_n_lazy(&self.0, n, &MODULUS.0, INV),
+                &MODULUS.0,
+            ))
         }
     }
 
@@ -523,35 +563,15 @@ impl Fp {
     }
 
     /// Squares this element, returning the unreduced 512-bit product.
+    /// On x86-64, `square` reduces the product's halves separately, so this
+    /// only feeds the `deferred` accumulator and the tests on that target.
+    #[cfg_attr(
+        all(target_arch = "x86_64", not(feature = "deferred")),
+        allow(dead_code)
+    )]
     #[cfg_attr(not(feature = "uninline-portable"), inline)]
     pub(crate) const fn square_unreduced(&self) -> [u64; 8] {
-        let (r1, carry) = mac(0, self.0[0], self.0[1], 0);
-        let (r2, carry) = mac(0, self.0[0], self.0[2], carry);
-        let (r3, r4) = mac(0, self.0[0], self.0[3], carry);
-
-        let (r3, carry) = mac(r3, self.0[1], self.0[2], 0);
-        let (r4, r5) = mac(r4, self.0[1], self.0[3], carry);
-
-        let (r5, r6) = mac(r5, self.0[2], self.0[3], 0);
-
-        let r7 = r6 >> 63;
-        let r6 = (r6 << 1) | (r5 >> 63);
-        let r5 = (r5 << 1) | (r4 >> 63);
-        let r4 = (r4 << 1) | (r3 >> 63);
-        let r3 = (r3 << 1) | (r2 >> 63);
-        let r2 = (r2 << 1) | (r1 >> 63);
-        let r1 = r1 << 1;
-
-        let (r0, carry) = mac(0, self.0[0], self.0[0], 0);
-        let (r1, carry) = adc(0, r1, carry);
-        let (r2, carry) = mac(r2, self.0[1], self.0[1], carry);
-        let (r3, carry) = adc(0, r3, carry);
-        let (r4, carry) = mac(r4, self.0[2], self.0[2], carry);
-        let (r5, carry) = adc(0, r5, carry);
-        let (r6, carry) = mac(r6, self.0[3], self.0[3], carry);
-        let (r7, _) = adc(0, r7, carry);
-
-        [r0, r1, r2, r3, r4, r5, r6, r7]
+        portable::square_wide(&self.0)
     }
 }
 
@@ -694,9 +714,9 @@ impl ff::Field for Fp {
             Some(res) => res,
             None => return Self::one(),
         };
-        // Flush the squarings for any trailing zero bits.
-        for _ in 0..squares {
-            res = res.square_runtime();
+        // Flush any trailing zero bits as one lazy squaring chain.
+        if squares != 0 {
+            res = res.sqr_n_runtime(squares);
         }
         res
     }
@@ -872,6 +892,14 @@ impl SqrtTableHelpers for Fp {
         let rr = rq.sqr_n_mul_runtime(7, &r111);
         let rs = rr.sqr_n_mul_runtime(3, &r11);
         rs.square_runtime() // rt
+    }
+
+    fn sqr_n(&self, n: u32) -> Self {
+        self.sqr_n_runtime(n)
+    }
+
+    fn sqr_n_mul(&self, n: u32, by: &Self) -> Self {
+        self.sqr_n_mul_runtime(n, by)
     }
 
     fn sqrt_hash_key(&self) -> u32 {
@@ -1098,6 +1126,131 @@ fn test_pow_by_t_minus1_over2() {
     // NB: TWO_INV is standing in as a "random" field element
     let v = (Fp::TWO_INV).pow_by_t_minus1_over2();
     assert!(v == ff::Field::pow_vartime(&Fp::TWO_INV, T_MINUS1_OVER2));
+}
+
+#[test]
+fn low_half_reduction_matches_classical() {
+    use rand::SeedableRng;
+
+    let mut rng = rand_xorshift::XorShiftRng::from_seed([0x3c; 16]);
+    let classical =
+        |t: [u64; 8]| Fp::montgomery_reduce(t[0], t[1], t[2], t[3], t[4], t[5], t[6], t[7]);
+    let low_half = |t: [u64; 8]| {
+        Fp(super::portable::canonicalize(
+            &super::portable::montgomery_reduce_low_lazy(&t, &MODULUS.0, INV),
+            &MODULUS.0,
+        ))
+    };
+    // Any `t_lo + R * t_hi` with canonical `t_hi` is below `R * p`, the whole
+    // domain both reductions accept; squares and products are a subset.
+    for _ in 0..20_000 {
+        let hi = <Fp as ff::Field>::random(&mut rng);
+        let lo = <Fp as ff::Field>::random(&mut rng);
+        let t = [
+            lo.0[0], lo.0[1], lo.0[2], lo.0[3], hi.0[0], hi.0[1], hi.0[2], hi.0[3],
+        ];
+        assert_eq!(low_half(t), classical(t));
+        let a = <Fp as ff::Field>::random(&mut rng);
+        let u = a.square_unreduced();
+        assert_eq!(a.square(), classical(u));
+        assert_eq!(a.square(), low_half(u));
+    }
+
+    // Boundary values: zero, `R * (p - 1)`, an all-ones low half under both
+    // the largest canonical and a zero high half, and `(p - 1)^2`.
+    let max = -Fp::one();
+    let ones = [u64::MAX; 4];
+    for t in [
+        [0u64; 8],
+        [0, 0, 0, 0, max.0[0], max.0[1], max.0[2], max.0[3]],
+        [
+            ones[0], ones[1], ones[2], ones[3], max.0[0], max.0[1], max.0[2], max.0[3],
+        ],
+        [ones[0], ones[1], ones[2], ones[3], 0, 0, 0, 0],
+        max.square_unreduced(),
+    ] {
+        assert_eq!(low_half(t), classical(t));
+    }
+    assert_eq!(max.square(), classical(max.square_unreduced()));
+}
+
+#[test]
+fn sqr_n_chains_match_eager_squaring() {
+    use rand::SeedableRng;
+
+    let mut rng = rand_xorshift::XorShiftRng::from_seed([0x71; 16]);
+
+    // Test chains much longer than any production caller uses.
+    for _ in 0..100 {
+        let a = <Fp as ff::Field>::random(&mut rng);
+        let by = <Fp as ff::Field>::random(&mut rng);
+
+        let mut eager = a;
+        for n in 1..=512u32 {
+            eager = eager.square();
+            assert_eq!(a.sqr_n_runtime(n), eager, "sqr_n, n = {n}");
+            assert_eq!(
+                a.sqr_n_mul_runtime(n, &by),
+                eager * by,
+                "sqr_n_mul, n = {n}"
+            );
+        }
+    }
+
+    assert_eq!(Fp::zero().sqr_n_runtime(7), Fp::zero());
+    assert_eq!(Fp::one().sqr_n_mul_runtime(7, &Fp::one()), Fp::one());
+    let a = <Fp as ff::Field>::random(&mut rng);
+    assert_eq!(a.sqr_n(9), a.sqr_n_runtime(9));
+    assert_eq!(a.sqr_n_mul(9, &a), a.sqr_n_mul_runtime(9, &a));
+}
+
+#[test]
+fn sqr_n_lazy_accumulator_stays_below_two_p() {
+    use rand::SeedableRng;
+
+    let mut rng = rand_xorshift::XorShiftRng::from_seed([0x9d; 16]);
+
+    let two_p = {
+        let (d0, c0) = MODULUS.0[0].overflowing_add(MODULUS.0[0]);
+        let (d1, c1) = MODULUS.0[1].overflowing_add(MODULUS.0[1]);
+        let (d1, c2) = d1.overflowing_add(c0 as u64);
+        let (d2, c3) = MODULUS.0[2].overflowing_add(MODULUS.0[2]);
+        let (d2, c4) = d2.overflowing_add((c1 | c2) as u64);
+        let d3 = MODULUS.0[3]
+            .wrapping_add(MODULUS.0[3])
+            .wrapping_add((c3 | c4) as u64);
+        [d0, d1, d2, d3]
+    };
+    let below_two_p = |x: &[u64; 4]| {
+        let mut i = 4;
+        while i > 0 {
+            i -= 1;
+            if x[i] != two_p[i] {
+                return x[i] < two_p[i];
+            }
+        }
+        false
+    };
+
+    // Exercise random starts and the largest canonical value.
+    for i in 0..51 {
+        let start = if i < 50 {
+            <Fp as ff::Field>::random(&mut rng).0
+        } else {
+            (-Fp::one()).0
+        };
+        let mut acc = start;
+        for n in 1..=2048u32 {
+            acc = portable::sqr_n_lazy(&acc, 1, &MODULUS.0, INV);
+            assert!(below_two_p(&acc), "accumulator reached 2p at step {n}");
+            if n.is_power_of_two() {
+                assert_eq!(
+                    Fp(portable::canonicalize(&acc, &MODULUS.0)),
+                    Fp(start).sqr_n_runtime(n)
+                );
+            }
+        }
+    }
 }
 
 #[test]

--- a/src/fields/fp.rs
+++ b/src/fields/fp.rs
@@ -390,7 +390,8 @@ impl Fp {
             feature = "aarch64-asm",
             target_arch = "aarch64",
             target_family = "unix",
-            target_pointer_width = "64"
+            target_pointer_width = "64",
+            target_endian = "little"
         ))]
         {
             Fp(super::aarch64_asm::mul(&self.0, &rhs.0, &MODULUS.0, INV))
@@ -400,7 +401,8 @@ impl Fp {
             feature = "aarch64-asm",
             target_arch = "aarch64",
             target_family = "unix",
-            target_pointer_width = "64"
+            target_pointer_width = "64",
+            target_endian = "little"
         )))]
         {
             self.mul(rhs)
@@ -413,7 +415,8 @@ impl Fp {
             feature = "aarch64-asm",
             target_arch = "aarch64",
             target_family = "unix",
-            target_pointer_width = "64"
+            target_pointer_width = "64",
+            target_endian = "little"
         ))]
         {
             Fp(super::aarch64_asm::square(&self.0, &MODULUS.0, INV))
@@ -423,7 +426,8 @@ impl Fp {
             feature = "aarch64-asm",
             target_arch = "aarch64",
             target_family = "unix",
-            target_pointer_width = "64"
+            target_pointer_width = "64",
+            target_endian = "little"
         )))]
         {
             self.square()
@@ -441,7 +445,8 @@ impl Fp {
             feature = "aarch64-asm",
             target_arch = "aarch64",
             target_family = "unix",
-            target_pointer_width = "64"
+            target_pointer_width = "64",
+            target_endian = "little"
         ))]
         {
             Fp(super::aarch64_asm::sqr_n_mul(
@@ -453,7 +458,8 @@ impl Fp {
             feature = "aarch64-asm",
             target_arch = "aarch64",
             target_family = "unix",
-            target_pointer_width = "64"
+            target_pointer_width = "64",
+            target_endian = "little"
         )))]
         {
             // Leave the accumulator unreduced between squarings. The closing
@@ -473,7 +479,8 @@ impl Fp {
             feature = "aarch64-asm",
             target_arch = "aarch64",
             target_family = "unix",
-            target_pointer_width = "64"
+            target_pointer_width = "64",
+            target_endian = "little"
         ))]
         {
             // Calling the dedicated single-square routine is faster than
@@ -491,7 +498,8 @@ impl Fp {
             feature = "aarch64-asm",
             target_arch = "aarch64",
             target_family = "unix",
-            target_pointer_width = "64"
+            target_pointer_width = "64",
+            target_endian = "little"
         )))]
         {
             Fp(portable::canonicalize(
@@ -799,7 +807,8 @@ impl ff::PrimeField for Fp {
             feature = "aarch64-asm",
             target_arch = "aarch64",
             target_family = "unix",
-            target_pointer_width = "64"
+            target_pointer_width = "64",
+            target_endian = "little"
         ))]
         let tmp = Fp(super::aarch64_asm::from_mont(&self.0, &MODULUS.0, INV));
 
@@ -807,7 +816,8 @@ impl ff::PrimeField for Fp {
             feature = "aarch64-asm",
             target_arch = "aarch64",
             target_family = "unix",
-            target_pointer_width = "64"
+            target_pointer_width = "64",
+            target_endian = "little"
         )))]
         let tmp = Fp::montgomery_reduce(self.0[0], self.0[1], self.0[2], self.0[3], 0, 0, 0, 0);
 
@@ -978,7 +988,8 @@ impl ec_gpu::GpuField for Fp {
     feature = "aarch64-asm",
     target_arch = "aarch64",
     target_family = "unix",
-    target_pointer_width = "64"
+    target_pointer_width = "64",
+    target_endian = "little"
 ))]
 fn aarch64_asm_portable_repr(value: Fp) -> [u8; 32] {
     let value = Fp::montgomery_reduce(value.0[0], value.0[1], value.0[2], value.0[3], 0, 0, 0, 0);
@@ -994,7 +1005,8 @@ fn aarch64_asm_portable_repr(value: Fp) -> [u8; 32] {
     feature = "aarch64-asm",
     target_arch = "aarch64",
     target_family = "unix",
-    target_pointer_width = "64"
+    target_pointer_width = "64",
+    target_endian = "little"
 ))]
 fn aarch64_asm_check_repr(value: Fp) {
     let portable = aarch64_asm_portable_repr(value);
@@ -1008,7 +1020,8 @@ fn aarch64_asm_check_repr(value: Fp) {
     feature = "aarch64-asm",
     target_arch = "aarch64",
     target_family = "unix",
-    target_pointer_width = "64"
+    target_pointer_width = "64",
+    target_endian = "little"
 ))]
 fn aarch64_asm_portable_cmp(lhs: Fp, rhs: Fp) -> core::cmp::Ordering {
     aarch64_asm_portable_repr(lhs)
@@ -1027,7 +1040,8 @@ fn aarch64_asm_portable_cmp(lhs: Fp, rhs: Fp) -> core::cmp::Ordering {
     feature = "aarch64-asm",
     target_arch = "aarch64",
     target_family = "unix",
-    target_pointer_width = "64"
+    target_pointer_width = "64",
+    target_endian = "little"
 ))]
 #[test]
 fn aarch64_asm_matches_portable_arithmetic() {
@@ -1485,7 +1499,8 @@ fn test_from_u512() {
     feature = "aarch64-asm",
     target_arch = "aarch64",
     target_family = "unix",
-    target_pointer_width = "64"
+    target_pointer_width = "64",
+    target_endian = "little"
 ))]
 #[test]
 fn aarch64_asm_mul_unreduced_lhs_matches_portable() {
@@ -1619,7 +1634,8 @@ fn constants_are_canonical() {
     feature = "aarch64-asm",
     target_arch = "aarch64",
     target_family = "unix",
-    target_pointer_width = "64"
+    target_pointer_width = "64",
+    target_endian = "little"
 ))]
 #[test]
 fn aarch64_asm_mul_canonical_sweep_matches_portable() {
@@ -1649,7 +1665,8 @@ fn aarch64_asm_mul_canonical_sweep_matches_portable() {
     feature = "aarch64-asm",
     target_arch = "aarch64",
     target_family = "unix",
-    target_pointer_width = "64"
+    target_pointer_width = "64",
+    target_endian = "little"
 ))]
 #[test]
 fn aarch64_asm_mul_unreduced_lhs_near_modulus_rhs_matches_portable() {
@@ -1697,7 +1714,8 @@ fn aarch64_asm_mul_unreduced_lhs_near_modulus_rhs_matches_portable() {
     feature = "aarch64-asm",
     target_arch = "aarch64",
     target_family = "unix",
-    target_pointer_width = "64"
+    target_pointer_width = "64",
+    target_endian = "little"
 ))]
 #[test]
 #[should_panic(expected = "requires a canonical rhs")]

--- a/src/fields/fp.rs
+++ b/src/fields/fp.rs
@@ -160,7 +160,26 @@ impl Add<&Fp> for &Fp {
 
     #[inline]
     fn add(self, rhs: &Fp) -> Fp {
-        self.add(rhs)
+        #[cfg(all(
+            feature = "aarch64-asm",
+            target_arch = "aarch64",
+            target_vendor = "apple",
+            target_pointer_width = "64",
+            target_endian = "little",
+        ))]
+        {
+            Fp(super::aarch64_asm::add(&self.0, &rhs.0, &MODULUS.0))
+        }
+        #[cfg(not(all(
+            feature = "aarch64-asm",
+            target_arch = "aarch64",
+            target_vendor = "apple",
+            target_pointer_width = "64",
+            target_endian = "little",
+        )))]
+        {
+            self.add(rhs)
+        }
     }
 }
 
@@ -1074,6 +1093,7 @@ fn aarch64_asm_matches_portable_arithmetic() {
         for rhs in boundaries {
             assert_eq!(lhs.cmp(&rhs), aarch64_asm_portable_cmp(lhs, rhs));
             assert_eq!(&lhs * &rhs, Fp::mul(&lhs, &rhs));
+            assert_eq!(&lhs + &rhs, Fp::add(&lhs, &rhs));
             for n in [1, 2, 7] {
                 assert_eq!(
                     lhs.sqr_n_mul_runtime(n, &rhs),
@@ -1084,6 +1104,19 @@ fn aarch64_asm_matches_portable_arithmetic() {
     }
 
     let mut rng = rand_xorshift::XorShiftRng::from_seed([0x5a; 16]);
+    // Exercise carries across each limb and sums immediately around p.
+    // These are raw Montgomery residues; 2^bit < p for bit < 254.
+    for bit in 0..254 {
+        let mut limbs = [0; 4];
+        limbs[bit / 64] = 1 << (bit % 64);
+        let lhs = Fp(limbs);
+        let complement = Fp::sub(&MODULUS, &lhs);
+        for rhs in [complement.sub(&Fp([1, 0, 0, 0])), complement] {
+            assert_eq!(&lhs + &rhs, Fp::add(&lhs, &rhs));
+        }
+        assert_eq!(&lhs + &lhs, Fp::double(&lhs));
+    }
+
     for _ in 0..1024 {
         let lhs = Fp::from_raw([
             rng.next_u64(),
@@ -1101,6 +1134,8 @@ fn aarch64_asm_matches_portable_arithmetic() {
         aarch64_asm_check_repr(lhs);
         assert_eq!(lhs.cmp(&rhs), aarch64_asm_portable_cmp(lhs, rhs));
         assert_eq!(&lhs * &rhs, Fp::mul(&lhs, &rhs));
+        assert_eq!(&lhs + &rhs, Fp::add(&lhs, &rhs));
+        assert_eq!(&lhs + &lhs, Fp::double(&lhs));
         assert_eq!(<Fp as Field>::square(&lhs), Fp::square(&lhs));
         for n in [1, 129] {
             assert_eq!(lhs.sqr_n_runtime(n), portable_sqr_n(lhs, n));

--- a/src/fields/fp.rs
+++ b/src/fields/fp.rs
@@ -389,7 +389,7 @@ impl Fp {
         #[cfg(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_vendor = "apple"
+            target_family = "unix"
         ))]
         {
             Fp(super::aarch64_asm::mul(&self.0, &rhs.0, &MODULUS.0, INV))
@@ -398,7 +398,7 @@ impl Fp {
         #[cfg(not(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_vendor = "apple"
+            target_family = "unix"
         )))]
         {
             self.mul(rhs)
@@ -410,7 +410,7 @@ impl Fp {
         #[cfg(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_vendor = "apple"
+            target_family = "unix"
         ))]
         {
             Fp(super::aarch64_asm::square(&self.0, &MODULUS.0, INV))
@@ -419,7 +419,7 @@ impl Fp {
         #[cfg(not(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_vendor = "apple"
+            target_family = "unix"
         )))]
         {
             self.square()
@@ -436,7 +436,7 @@ impl Fp {
         #[cfg(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_vendor = "apple"
+            target_family = "unix"
         ))]
         {
             Fp(super::aarch64_asm::sqr_n_mul(
@@ -447,7 +447,7 @@ impl Fp {
         #[cfg(not(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_vendor = "apple"
+            target_family = "unix"
         )))]
         {
             // Leave the accumulator unreduced between squarings. The closing
@@ -466,7 +466,7 @@ impl Fp {
         #[cfg(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_vendor = "apple"
+            target_family = "unix"
         ))]
         {
             // Calling the dedicated single-square routine is faster than
@@ -483,7 +483,7 @@ impl Fp {
         #[cfg(not(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_vendor = "apple"
+            target_family = "unix"
         )))]
         {
             Fp(portable::canonicalize(
@@ -790,14 +790,14 @@ impl ff::PrimeField for Fp {
         #[cfg(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_vendor = "apple"
+            target_family = "unix"
         ))]
         let tmp = Fp(super::aarch64_asm::from_mont(&self.0, &MODULUS.0, INV));
 
         #[cfg(not(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_vendor = "apple"
+            target_family = "unix"
         )))]
         let tmp = Fp::montgomery_reduce(self.0[0], self.0[1], self.0[2], self.0[3], 0, 0, 0, 0);
 
@@ -967,7 +967,7 @@ impl ec_gpu::GpuField for Fp {
     test,
     feature = "aarch64-asm",
     target_arch = "aarch64",
-    target_vendor = "apple"
+    target_family = "unix"
 ))]
 fn aarch64_asm_portable_repr(value: Fp) -> [u8; 32] {
     let value = Fp::montgomery_reduce(value.0[0], value.0[1], value.0[2], value.0[3], 0, 0, 0, 0);
@@ -982,7 +982,7 @@ fn aarch64_asm_portable_repr(value: Fp) -> [u8; 32] {
     test,
     feature = "aarch64-asm",
     target_arch = "aarch64",
-    target_vendor = "apple"
+    target_family = "unix"
 ))]
 fn aarch64_asm_check_repr(value: Fp) {
     let portable = aarch64_asm_portable_repr(value);
@@ -995,7 +995,7 @@ fn aarch64_asm_check_repr(value: Fp) {
     test,
     feature = "aarch64-asm",
     target_arch = "aarch64",
-    target_vendor = "apple"
+    target_family = "unix"
 ))]
 fn aarch64_asm_portable_cmp(lhs: Fp, rhs: Fp) -> core::cmp::Ordering {
     aarch64_asm_portable_repr(lhs)
@@ -1013,7 +1013,7 @@ fn aarch64_asm_portable_cmp(lhs: Fp, rhs: Fp) -> core::cmp::Ordering {
     test,
     feature = "aarch64-asm",
     target_arch = "aarch64",
-    target_vendor = "apple"
+    target_family = "unix"
 ))]
 #[test]
 fn aarch64_asm_matches_portable_arithmetic() {
@@ -1470,7 +1470,7 @@ fn test_from_u512() {
     test,
     feature = "aarch64-asm",
     target_arch = "aarch64",
-    target_vendor = "apple"
+    target_family = "unix"
 ))]
 #[test]
 fn aarch64_asm_mul_unreduced_lhs_matches_portable() {
@@ -1603,7 +1603,7 @@ fn constants_are_canonical() {
     test,
     feature = "aarch64-asm",
     target_arch = "aarch64",
-    target_vendor = "apple"
+    target_family = "unix"
 ))]
 #[test]
 fn aarch64_asm_mul_canonical_sweep_matches_portable() {
@@ -1632,7 +1632,7 @@ fn aarch64_asm_mul_canonical_sweep_matches_portable() {
     test,
     feature = "aarch64-asm",
     target_arch = "aarch64",
-    target_vendor = "apple"
+    target_family = "unix"
 ))]
 #[test]
 fn aarch64_asm_mul_unreduced_lhs_near_modulus_rhs_matches_portable() {
@@ -1679,7 +1679,7 @@ fn aarch64_asm_mul_unreduced_lhs_near_modulus_rhs_matches_portable() {
     debug_assertions,
     feature = "aarch64-asm",
     target_arch = "aarch64",
-    target_vendor = "apple"
+    target_family = "unix"
 ))]
 #[test]
 #[should_panic(expected = "requires a canonical rhs")]

--- a/src/fields/fp.rs
+++ b/src/fields/fp.rs
@@ -696,8 +696,28 @@ impl ff::Field for Fp {
         ])
     }
 
+    #[inline(always)]
     fn double(&self) -> Self {
-        self.double()
+        #[cfg(all(
+            feature = "aarch64-asm",
+            target_arch = "aarch64",
+            target_vendor = "apple",
+            target_pointer_width = "64",
+            target_endian = "little",
+        ))]
+        {
+            Self(super::aarch64_asm::add(&self.0, &self.0, &MODULUS.0))
+        }
+        #[cfg(not(all(
+            feature = "aarch64-asm",
+            target_arch = "aarch64",
+            target_vendor = "apple",
+            target_pointer_width = "64",
+            target_endian = "little",
+        )))]
+        {
+            self.double()
+        }
     }
 
     #[inline(always)]
@@ -1086,12 +1106,20 @@ fn aarch64_asm_matches_portable_arithmetic() {
     use rand::SeedableRng;
 
     let max_montgomery_residue = Fp([MODULUS.0[0] - 1, MODULUS.0[1], MODULUS.0[2], MODULUS.0[3]]);
+    // Raw Montgomery residues straddling the doubling reduction threshold.
+    let half_modulus = Fp(core::array::from_fn(|limb| {
+        (MODULUS.0[limb] >> 1) | (MODULUS.0.get(limb + 1).copied().unwrap_or(0) << 63)
+    }));
+    let raw_one = Fp([1, 0, 0, 0]);
     let boundaries = [
         Fp::zero(),
         Fp::one(),
         -Fp::one(),
         Fp::from_raw([1, 0, 0, 0]),
         max_montgomery_residue,
+        Fp::sub(&half_modulus, &raw_one),
+        half_modulus,
+        Fp::add(&half_modulus, &raw_one),
         Fp::from_raw([u64::MAX; 4]),
     ];
 
@@ -1105,6 +1133,7 @@ fn aarch64_asm_matches_portable_arithmetic() {
 
     for lhs in boundaries {
         aarch64_asm_check_repr(lhs);
+        assert_eq!(<Fp as Field>::double(&lhs), Fp::double(&lhs));
         assert_eq!(<Fp as Field>::square(&lhs), Fp::square(&lhs));
         for n in [1, 2, 7, 129] {
             assert_eq!(lhs.sqr_n_runtime(n), portable_sqr_n(lhs, n));
@@ -1137,6 +1166,7 @@ fn aarch64_asm_matches_portable_arithmetic() {
         assert_eq!(&lhs - &raw_one, Fp::sub(&lhs, &raw_one));
         assert_eq!(&raw_one - &lhs, Fp::sub(&raw_one, &lhs));
         assert_eq!(&lhs - &lhs, Fp::ZERO);
+        assert_eq!(<Fp as Field>::double(&lhs), Fp::double(&lhs));
         for rhs in [complement.sub(&Fp([1, 0, 0, 0])), complement] {
             assert_eq!(&lhs + &rhs, Fp::add(&lhs, &rhs));
         }
@@ -1157,6 +1187,7 @@ fn aarch64_asm_matches_portable_arithmetic() {
             rng.next_u64(),
         ]);
 
+        assert_eq!(<Fp as Field>::double(&lhs), Fp::double(&lhs));
         aarch64_asm_check_repr(lhs);
         assert_eq!(lhs.cmp(&rhs), aarch64_asm_portable_cmp(lhs, rhs));
         assert_eq!(&lhs * &rhs, Fp::mul(&lhs, &rhs));

--- a/src/fields/fp.rs
+++ b/src/fields/fp.rs
@@ -151,7 +151,26 @@ impl Sub<&Fp> for &Fp {
 
     #[inline]
     fn sub(self, rhs: &Fp) -> Fp {
-        self.sub(rhs)
+        #[cfg(all(
+            feature = "aarch64-asm",
+            target_arch = "aarch64",
+            target_vendor = "apple",
+            target_pointer_width = "64",
+            target_endian = "little",
+        ))]
+        {
+            Fp(super::aarch64_asm::sub(&self.0, &rhs.0, &MODULUS.0))
+        }
+        #[cfg(not(all(
+            feature = "aarch64-asm",
+            target_arch = "aarch64",
+            target_vendor = "apple",
+            target_pointer_width = "64",
+            target_endian = "little",
+        )))]
+        {
+            self.sub(rhs)
+        }
     }
 }
 
@@ -1094,6 +1113,7 @@ fn aarch64_asm_matches_portable_arithmetic() {
             assert_eq!(lhs.cmp(&rhs), aarch64_asm_portable_cmp(lhs, rhs));
             assert_eq!(&lhs * &rhs, Fp::mul(&lhs, &rhs));
             assert_eq!(&lhs + &rhs, Fp::add(&lhs, &rhs));
+            assert_eq!(&lhs - &rhs, Fp::sub(&lhs, &rhs));
             for n in [1, 2, 7] {
                 assert_eq!(
                     lhs.sqr_n_mul_runtime(n, &rhs),
@@ -1111,6 +1131,12 @@ fn aarch64_asm_matches_portable_arithmetic() {
         limbs[bit / 64] = 1 << (bit % 64);
         let lhs = Fp(limbs);
         let complement = Fp::sub(&MODULUS, &lhs);
+        let raw_one = Fp([1, 0, 0, 0]);
+        // Subtracting one from a single set bit borrows across lower limbs;
+        // reversing the operands also exercises conditional modulus addition.
+        assert_eq!(&lhs - &raw_one, Fp::sub(&lhs, &raw_one));
+        assert_eq!(&raw_one - &lhs, Fp::sub(&raw_one, &lhs));
+        assert_eq!(&lhs - &lhs, Fp::ZERO);
         for rhs in [complement.sub(&Fp([1, 0, 0, 0])), complement] {
             assert_eq!(&lhs + &rhs, Fp::add(&lhs, &rhs));
         }
@@ -1135,6 +1161,7 @@ fn aarch64_asm_matches_portable_arithmetic() {
         assert_eq!(lhs.cmp(&rhs), aarch64_asm_portable_cmp(lhs, rhs));
         assert_eq!(&lhs * &rhs, Fp::mul(&lhs, &rhs));
         assert_eq!(&lhs + &rhs, Fp::add(&lhs, &rhs));
+        assert_eq!(&lhs - &rhs, Fp::sub(&lhs, &rhs));
         assert_eq!(&lhs + &lhs, Fp::double(&lhs));
         assert_eq!(<Fp as Field>::square(&lhs), Fp::square(&lhs));
         for n in [1, 129] {

--- a/src/fields/fp.rs
+++ b/src/fields/fp.rs
@@ -154,7 +154,7 @@ impl Sub<&Fp> for &Fp {
         #[cfg(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_family = "unix",
+            any(target_family = "unix", target_os = "none"),
             target_pointer_width = "64",
             target_endian = "little",
         ))]
@@ -164,7 +164,7 @@ impl Sub<&Fp> for &Fp {
         #[cfg(not(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_family = "unix",
+            any(target_family = "unix", target_os = "none"),
             target_pointer_width = "64",
             target_endian = "little",
         )))]
@@ -182,7 +182,7 @@ impl Add<&Fp> for &Fp {
         #[cfg(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_family = "unix",
+            any(target_family = "unix", target_os = "none"),
             target_pointer_width = "64",
             target_endian = "little",
         ))]
@@ -192,7 +192,7 @@ impl Add<&Fp> for &Fp {
         #[cfg(not(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_family = "unix",
+            any(target_family = "unix", target_os = "none"),
             target_pointer_width = "64",
             target_endian = "little",
         )))]
@@ -427,7 +427,7 @@ impl Fp {
         #[cfg(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_family = "unix",
+            any(target_family = "unix", target_os = "none"),
             target_pointer_width = "64",
             target_endian = "little"
         ))]
@@ -438,7 +438,7 @@ impl Fp {
         #[cfg(not(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_family = "unix",
+            any(target_family = "unix", target_os = "none"),
             target_pointer_width = "64",
             target_endian = "little"
         )))]
@@ -452,7 +452,7 @@ impl Fp {
         #[cfg(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_family = "unix",
+            any(target_family = "unix", target_os = "none"),
             target_pointer_width = "64",
             target_endian = "little"
         ))]
@@ -463,7 +463,7 @@ impl Fp {
         #[cfg(not(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_family = "unix",
+            any(target_family = "unix", target_os = "none"),
             target_pointer_width = "64",
             target_endian = "little"
         )))]
@@ -482,7 +482,7 @@ impl Fp {
         #[cfg(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_family = "unix",
+            any(target_family = "unix", target_os = "none"),
             target_pointer_width = "64",
             target_endian = "little"
         ))]
@@ -495,7 +495,7 @@ impl Fp {
         #[cfg(not(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_family = "unix",
+            any(target_family = "unix", target_os = "none"),
             target_pointer_width = "64",
             target_endian = "little"
         )))]
@@ -516,7 +516,7 @@ impl Fp {
         #[cfg(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_family = "unix",
+            any(target_family = "unix", target_os = "none"),
             target_pointer_width = "64",
             target_endian = "little"
         ))]
@@ -535,7 +535,7 @@ impl Fp {
         #[cfg(not(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_family = "unix",
+            any(target_family = "unix", target_os = "none"),
             target_pointer_width = "64",
             target_endian = "little"
         )))]
@@ -864,7 +864,7 @@ impl ff::PrimeField for Fp {
         #[cfg(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_family = "unix",
+            any(target_family = "unix", target_os = "none"),
             target_pointer_width = "64",
             target_endian = "little"
         ))]
@@ -873,7 +873,7 @@ impl ff::PrimeField for Fp {
         #[cfg(not(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_family = "unix",
+            any(target_family = "unix", target_os = "none"),
             target_pointer_width = "64",
             target_endian = "little"
         )))]
@@ -1045,7 +1045,7 @@ impl ec_gpu::GpuField for Fp {
     test,
     feature = "aarch64-asm",
     target_arch = "aarch64",
-    target_family = "unix",
+    any(target_family = "unix", target_os = "none"),
     target_pointer_width = "64",
     target_endian = "little"
 ))]
@@ -1062,7 +1062,7 @@ fn aarch64_asm_portable_repr(value: Fp) -> [u8; 32] {
     test,
     feature = "aarch64-asm",
     target_arch = "aarch64",
-    target_family = "unix",
+    any(target_family = "unix", target_os = "none"),
     target_pointer_width = "64",
     target_endian = "little"
 ))]
@@ -1077,7 +1077,7 @@ fn aarch64_asm_check_repr(value: Fp) {
     test,
     feature = "aarch64-asm",
     target_arch = "aarch64",
-    target_family = "unix",
+    any(target_family = "unix", target_os = "none"),
     target_pointer_width = "64",
     target_endian = "little"
 ))]
@@ -1097,7 +1097,7 @@ fn aarch64_asm_portable_cmp(lhs: Fp, rhs: Fp) -> core::cmp::Ordering {
     test,
     feature = "aarch64-asm",
     target_arch = "aarch64",
-    target_family = "unix",
+    any(target_family = "unix", target_os = "none"),
     target_pointer_width = "64",
     target_endian = "little"
 ))]
@@ -1591,7 +1591,7 @@ fn test_from_u512() {
     test,
     feature = "aarch64-asm",
     target_arch = "aarch64",
-    target_family = "unix",
+    any(target_family = "unix", target_os = "none"),
     target_pointer_width = "64",
     target_endian = "little"
 ))]
@@ -1726,7 +1726,7 @@ fn constants_are_canonical() {
     test,
     feature = "aarch64-asm",
     target_arch = "aarch64",
-    target_family = "unix",
+    any(target_family = "unix", target_os = "none"),
     target_pointer_width = "64",
     target_endian = "little"
 ))]
@@ -1757,7 +1757,7 @@ fn aarch64_asm_mul_canonical_sweep_matches_portable() {
     test,
     feature = "aarch64-asm",
     target_arch = "aarch64",
-    target_family = "unix",
+    any(target_family = "unix", target_os = "none"),
     target_pointer_width = "64",
     target_endian = "little"
 ))]
@@ -1806,7 +1806,7 @@ fn aarch64_asm_mul_unreduced_lhs_near_modulus_rhs_matches_portable() {
     debug_assertions,
     feature = "aarch64-asm",
     target_arch = "aarch64",
-    target_family = "unix",
+    any(target_family = "unix", target_os = "none"),
     target_pointer_width = "64",
     target_endian = "little"
 ))]

--- a/src/fields/fp.rs
+++ b/src/fields/fp.rs
@@ -389,7 +389,8 @@ impl Fp {
         #[cfg(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_family = "unix"
+            target_family = "unix",
+            target_pointer_width = "64"
         ))]
         {
             Fp(super::aarch64_asm::mul(&self.0, &rhs.0, &MODULUS.0, INV))
@@ -398,7 +399,8 @@ impl Fp {
         #[cfg(not(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_family = "unix"
+            target_family = "unix",
+            target_pointer_width = "64"
         )))]
         {
             self.mul(rhs)
@@ -410,7 +412,8 @@ impl Fp {
         #[cfg(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_family = "unix"
+            target_family = "unix",
+            target_pointer_width = "64"
         ))]
         {
             Fp(super::aarch64_asm::square(&self.0, &MODULUS.0, INV))
@@ -419,7 +422,8 @@ impl Fp {
         #[cfg(not(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_family = "unix"
+            target_family = "unix",
+            target_pointer_width = "64"
         )))]
         {
             self.square()
@@ -436,7 +440,8 @@ impl Fp {
         #[cfg(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_family = "unix"
+            target_family = "unix",
+            target_pointer_width = "64"
         ))]
         {
             Fp(super::aarch64_asm::sqr_n_mul(
@@ -447,7 +452,8 @@ impl Fp {
         #[cfg(not(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_family = "unix"
+            target_family = "unix",
+            target_pointer_width = "64"
         )))]
         {
             // Leave the accumulator unreduced between squarings. The closing
@@ -466,7 +472,8 @@ impl Fp {
         #[cfg(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_family = "unix"
+            target_family = "unix",
+            target_pointer_width = "64"
         ))]
         {
             // Calling the dedicated single-square routine is faster than
@@ -483,7 +490,8 @@ impl Fp {
         #[cfg(not(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_family = "unix"
+            target_family = "unix",
+            target_pointer_width = "64"
         )))]
         {
             Fp(portable::canonicalize(
@@ -790,14 +798,16 @@ impl ff::PrimeField for Fp {
         #[cfg(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_family = "unix"
+            target_family = "unix",
+            target_pointer_width = "64"
         ))]
         let tmp = Fp(super::aarch64_asm::from_mont(&self.0, &MODULUS.0, INV));
 
         #[cfg(not(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_family = "unix"
+            target_family = "unix",
+            target_pointer_width = "64"
         )))]
         let tmp = Fp::montgomery_reduce(self.0[0], self.0[1], self.0[2], self.0[3], 0, 0, 0, 0);
 
@@ -967,7 +977,8 @@ impl ec_gpu::GpuField for Fp {
     test,
     feature = "aarch64-asm",
     target_arch = "aarch64",
-    target_family = "unix"
+    target_family = "unix",
+    target_pointer_width = "64"
 ))]
 fn aarch64_asm_portable_repr(value: Fp) -> [u8; 32] {
     let value = Fp::montgomery_reduce(value.0[0], value.0[1], value.0[2], value.0[3], 0, 0, 0, 0);
@@ -982,7 +993,8 @@ fn aarch64_asm_portable_repr(value: Fp) -> [u8; 32] {
     test,
     feature = "aarch64-asm",
     target_arch = "aarch64",
-    target_family = "unix"
+    target_family = "unix",
+    target_pointer_width = "64"
 ))]
 fn aarch64_asm_check_repr(value: Fp) {
     let portable = aarch64_asm_portable_repr(value);
@@ -995,7 +1007,8 @@ fn aarch64_asm_check_repr(value: Fp) {
     test,
     feature = "aarch64-asm",
     target_arch = "aarch64",
-    target_family = "unix"
+    target_family = "unix",
+    target_pointer_width = "64"
 ))]
 fn aarch64_asm_portable_cmp(lhs: Fp, rhs: Fp) -> core::cmp::Ordering {
     aarch64_asm_portable_repr(lhs)
@@ -1013,7 +1026,8 @@ fn aarch64_asm_portable_cmp(lhs: Fp, rhs: Fp) -> core::cmp::Ordering {
     test,
     feature = "aarch64-asm",
     target_arch = "aarch64",
-    target_family = "unix"
+    target_family = "unix",
+    target_pointer_width = "64"
 ))]
 #[test]
 fn aarch64_asm_matches_portable_arithmetic() {
@@ -1470,7 +1484,8 @@ fn test_from_u512() {
     test,
     feature = "aarch64-asm",
     target_arch = "aarch64",
-    target_family = "unix"
+    target_family = "unix",
+    target_pointer_width = "64"
 ))]
 #[test]
 fn aarch64_asm_mul_unreduced_lhs_matches_portable() {
@@ -1603,7 +1618,8 @@ fn constants_are_canonical() {
     test,
     feature = "aarch64-asm",
     target_arch = "aarch64",
-    target_family = "unix"
+    target_family = "unix",
+    target_pointer_width = "64"
 ))]
 #[test]
 fn aarch64_asm_mul_canonical_sweep_matches_portable() {
@@ -1632,7 +1648,8 @@ fn aarch64_asm_mul_canonical_sweep_matches_portable() {
     test,
     feature = "aarch64-asm",
     target_arch = "aarch64",
-    target_family = "unix"
+    target_family = "unix",
+    target_pointer_width = "64"
 ))]
 #[test]
 fn aarch64_asm_mul_unreduced_lhs_near_modulus_rhs_matches_portable() {
@@ -1679,7 +1696,8 @@ fn aarch64_asm_mul_unreduced_lhs_near_modulus_rhs_matches_portable() {
     debug_assertions,
     feature = "aarch64-asm",
     target_arch = "aarch64",
-    target_family = "unix"
+    target_family = "unix",
+    target_pointer_width = "64"
 ))]
 #[test]
 #[should_panic(expected = "requires a canonical rhs")]

--- a/src/fields/fq.rs
+++ b/src/fields/fq.rs
@@ -11,6 +11,7 @@ use lazy_static::lazy_static;
 #[cfg(feature = "bits")]
 use ff::{FieldBits, PrimeFieldBits};
 
+use super::portable;
 use crate::arithmetic::{adc, mac, sbb, SqrtTableHelpers};
 #[cfg(feature = "deferred")]
 use crate::deferred::{DeferredField, Product};
@@ -316,8 +317,16 @@ impl Fq {
     /// Squares this element.
     #[cfg_attr(not(feature = "uninline-portable"), inline)]
     pub const fn square(&self) -> Fq {
-        let u = self.square_unreduced();
-        Fq::montgomery_reduce(u[0], u[1], u[2], u[3], u[4], u[5], u[6], u[7])
+        #[cfg(target_arch = "x86_64")]
+        {
+            Fq(portable::square(&self.0, &MODULUS.0, INV))
+        }
+
+        #[cfg(not(target_arch = "x86_64"))]
+        {
+            let u = self.square_unreduced();
+            Fq::montgomery_reduce(u[0], u[1], u[2], u[3], u[4], u[5], u[6], u[7])
+        }
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -441,7 +450,38 @@ impl Fq {
             target_vendor = "apple"
         )))]
         {
-            (0..n).fold(*self, |acc, _| acc.square()).mul(by)
+            // Leave the accumulator unreduced between squarings. The closing
+            // multiplication canonicalizes its result.
+            Fq(portable::sqr_n_lazy(&self.0, n, &MODULUS.0, INV)).mul(by)
+        }
+    }
+
+    /// Squares `self` `n` times (`n` must be at least 1). Reached through
+    /// [`SqrtTableHelpers`], which nothing uses without `sqrt-table`.
+    #[cfg_attr(not(feature = "sqrt-table"), allow(dead_code))]
+    #[inline]
+    fn sqr_n_runtime(&self, n: u32) -> Self {
+        assert!(n >= 1);
+
+        #[cfg(all(
+            feature = "aarch64-asm",
+            target_arch = "aarch64",
+            target_vendor = "apple"
+        ))]
+        {
+            (0..n).fold(*self, |acc, _| acc.square_runtime())
+        }
+
+        #[cfg(not(all(
+            feature = "aarch64-asm",
+            target_arch = "aarch64",
+            target_vendor = "apple"
+        )))]
+        {
+            Fq(portable::canonicalize(
+                &portable::sqr_n_lazy(&self.0, n, &MODULUS.0, INV),
+                &MODULUS.0,
+            ))
         }
     }
 
@@ -523,35 +563,15 @@ impl Fq {
     }
 
     /// Squares this element, returning the unreduced 512-bit product.
+    /// On x86-64, `square` reduces the product's halves separately, so this
+    /// only feeds the `deferred` accumulator and the tests on that target.
+    #[cfg_attr(
+        all(target_arch = "x86_64", not(feature = "deferred")),
+        allow(dead_code)
+    )]
     #[cfg_attr(not(feature = "uninline-portable"), inline)]
     pub(crate) const fn square_unreduced(&self) -> [u64; 8] {
-        let (r1, carry) = mac(0, self.0[0], self.0[1], 0);
-        let (r2, carry) = mac(0, self.0[0], self.0[2], carry);
-        let (r3, r4) = mac(0, self.0[0], self.0[3], carry);
-
-        let (r3, carry) = mac(r3, self.0[1], self.0[2], 0);
-        let (r4, r5) = mac(r4, self.0[1], self.0[3], carry);
-
-        let (r5, r6) = mac(r5, self.0[2], self.0[3], 0);
-
-        let r7 = r6 >> 63;
-        let r6 = (r6 << 1) | (r5 >> 63);
-        let r5 = (r5 << 1) | (r4 >> 63);
-        let r4 = (r4 << 1) | (r3 >> 63);
-        let r3 = (r3 << 1) | (r2 >> 63);
-        let r2 = (r2 << 1) | (r1 >> 63);
-        let r1 = r1 << 1;
-
-        let (r0, carry) = mac(0, self.0[0], self.0[0], 0);
-        let (r1, carry) = adc(0, r1, carry);
-        let (r2, carry) = mac(r2, self.0[1], self.0[1], carry);
-        let (r3, carry) = adc(0, r3, carry);
-        let (r4, carry) = mac(r4, self.0[2], self.0[2], carry);
-        let (r5, carry) = adc(0, r5, carry);
-        let (r6, carry) = mac(r6, self.0[3], self.0[3], carry);
-        let (r7, _) = adc(0, r7, carry);
-
-        [r0, r1, r2, r3, r4, r5, r6, r7]
+        portable::square_wide(&self.0)
     }
 }
 
@@ -694,9 +714,9 @@ impl ff::Field for Fq {
             Some(res) => res,
             None => return Self::one(),
         };
-        // Flush the squarings for any trailing zero bits.
-        for _ in 0..squares {
-            res = res.square_runtime();
+        // Flush any trailing zero bits as one lazy squaring chain.
+        if squares != 0 {
+            res = res.sqr_n_runtime(squares);
         }
         res
     }
@@ -870,7 +890,15 @@ impl SqrtTableHelpers for Fq {
         let sq = sp.sqr_n_mul_runtime(4, &s111);
         let sr = sq.sqr_n_mul_runtime(5, &s1011);
         let ss = sr.sqr_n_mul_runtime(3, self);
-        (0..4).fold(ss, |x, _| x.square_runtime()) // st
+        ss.sqr_n_runtime(4) // st
+    }
+
+    fn sqr_n(&self, n: u32) -> Self {
+        self.sqr_n_runtime(n)
+    }
+
+    fn sqr_n_mul(&self, n: u32, by: &Self) -> Self {
+        self.sqr_n_mul_runtime(n, by)
     }
 
     fn sqrt_hash_key(&self) -> u32 {
@@ -1167,6 +1195,131 @@ fn test_pow_by_t_minus1_over2() {
     // NB: TWO_INV is standing in as a "random" field element
     let v = (Fq::TWO_INV).pow_by_t_minus1_over2();
     assert!(v == ff::Field::pow_vartime(&Fq::TWO_INV, T_MINUS1_OVER2));
+}
+
+#[test]
+fn low_half_reduction_matches_classical() {
+    use rand::SeedableRng;
+
+    let mut rng = rand_xorshift::XorShiftRng::from_seed([0x3c; 16]);
+    let classical =
+        |t: [u64; 8]| Fq::montgomery_reduce(t[0], t[1], t[2], t[3], t[4], t[5], t[6], t[7]);
+    let low_half = |t: [u64; 8]| {
+        Fq(super::portable::canonicalize(
+            &super::portable::montgomery_reduce_low_lazy(&t, &MODULUS.0, INV),
+            &MODULUS.0,
+        ))
+    };
+    // Any `t_lo + R * t_hi` with canonical `t_hi` is below `R * q`, the whole
+    // domain both reductions accept; squares and products are a subset.
+    for _ in 0..20_000 {
+        let hi = <Fq as ff::Field>::random(&mut rng);
+        let lo = <Fq as ff::Field>::random(&mut rng);
+        let t = [
+            lo.0[0], lo.0[1], lo.0[2], lo.0[3], hi.0[0], hi.0[1], hi.0[2], hi.0[3],
+        ];
+        assert_eq!(low_half(t), classical(t));
+        let a = <Fq as ff::Field>::random(&mut rng);
+        let u = a.square_unreduced();
+        assert_eq!(a.square(), classical(u));
+        assert_eq!(a.square(), low_half(u));
+    }
+
+    // Boundary values: zero, `R * (q - 1)`, an all-ones low half under both
+    // the largest canonical and a zero high half, and `(q - 1)^2`.
+    let max = -Fq::one();
+    let ones = [u64::MAX; 4];
+    for t in [
+        [0u64; 8],
+        [0, 0, 0, 0, max.0[0], max.0[1], max.0[2], max.0[3]],
+        [
+            ones[0], ones[1], ones[2], ones[3], max.0[0], max.0[1], max.0[2], max.0[3],
+        ],
+        [ones[0], ones[1], ones[2], ones[3], 0, 0, 0, 0],
+        max.square_unreduced(),
+    ] {
+        assert_eq!(low_half(t), classical(t));
+    }
+    assert_eq!(max.square(), classical(max.square_unreduced()));
+}
+
+#[test]
+fn sqr_n_chains_match_eager_squaring() {
+    use rand::SeedableRng;
+
+    let mut rng = rand_xorshift::XorShiftRng::from_seed([0x71; 16]);
+
+    // Test chains much longer than any production caller uses.
+    for _ in 0..100 {
+        let a = <Fq as ff::Field>::random(&mut rng);
+        let by = <Fq as ff::Field>::random(&mut rng);
+
+        let mut eager = a;
+        for n in 1..=512u32 {
+            eager = eager.square();
+            assert_eq!(a.sqr_n_runtime(n), eager, "sqr_n, n = {n}");
+            assert_eq!(
+                a.sqr_n_mul_runtime(n, &by),
+                eager * by,
+                "sqr_n_mul, n = {n}"
+            );
+        }
+    }
+
+    assert_eq!(Fq::zero().sqr_n_runtime(7), Fq::zero());
+    assert_eq!(Fq::one().sqr_n_mul_runtime(7, &Fq::one()), Fq::one());
+    let a = <Fq as ff::Field>::random(&mut rng);
+    assert_eq!(a.sqr_n(9), a.sqr_n_runtime(9));
+    assert_eq!(a.sqr_n_mul(9, &a), a.sqr_n_mul_runtime(9, &a));
+}
+
+#[test]
+fn sqr_n_lazy_accumulator_stays_below_two_q() {
+    use rand::SeedableRng;
+
+    let mut rng = rand_xorshift::XorShiftRng::from_seed([0x9d; 16]);
+
+    let two_q = {
+        let (d0, c0) = MODULUS.0[0].overflowing_add(MODULUS.0[0]);
+        let (d1, c1) = MODULUS.0[1].overflowing_add(MODULUS.0[1]);
+        let (d1, c2) = d1.overflowing_add(c0 as u64);
+        let (d2, c3) = MODULUS.0[2].overflowing_add(MODULUS.0[2]);
+        let (d2, c4) = d2.overflowing_add((c1 | c2) as u64);
+        let d3 = MODULUS.0[3]
+            .wrapping_add(MODULUS.0[3])
+            .wrapping_add((c3 | c4) as u64);
+        [d0, d1, d2, d3]
+    };
+    let below_two_q = |x: &[u64; 4]| {
+        let mut i = 4;
+        while i > 0 {
+            i -= 1;
+            if x[i] != two_q[i] {
+                return x[i] < two_q[i];
+            }
+        }
+        false
+    };
+
+    // Exercise random starts and the largest canonical value.
+    for i in 0..51 {
+        let start = if i < 50 {
+            <Fq as ff::Field>::random(&mut rng).0
+        } else {
+            (-Fq::one()).0
+        };
+        let mut acc = start;
+        for n in 1..=2048u32 {
+            acc = portable::sqr_n_lazy(&acc, 1, &MODULUS.0, INV);
+            assert!(below_two_q(&acc), "accumulator reached 2q at step {n}");
+            if n.is_power_of_two() {
+                assert_eq!(
+                    Fq(portable::canonicalize(&acc, &MODULUS.0)),
+                    Fq(start).sqr_n_runtime(n)
+                );
+            }
+        }
+    }
 }
 
 #[test]

--- a/src/fields/fq.rs
+++ b/src/fields/fq.rs
@@ -696,8 +696,28 @@ impl ff::Field for Fq {
         ])
     }
 
+    #[inline(always)]
     fn double(&self) -> Self {
-        self.double()
+        #[cfg(all(
+            feature = "aarch64-asm",
+            target_arch = "aarch64",
+            target_vendor = "apple",
+            target_pointer_width = "64",
+            target_endian = "little",
+        ))]
+        {
+            Self(super::aarch64_asm::add(&self.0, &self.0, &MODULUS.0))
+        }
+        #[cfg(not(all(
+            feature = "aarch64-asm",
+            target_arch = "aarch64",
+            target_vendor = "apple",
+            target_pointer_width = "64",
+            target_endian = "little",
+        )))]
+        {
+            self.double()
+        }
     }
 
     #[inline(always)]
@@ -1085,12 +1105,20 @@ fn aarch64_asm_matches_portable_arithmetic() {
     use rand::SeedableRng;
 
     let max_montgomery_residue = Fq([MODULUS.0[0] - 1, MODULUS.0[1], MODULUS.0[2], MODULUS.0[3]]);
+    // Raw Montgomery residues straddling the doubling reduction threshold.
+    let half_modulus = Fq(core::array::from_fn(|limb| {
+        (MODULUS.0[limb] >> 1) | (MODULUS.0.get(limb + 1).copied().unwrap_or(0) << 63)
+    }));
+    let raw_one = Fq([1, 0, 0, 0]);
     let boundaries = [
         Fq::zero(),
         Fq::one(),
         -Fq::one(),
         Fq::from_raw([1, 0, 0, 0]),
         max_montgomery_residue,
+        Fq::sub(&half_modulus, &raw_one),
+        half_modulus,
+        Fq::add(&half_modulus, &raw_one),
         Fq::from_raw([u64::MAX; 4]),
     ];
 
@@ -1104,6 +1132,7 @@ fn aarch64_asm_matches_portable_arithmetic() {
 
     for lhs in boundaries {
         aarch64_asm_check_repr(lhs);
+        assert_eq!(<Fq as Field>::double(&lhs), Fq::double(&lhs));
         assert_eq!(<Fq as Field>::square(&lhs), Fq::square(&lhs));
         for n in [1, 2, 7, 129] {
             assert_eq!(lhs.sqr_n_runtime(n), portable_sqr_n(lhs, n));
@@ -1136,6 +1165,7 @@ fn aarch64_asm_matches_portable_arithmetic() {
         assert_eq!(&lhs - &raw_one, Fq::sub(&lhs, &raw_one));
         assert_eq!(&raw_one - &lhs, Fq::sub(&raw_one, &lhs));
         assert_eq!(&lhs - &lhs, Fq::ZERO);
+        assert_eq!(<Fq as Field>::double(&lhs), Fq::double(&lhs));
         for rhs in [complement.sub(&Fq([1, 0, 0, 0])), complement] {
             assert_eq!(&lhs + &rhs, Fq::add(&lhs, &rhs));
         }
@@ -1156,6 +1186,7 @@ fn aarch64_asm_matches_portable_arithmetic() {
             rng.next_u64(),
         ]);
 
+        assert_eq!(<Fq as Field>::double(&lhs), Fq::double(&lhs));
         aarch64_asm_check_repr(lhs);
         assert_eq!(lhs.cmp(&rhs), aarch64_asm_portable_cmp(lhs, rhs));
         assert_eq!(&lhs * &rhs, Fq::mul(&lhs, &rhs));

--- a/src/fields/fq.rs
+++ b/src/fields/fq.rs
@@ -389,7 +389,7 @@ impl Fq {
         #[cfg(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_vendor = "apple"
+            target_family = "unix"
         ))]
         {
             Fq(super::aarch64_asm::mul(&self.0, &rhs.0, &MODULUS.0, INV))
@@ -398,7 +398,7 @@ impl Fq {
         #[cfg(not(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_vendor = "apple"
+            target_family = "unix"
         )))]
         {
             self.mul(rhs)
@@ -410,7 +410,7 @@ impl Fq {
         #[cfg(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_vendor = "apple"
+            target_family = "unix"
         ))]
         {
             Fq(super::aarch64_asm::square(&self.0, &MODULUS.0, INV))
@@ -419,7 +419,7 @@ impl Fq {
         #[cfg(not(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_vendor = "apple"
+            target_family = "unix"
         )))]
         {
             self.square()
@@ -436,7 +436,7 @@ impl Fq {
         #[cfg(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_vendor = "apple"
+            target_family = "unix"
         ))]
         {
             Fq(super::aarch64_asm::sqr_n_mul(
@@ -447,7 +447,7 @@ impl Fq {
         #[cfg(not(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_vendor = "apple"
+            target_family = "unix"
         )))]
         {
             // Leave the accumulator unreduced between squarings. The closing
@@ -466,7 +466,7 @@ impl Fq {
         #[cfg(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_vendor = "apple"
+            target_family = "unix"
         ))]
         {
             // Calling the dedicated single-square routine is faster than
@@ -483,7 +483,7 @@ impl Fq {
         #[cfg(not(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_vendor = "apple"
+            target_family = "unix"
         )))]
         {
             Fq(portable::canonicalize(
@@ -790,14 +790,14 @@ impl ff::PrimeField for Fq {
         #[cfg(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_vendor = "apple"
+            target_family = "unix"
         ))]
         let tmp = Fq(super::aarch64_asm::from_mont(&self.0, &MODULUS.0, INV));
 
         #[cfg(not(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_vendor = "apple"
+            target_family = "unix"
         )))]
         let tmp = Fq::montgomery_reduce(self.0[0], self.0[1], self.0[2], self.0[3], 0, 0, 0, 0);
 
@@ -966,7 +966,7 @@ impl ec_gpu::GpuField for Fq {
     test,
     feature = "aarch64-asm",
     target_arch = "aarch64",
-    target_vendor = "apple"
+    target_family = "unix"
 ))]
 fn aarch64_asm_portable_repr(value: Fq) -> [u8; 32] {
     let value = Fq::montgomery_reduce(value.0[0], value.0[1], value.0[2], value.0[3], 0, 0, 0, 0);
@@ -981,7 +981,7 @@ fn aarch64_asm_portable_repr(value: Fq) -> [u8; 32] {
     test,
     feature = "aarch64-asm",
     target_arch = "aarch64",
-    target_vendor = "apple"
+    target_family = "unix"
 ))]
 fn aarch64_asm_check_repr(value: Fq) {
     let portable = aarch64_asm_portable_repr(value);
@@ -994,7 +994,7 @@ fn aarch64_asm_check_repr(value: Fq) {
     test,
     feature = "aarch64-asm",
     target_arch = "aarch64",
-    target_vendor = "apple"
+    target_family = "unix"
 ))]
 fn aarch64_asm_portable_cmp(lhs: Fq, rhs: Fq) -> core::cmp::Ordering {
     aarch64_asm_portable_repr(lhs)
@@ -1012,7 +1012,7 @@ fn aarch64_asm_portable_cmp(lhs: Fq, rhs: Fq) -> core::cmp::Ordering {
     test,
     feature = "aarch64-asm",
     target_arch = "aarch64",
-    target_vendor = "apple"
+    target_family = "unix"
 ))]
 #[test]
 fn aarch64_asm_matches_portable_arithmetic() {
@@ -1468,7 +1468,7 @@ fn test_from_u512() {
     test,
     feature = "aarch64-asm",
     target_arch = "aarch64",
-    target_vendor = "apple"
+    target_family = "unix"
 ))]
 #[test]
 fn aarch64_asm_mul_unreduced_lhs_matches_portable() {
@@ -1602,7 +1602,7 @@ fn constants_are_canonical() {
     test,
     feature = "aarch64-asm",
     target_arch = "aarch64",
-    target_vendor = "apple"
+    target_family = "unix"
 ))]
 #[test]
 fn aarch64_asm_mul_canonical_sweep_matches_portable() {
@@ -1631,7 +1631,7 @@ fn aarch64_asm_mul_canonical_sweep_matches_portable() {
     test,
     feature = "aarch64-asm",
     target_arch = "aarch64",
-    target_vendor = "apple"
+    target_family = "unix"
 ))]
 #[test]
 fn aarch64_asm_mul_unreduced_lhs_near_modulus_rhs_matches_portable() {
@@ -1678,7 +1678,7 @@ fn aarch64_asm_mul_unreduced_lhs_near_modulus_rhs_matches_portable() {
     debug_assertions,
     feature = "aarch64-asm",
     target_arch = "aarch64",
-    target_vendor = "apple"
+    target_family = "unix"
 ))]
 #[test]
 #[should_panic(expected = "requires a canonical rhs")]

--- a/src/fields/fq.rs
+++ b/src/fields/fq.rs
@@ -389,7 +389,8 @@ impl Fq {
         #[cfg(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_family = "unix"
+            target_family = "unix",
+            target_pointer_width = "64"
         ))]
         {
             Fq(super::aarch64_asm::mul(&self.0, &rhs.0, &MODULUS.0, INV))
@@ -398,7 +399,8 @@ impl Fq {
         #[cfg(not(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_family = "unix"
+            target_family = "unix",
+            target_pointer_width = "64"
         )))]
         {
             self.mul(rhs)
@@ -410,7 +412,8 @@ impl Fq {
         #[cfg(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_family = "unix"
+            target_family = "unix",
+            target_pointer_width = "64"
         ))]
         {
             Fq(super::aarch64_asm::square(&self.0, &MODULUS.0, INV))
@@ -419,7 +422,8 @@ impl Fq {
         #[cfg(not(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_family = "unix"
+            target_family = "unix",
+            target_pointer_width = "64"
         )))]
         {
             self.square()
@@ -436,7 +440,8 @@ impl Fq {
         #[cfg(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_family = "unix"
+            target_family = "unix",
+            target_pointer_width = "64"
         ))]
         {
             Fq(super::aarch64_asm::sqr_n_mul(
@@ -447,7 +452,8 @@ impl Fq {
         #[cfg(not(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_family = "unix"
+            target_family = "unix",
+            target_pointer_width = "64"
         )))]
         {
             // Leave the accumulator unreduced between squarings. The closing
@@ -466,7 +472,8 @@ impl Fq {
         #[cfg(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_family = "unix"
+            target_family = "unix",
+            target_pointer_width = "64"
         ))]
         {
             // Calling the dedicated single-square routine is faster than
@@ -483,7 +490,8 @@ impl Fq {
         #[cfg(not(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_family = "unix"
+            target_family = "unix",
+            target_pointer_width = "64"
         )))]
         {
             Fq(portable::canonicalize(
@@ -790,14 +798,16 @@ impl ff::PrimeField for Fq {
         #[cfg(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_family = "unix"
+            target_family = "unix",
+            target_pointer_width = "64"
         ))]
         let tmp = Fq(super::aarch64_asm::from_mont(&self.0, &MODULUS.0, INV));
 
         #[cfg(not(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_family = "unix"
+            target_family = "unix",
+            target_pointer_width = "64"
         )))]
         let tmp = Fq::montgomery_reduce(self.0[0], self.0[1], self.0[2], self.0[3], 0, 0, 0, 0);
 
@@ -966,7 +976,8 @@ impl ec_gpu::GpuField for Fq {
     test,
     feature = "aarch64-asm",
     target_arch = "aarch64",
-    target_family = "unix"
+    target_family = "unix",
+    target_pointer_width = "64"
 ))]
 fn aarch64_asm_portable_repr(value: Fq) -> [u8; 32] {
     let value = Fq::montgomery_reduce(value.0[0], value.0[1], value.0[2], value.0[3], 0, 0, 0, 0);
@@ -981,7 +992,8 @@ fn aarch64_asm_portable_repr(value: Fq) -> [u8; 32] {
     test,
     feature = "aarch64-asm",
     target_arch = "aarch64",
-    target_family = "unix"
+    target_family = "unix",
+    target_pointer_width = "64"
 ))]
 fn aarch64_asm_check_repr(value: Fq) {
     let portable = aarch64_asm_portable_repr(value);
@@ -994,7 +1006,8 @@ fn aarch64_asm_check_repr(value: Fq) {
     test,
     feature = "aarch64-asm",
     target_arch = "aarch64",
-    target_family = "unix"
+    target_family = "unix",
+    target_pointer_width = "64"
 ))]
 fn aarch64_asm_portable_cmp(lhs: Fq, rhs: Fq) -> core::cmp::Ordering {
     aarch64_asm_portable_repr(lhs)
@@ -1012,7 +1025,8 @@ fn aarch64_asm_portable_cmp(lhs: Fq, rhs: Fq) -> core::cmp::Ordering {
     test,
     feature = "aarch64-asm",
     target_arch = "aarch64",
-    target_family = "unix"
+    target_family = "unix",
+    target_pointer_width = "64"
 ))]
 #[test]
 fn aarch64_asm_matches_portable_arithmetic() {
@@ -1468,7 +1482,8 @@ fn test_from_u512() {
     test,
     feature = "aarch64-asm",
     target_arch = "aarch64",
-    target_family = "unix"
+    target_family = "unix",
+    target_pointer_width = "64"
 ))]
 #[test]
 fn aarch64_asm_mul_unreduced_lhs_matches_portable() {
@@ -1602,7 +1617,8 @@ fn constants_are_canonical() {
     test,
     feature = "aarch64-asm",
     target_arch = "aarch64",
-    target_family = "unix"
+    target_family = "unix",
+    target_pointer_width = "64"
 ))]
 #[test]
 fn aarch64_asm_mul_canonical_sweep_matches_portable() {
@@ -1631,7 +1647,8 @@ fn aarch64_asm_mul_canonical_sweep_matches_portable() {
     test,
     feature = "aarch64-asm",
     target_arch = "aarch64",
-    target_family = "unix"
+    target_family = "unix",
+    target_pointer_width = "64"
 ))]
 #[test]
 fn aarch64_asm_mul_unreduced_lhs_near_modulus_rhs_matches_portable() {
@@ -1678,7 +1695,8 @@ fn aarch64_asm_mul_unreduced_lhs_near_modulus_rhs_matches_portable() {
     debug_assertions,
     feature = "aarch64-asm",
     target_arch = "aarch64",
-    target_family = "unix"
+    target_family = "unix",
+    target_pointer_width = "64"
 ))]
 #[test]
 #[should_panic(expected = "requires a canonical rhs")]

--- a/src/fields/fq.rs
+++ b/src/fields/fq.rs
@@ -160,7 +160,26 @@ impl Add<&Fq> for &Fq {
 
     #[inline]
     fn add(self, rhs: &Fq) -> Fq {
-        self.add(rhs)
+        #[cfg(all(
+            feature = "aarch64-asm",
+            target_arch = "aarch64",
+            target_vendor = "apple",
+            target_pointer_width = "64",
+            target_endian = "little",
+        ))]
+        {
+            Fq(super::aarch64_asm::add(&self.0, &rhs.0, &MODULUS.0))
+        }
+        #[cfg(not(all(
+            feature = "aarch64-asm",
+            target_arch = "aarch64",
+            target_vendor = "apple",
+            target_pointer_width = "64",
+            target_endian = "little",
+        )))]
+        {
+            self.add(rhs)
+        }
     }
 }
 
@@ -1073,6 +1092,7 @@ fn aarch64_asm_matches_portable_arithmetic() {
         for rhs in boundaries {
             assert_eq!(lhs.cmp(&rhs), aarch64_asm_portable_cmp(lhs, rhs));
             assert_eq!(&lhs * &rhs, Fq::mul(&lhs, &rhs));
+            assert_eq!(&lhs + &rhs, Fq::add(&lhs, &rhs));
             for n in [1, 2, 7] {
                 assert_eq!(
                     lhs.sqr_n_mul_runtime(n, &rhs),
@@ -1083,6 +1103,19 @@ fn aarch64_asm_matches_portable_arithmetic() {
     }
 
     let mut rng = rand_xorshift::XorShiftRng::from_seed([0xa5; 16]);
+    // Exercise carries across each limb and sums immediately around p.
+    // These are raw Montgomery residues; 2^bit < p for bit < 254.
+    for bit in 0..254 {
+        let mut limbs = [0; 4];
+        limbs[bit / 64] = 1 << (bit % 64);
+        let lhs = Fq(limbs);
+        let complement = Fq::sub(&MODULUS, &lhs);
+        for rhs in [complement.sub(&Fq([1, 0, 0, 0])), complement] {
+            assert_eq!(&lhs + &rhs, Fq::add(&lhs, &rhs));
+        }
+        assert_eq!(&lhs + &lhs, Fq::double(&lhs));
+    }
+
     for _ in 0..1024 {
         let lhs = Fq::from_raw([
             rng.next_u64(),
@@ -1100,6 +1133,8 @@ fn aarch64_asm_matches_portable_arithmetic() {
         aarch64_asm_check_repr(lhs);
         assert_eq!(lhs.cmp(&rhs), aarch64_asm_portable_cmp(lhs, rhs));
         assert_eq!(&lhs * &rhs, Fq::mul(&lhs, &rhs));
+        assert_eq!(&lhs + &rhs, Fq::add(&lhs, &rhs));
+        assert_eq!(&lhs + &lhs, Fq::double(&lhs));
         assert_eq!(<Fq as Field>::square(&lhs), Fq::square(&lhs));
         for n in [1, 129] {
             assert_eq!(lhs.sqr_n_runtime(n), portable_sqr_n(lhs, n));

--- a/src/fields/fq.rs
+++ b/src/fields/fq.rs
@@ -390,7 +390,8 @@ impl Fq {
             feature = "aarch64-asm",
             target_arch = "aarch64",
             target_family = "unix",
-            target_pointer_width = "64"
+            target_pointer_width = "64",
+            target_endian = "little"
         ))]
         {
             Fq(super::aarch64_asm::mul(&self.0, &rhs.0, &MODULUS.0, INV))
@@ -400,7 +401,8 @@ impl Fq {
             feature = "aarch64-asm",
             target_arch = "aarch64",
             target_family = "unix",
-            target_pointer_width = "64"
+            target_pointer_width = "64",
+            target_endian = "little"
         )))]
         {
             self.mul(rhs)
@@ -413,7 +415,8 @@ impl Fq {
             feature = "aarch64-asm",
             target_arch = "aarch64",
             target_family = "unix",
-            target_pointer_width = "64"
+            target_pointer_width = "64",
+            target_endian = "little"
         ))]
         {
             Fq(super::aarch64_asm::square(&self.0, &MODULUS.0, INV))
@@ -423,7 +426,8 @@ impl Fq {
             feature = "aarch64-asm",
             target_arch = "aarch64",
             target_family = "unix",
-            target_pointer_width = "64"
+            target_pointer_width = "64",
+            target_endian = "little"
         )))]
         {
             self.square()
@@ -441,7 +445,8 @@ impl Fq {
             feature = "aarch64-asm",
             target_arch = "aarch64",
             target_family = "unix",
-            target_pointer_width = "64"
+            target_pointer_width = "64",
+            target_endian = "little"
         ))]
         {
             Fq(super::aarch64_asm::sqr_n_mul(
@@ -453,7 +458,8 @@ impl Fq {
             feature = "aarch64-asm",
             target_arch = "aarch64",
             target_family = "unix",
-            target_pointer_width = "64"
+            target_pointer_width = "64",
+            target_endian = "little"
         )))]
         {
             // Leave the accumulator unreduced between squarings. The closing
@@ -473,7 +479,8 @@ impl Fq {
             feature = "aarch64-asm",
             target_arch = "aarch64",
             target_family = "unix",
-            target_pointer_width = "64"
+            target_pointer_width = "64",
+            target_endian = "little"
         ))]
         {
             // Calling the dedicated single-square routine is faster than
@@ -491,7 +498,8 @@ impl Fq {
             feature = "aarch64-asm",
             target_arch = "aarch64",
             target_family = "unix",
-            target_pointer_width = "64"
+            target_pointer_width = "64",
+            target_endian = "little"
         )))]
         {
             Fq(portable::canonicalize(
@@ -799,7 +807,8 @@ impl ff::PrimeField for Fq {
             feature = "aarch64-asm",
             target_arch = "aarch64",
             target_family = "unix",
-            target_pointer_width = "64"
+            target_pointer_width = "64",
+            target_endian = "little"
         ))]
         let tmp = Fq(super::aarch64_asm::from_mont(&self.0, &MODULUS.0, INV));
 
@@ -807,7 +816,8 @@ impl ff::PrimeField for Fq {
             feature = "aarch64-asm",
             target_arch = "aarch64",
             target_family = "unix",
-            target_pointer_width = "64"
+            target_pointer_width = "64",
+            target_endian = "little"
         )))]
         let tmp = Fq::montgomery_reduce(self.0[0], self.0[1], self.0[2], self.0[3], 0, 0, 0, 0);
 
@@ -977,7 +987,8 @@ impl ec_gpu::GpuField for Fq {
     feature = "aarch64-asm",
     target_arch = "aarch64",
     target_family = "unix",
-    target_pointer_width = "64"
+    target_pointer_width = "64",
+    target_endian = "little"
 ))]
 fn aarch64_asm_portable_repr(value: Fq) -> [u8; 32] {
     let value = Fq::montgomery_reduce(value.0[0], value.0[1], value.0[2], value.0[3], 0, 0, 0, 0);
@@ -993,7 +1004,8 @@ fn aarch64_asm_portable_repr(value: Fq) -> [u8; 32] {
     feature = "aarch64-asm",
     target_arch = "aarch64",
     target_family = "unix",
-    target_pointer_width = "64"
+    target_pointer_width = "64",
+    target_endian = "little"
 ))]
 fn aarch64_asm_check_repr(value: Fq) {
     let portable = aarch64_asm_portable_repr(value);
@@ -1007,7 +1019,8 @@ fn aarch64_asm_check_repr(value: Fq) {
     feature = "aarch64-asm",
     target_arch = "aarch64",
     target_family = "unix",
-    target_pointer_width = "64"
+    target_pointer_width = "64",
+    target_endian = "little"
 ))]
 fn aarch64_asm_portable_cmp(lhs: Fq, rhs: Fq) -> core::cmp::Ordering {
     aarch64_asm_portable_repr(lhs)
@@ -1026,7 +1039,8 @@ fn aarch64_asm_portable_cmp(lhs: Fq, rhs: Fq) -> core::cmp::Ordering {
     feature = "aarch64-asm",
     target_arch = "aarch64",
     target_family = "unix",
-    target_pointer_width = "64"
+    target_pointer_width = "64",
+    target_endian = "little"
 ))]
 #[test]
 fn aarch64_asm_matches_portable_arithmetic() {
@@ -1483,7 +1497,8 @@ fn test_from_u512() {
     feature = "aarch64-asm",
     target_arch = "aarch64",
     target_family = "unix",
-    target_pointer_width = "64"
+    target_pointer_width = "64",
+    target_endian = "little"
 ))]
 #[test]
 fn aarch64_asm_mul_unreduced_lhs_matches_portable() {
@@ -1618,7 +1633,8 @@ fn constants_are_canonical() {
     feature = "aarch64-asm",
     target_arch = "aarch64",
     target_family = "unix",
-    target_pointer_width = "64"
+    target_pointer_width = "64",
+    target_endian = "little"
 ))]
 #[test]
 fn aarch64_asm_mul_canonical_sweep_matches_portable() {
@@ -1648,7 +1664,8 @@ fn aarch64_asm_mul_canonical_sweep_matches_portable() {
     feature = "aarch64-asm",
     target_arch = "aarch64",
     target_family = "unix",
-    target_pointer_width = "64"
+    target_pointer_width = "64",
+    target_endian = "little"
 ))]
 #[test]
 fn aarch64_asm_mul_unreduced_lhs_near_modulus_rhs_matches_portable() {
@@ -1696,7 +1713,8 @@ fn aarch64_asm_mul_unreduced_lhs_near_modulus_rhs_matches_portable() {
     feature = "aarch64-asm",
     target_arch = "aarch64",
     target_family = "unix",
-    target_pointer_width = "64"
+    target_pointer_width = "64",
+    target_endian = "little"
 ))]
 #[test]
 #[should_panic(expected = "requires a canonical rhs")]

--- a/src/fields/fq.rs
+++ b/src/fields/fq.rs
@@ -154,7 +154,7 @@ impl Sub<&Fq> for &Fq {
         #[cfg(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_family = "unix",
+            any(target_family = "unix", target_os = "none"),
             target_pointer_width = "64",
             target_endian = "little",
         ))]
@@ -164,7 +164,7 @@ impl Sub<&Fq> for &Fq {
         #[cfg(not(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_family = "unix",
+            any(target_family = "unix", target_os = "none"),
             target_pointer_width = "64",
             target_endian = "little",
         )))]
@@ -182,7 +182,7 @@ impl Add<&Fq> for &Fq {
         #[cfg(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_family = "unix",
+            any(target_family = "unix", target_os = "none"),
             target_pointer_width = "64",
             target_endian = "little",
         ))]
@@ -192,7 +192,7 @@ impl Add<&Fq> for &Fq {
         #[cfg(not(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_family = "unix",
+            any(target_family = "unix", target_os = "none"),
             target_pointer_width = "64",
             target_endian = "little",
         )))]
@@ -427,7 +427,7 @@ impl Fq {
         #[cfg(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_family = "unix",
+            any(target_family = "unix", target_os = "none"),
             target_pointer_width = "64",
             target_endian = "little"
         ))]
@@ -438,7 +438,7 @@ impl Fq {
         #[cfg(not(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_family = "unix",
+            any(target_family = "unix", target_os = "none"),
             target_pointer_width = "64",
             target_endian = "little"
         )))]
@@ -452,7 +452,7 @@ impl Fq {
         #[cfg(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_family = "unix",
+            any(target_family = "unix", target_os = "none"),
             target_pointer_width = "64",
             target_endian = "little"
         ))]
@@ -463,7 +463,7 @@ impl Fq {
         #[cfg(not(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_family = "unix",
+            any(target_family = "unix", target_os = "none"),
             target_pointer_width = "64",
             target_endian = "little"
         )))]
@@ -482,7 +482,7 @@ impl Fq {
         #[cfg(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_family = "unix",
+            any(target_family = "unix", target_os = "none"),
             target_pointer_width = "64",
             target_endian = "little"
         ))]
@@ -495,7 +495,7 @@ impl Fq {
         #[cfg(not(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_family = "unix",
+            any(target_family = "unix", target_os = "none"),
             target_pointer_width = "64",
             target_endian = "little"
         )))]
@@ -516,7 +516,7 @@ impl Fq {
         #[cfg(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_family = "unix",
+            any(target_family = "unix", target_os = "none"),
             target_pointer_width = "64",
             target_endian = "little"
         ))]
@@ -535,7 +535,7 @@ impl Fq {
         #[cfg(not(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_family = "unix",
+            any(target_family = "unix", target_os = "none"),
             target_pointer_width = "64",
             target_endian = "little"
         )))]
@@ -864,7 +864,7 @@ impl ff::PrimeField for Fq {
         #[cfg(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_family = "unix",
+            any(target_family = "unix", target_os = "none"),
             target_pointer_width = "64",
             target_endian = "little"
         ))]
@@ -873,7 +873,7 @@ impl ff::PrimeField for Fq {
         #[cfg(not(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_family = "unix",
+            any(target_family = "unix", target_os = "none"),
             target_pointer_width = "64",
             target_endian = "little"
         )))]
@@ -1044,7 +1044,7 @@ impl ec_gpu::GpuField for Fq {
     test,
     feature = "aarch64-asm",
     target_arch = "aarch64",
-    target_family = "unix",
+    any(target_family = "unix", target_os = "none"),
     target_pointer_width = "64",
     target_endian = "little"
 ))]
@@ -1061,7 +1061,7 @@ fn aarch64_asm_portable_repr(value: Fq) -> [u8; 32] {
     test,
     feature = "aarch64-asm",
     target_arch = "aarch64",
-    target_family = "unix",
+    any(target_family = "unix", target_os = "none"),
     target_pointer_width = "64",
     target_endian = "little"
 ))]
@@ -1076,7 +1076,7 @@ fn aarch64_asm_check_repr(value: Fq) {
     test,
     feature = "aarch64-asm",
     target_arch = "aarch64",
-    target_family = "unix",
+    any(target_family = "unix", target_os = "none"),
     target_pointer_width = "64",
     target_endian = "little"
 ))]
@@ -1096,7 +1096,7 @@ fn aarch64_asm_portable_cmp(lhs: Fq, rhs: Fq) -> core::cmp::Ordering {
     test,
     feature = "aarch64-asm",
     target_arch = "aarch64",
-    target_family = "unix",
+    any(target_family = "unix", target_os = "none"),
     target_pointer_width = "64",
     target_endian = "little"
 ))]
@@ -1589,7 +1589,7 @@ fn test_from_u512() {
     test,
     feature = "aarch64-asm",
     target_arch = "aarch64",
-    target_family = "unix",
+    any(target_family = "unix", target_os = "none"),
     target_pointer_width = "64",
     target_endian = "little"
 ))]
@@ -1725,7 +1725,7 @@ fn constants_are_canonical() {
     test,
     feature = "aarch64-asm",
     target_arch = "aarch64",
-    target_family = "unix",
+    any(target_family = "unix", target_os = "none"),
     target_pointer_width = "64",
     target_endian = "little"
 ))]
@@ -1756,7 +1756,7 @@ fn aarch64_asm_mul_canonical_sweep_matches_portable() {
     test,
     feature = "aarch64-asm",
     target_arch = "aarch64",
-    target_family = "unix",
+    any(target_family = "unix", target_os = "none"),
     target_pointer_width = "64",
     target_endian = "little"
 ))]
@@ -1805,7 +1805,7 @@ fn aarch64_asm_mul_unreduced_lhs_near_modulus_rhs_matches_portable() {
     debug_assertions,
     feature = "aarch64-asm",
     target_arch = "aarch64",
-    target_family = "unix",
+    any(target_family = "unix", target_os = "none"),
     target_pointer_width = "64",
     target_endian = "little"
 ))]

--- a/src/fields/fq.rs
+++ b/src/fields/fq.rs
@@ -154,7 +154,7 @@ impl Sub<&Fq> for &Fq {
         #[cfg(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_vendor = "apple",
+            target_family = "unix",
             target_pointer_width = "64",
             target_endian = "little",
         ))]
@@ -164,7 +164,7 @@ impl Sub<&Fq> for &Fq {
         #[cfg(not(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_vendor = "apple",
+            target_family = "unix",
             target_pointer_width = "64",
             target_endian = "little",
         )))]
@@ -182,7 +182,7 @@ impl Add<&Fq> for &Fq {
         #[cfg(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_vendor = "apple",
+            target_family = "unix",
             target_pointer_width = "64",
             target_endian = "little",
         ))]
@@ -192,7 +192,7 @@ impl Add<&Fq> for &Fq {
         #[cfg(not(all(
             feature = "aarch64-asm",
             target_arch = "aarch64",
-            target_vendor = "apple",
+            target_family = "unix",
             target_pointer_width = "64",
             target_endian = "little",
         )))]

--- a/src/fields/fq.rs
+++ b/src/fields/fq.rs
@@ -469,7 +469,15 @@ impl Fq {
             target_vendor = "apple"
         ))]
         {
-            (0..n).fold(*self, |acc, _| acc.square_runtime())
+            // Calling the dedicated single-square routine is faster than
+            // entering the repeated-squaring loop for a one-element chain.
+            if n == 1 {
+                self.square_runtime()
+            } else {
+                Fq(super::aarch64_asm::sqr_n(
+                    &self.0, n as usize, &MODULUS.0, INV,
+                ))
+            }
         }
 
         #[cfg(not(all(
@@ -1024,9 +1032,16 @@ fn aarch64_asm_matches_portable_arithmetic() {
         (0..n).fold(value, |acc, _| Fq::square(&acc)).mul(&by)
     }
 
+    fn portable_sqr_n(value: Fq, n: u32) -> Fq {
+        (0..n).fold(value, |acc, _| Fq::square(&acc))
+    }
+
     for lhs in boundaries {
         aarch64_asm_check_repr(lhs);
         assert_eq!(<Fq as Field>::square(&lhs), Fq::square(&lhs));
+        for n in [1, 2, 7, 129] {
+            assert_eq!(lhs.sqr_n_runtime(n), portable_sqr_n(lhs, n));
+        }
         for rhs in boundaries {
             assert_eq!(lhs.cmp(&rhs), aarch64_asm_portable_cmp(lhs, rhs));
             assert_eq!(&lhs * &rhs, Fq::mul(&lhs, &rhs));
@@ -1059,6 +1074,7 @@ fn aarch64_asm_matches_portable_arithmetic() {
         assert_eq!(&lhs * &rhs, Fq::mul(&lhs, &rhs));
         assert_eq!(<Fq as Field>::square(&lhs), Fq::square(&lhs));
         for n in [1, 129] {
+            assert_eq!(lhs.sqr_n_runtime(n), portable_sqr_n(lhs, n));
             assert_eq!(
                 lhs.sqr_n_mul_runtime(n, &rhs),
                 portable_sqr_n_mul(lhs, n, rhs)

--- a/src/fields/fq.rs
+++ b/src/fields/fq.rs
@@ -151,7 +151,26 @@ impl Sub<&Fq> for &Fq {
 
     #[inline]
     fn sub(self, rhs: &Fq) -> Fq {
-        self.sub(rhs)
+        #[cfg(all(
+            feature = "aarch64-asm",
+            target_arch = "aarch64",
+            target_vendor = "apple",
+            target_pointer_width = "64",
+            target_endian = "little",
+        ))]
+        {
+            Fq(super::aarch64_asm::sub(&self.0, &rhs.0, &MODULUS.0))
+        }
+        #[cfg(not(all(
+            feature = "aarch64-asm",
+            target_arch = "aarch64",
+            target_vendor = "apple",
+            target_pointer_width = "64",
+            target_endian = "little",
+        )))]
+        {
+            self.sub(rhs)
+        }
     }
 }
 
@@ -1093,6 +1112,7 @@ fn aarch64_asm_matches_portable_arithmetic() {
             assert_eq!(lhs.cmp(&rhs), aarch64_asm_portable_cmp(lhs, rhs));
             assert_eq!(&lhs * &rhs, Fq::mul(&lhs, &rhs));
             assert_eq!(&lhs + &rhs, Fq::add(&lhs, &rhs));
+            assert_eq!(&lhs - &rhs, Fq::sub(&lhs, &rhs));
             for n in [1, 2, 7] {
                 assert_eq!(
                     lhs.sqr_n_mul_runtime(n, &rhs),
@@ -1110,6 +1130,12 @@ fn aarch64_asm_matches_portable_arithmetic() {
         limbs[bit / 64] = 1 << (bit % 64);
         let lhs = Fq(limbs);
         let complement = Fq::sub(&MODULUS, &lhs);
+        let raw_one = Fq([1, 0, 0, 0]);
+        // Subtracting one from a single set bit borrows across lower limbs;
+        // reversing the operands also exercises conditional modulus addition.
+        assert_eq!(&lhs - &raw_one, Fq::sub(&lhs, &raw_one));
+        assert_eq!(&raw_one - &lhs, Fq::sub(&raw_one, &lhs));
+        assert_eq!(&lhs - &lhs, Fq::ZERO);
         for rhs in [complement.sub(&Fq([1, 0, 0, 0])), complement] {
             assert_eq!(&lhs + &rhs, Fq::add(&lhs, &rhs));
         }
@@ -1134,6 +1160,7 @@ fn aarch64_asm_matches_portable_arithmetic() {
         assert_eq!(lhs.cmp(&rhs), aarch64_asm_portable_cmp(lhs, rhs));
         assert_eq!(&lhs * &rhs, Fq::mul(&lhs, &rhs));
         assert_eq!(&lhs + &rhs, Fq::add(&lhs, &rhs));
+        assert_eq!(&lhs - &rhs, Fq::sub(&lhs, &rhs));
         assert_eq!(&lhs + &lhs, Fq::double(&lhs));
         assert_eq!(<Fq as Field>::square(&lhs), Fq::square(&lhs));
         for n in [1, 129] {

--- a/src/fields/portable.rs
+++ b/src/fields/portable.rs
@@ -252,7 +252,8 @@ const fn reduce_square_lazy(t: &[u64; 8], modulus: &[u64; 4], inv: u64) -> [u64;
     all(
         feature = "aarch64-asm",
         target_arch = "aarch64",
-        target_family = "unix"
+        target_family = "unix",
+        target_pointer_width = "64"
     ),
     allow(dead_code)
 )]
@@ -292,7 +293,8 @@ pub(super) const fn canonicalize(value: &[u64; 4], modulus: &[u64; 4]) -> [u64; 
     all(
         feature = "aarch64-asm",
         target_arch = "aarch64",
-        target_family = "unix"
+        target_family = "unix",
+        target_pointer_width = "64"
     ),
     allow(dead_code)
 )]

--- a/src/fields/portable.rs
+++ b/src/fields/portable.rs
@@ -252,7 +252,7 @@ const fn reduce_square_lazy(t: &[u64; 8], modulus: &[u64; 4], inv: u64) -> [u64;
     all(
         feature = "aarch64-asm",
         target_arch = "aarch64",
-        target_vendor = "apple"
+        target_family = "unix"
     ),
     allow(dead_code)
 )]
@@ -292,7 +292,7 @@ pub(super) const fn canonicalize(value: &[u64; 4], modulus: &[u64; 4]) -> [u64; 
     all(
         feature = "aarch64-asm",
         target_arch = "aarch64",
-        target_vendor = "apple"
+        target_family = "unix"
     ),
     allow(dead_code)
 )]

--- a/src/fields/portable.rs
+++ b/src/fields/portable.rs
@@ -253,7 +253,8 @@ const fn reduce_square_lazy(t: &[u64; 8], modulus: &[u64; 4], inv: u64) -> [u64;
         feature = "aarch64-asm",
         target_arch = "aarch64",
         target_family = "unix",
-        target_pointer_width = "64"
+        target_pointer_width = "64",
+        target_endian = "little"
     ),
     allow(dead_code)
 )]
@@ -294,7 +295,8 @@ pub(super) const fn canonicalize(value: &[u64; 4], modulus: &[u64; 4]) -> [u64; 
         feature = "aarch64-asm",
         target_arch = "aarch64",
         target_family = "unix",
-        target_pointer_width = "64"
+        target_pointer_width = "64",
+        target_endian = "little"
     ),
     allow(dead_code)
 )]

--- a/src/fields/portable.rs
+++ b/src/fields/portable.rs
@@ -1,0 +1,313 @@
+//! Shared portable squaring for the Pasta fields.
+//!
+//! `Fp` and `Fq` have the same representation (four little-endian `u64`
+//! limbs in Montgomery form with `R = 2^256`), so their pure-Rust squaring
+//! routines are written once here over limb arrays. Each field keeps its own
+//! modulus and Montgomery reduction wrapper.
+
+use crate::arithmetic::{adc, mac, sbb};
+
+#[cfg(target_arch = "x86_64")]
+const PASTA_MODULUS_TOP_SHIFT: u32 = 62;
+#[cfg(target_arch = "x86_64")]
+const PASTA_MODULUS_TOP_OVERFLOW_SHIFT: u32 = u64::BITS - PASTA_MODULUS_TOP_SHIFT;
+
+/// Squares a canonical element, returning the canonical square.
+#[cfg(target_arch = "x86_64")]
+#[cfg_attr(not(feature = "uninline-portable"), inline)]
+pub(super) const fn square(value: &[u64; 4], modulus: &[u64; 4], inv: u64) -> [u64; 4] {
+    canonicalize(
+        &montgomery_reduce_low_lazy(&square_wide(value), modulus, inv),
+        modulus,
+    )
+}
+
+/// Squares `value`, returning the unreduced 512-bit product.
+#[cfg_attr(not(feature = "uninline-portable"), inline)]
+pub(super) const fn square_wide(value: &[u64; 4]) -> [u64; 8] {
+    let (r1, carry) = mac(0, value[0], value[1], 0);
+    let (r2, carry) = mac(0, value[0], value[2], carry);
+    let (r3, r4) = mac(0, value[0], value[3], carry);
+
+    let (r3, carry) = mac(r3, value[1], value[2], 0);
+    let (r4, r5) = mac(r4, value[1], value[3], carry);
+
+    let (r5, r6) = mac(r5, value[2], value[3], 0);
+
+    let r7 = r6 >> 63;
+    let r6 = (r6 << 1) | (r5 >> 63);
+    let r5 = (r5 << 1) | (r4 >> 63);
+    let r4 = (r4 << 1) | (r3 >> 63);
+    let r3 = (r3 << 1) | (r2 >> 63);
+    let r2 = (r2 << 1) | (r1 >> 63);
+    let r1 = r1 << 1;
+
+    let (r0, carry) = mac(0, value[0], value[0], 0);
+    let (r1, carry) = adc(0, r1, carry);
+    let (r2, carry) = mac(r2, value[1], value[1], carry);
+    let (r3, carry) = adc(0, r3, carry);
+    let (r4, carry) = mac(r4, value[2], value[2], carry);
+    let (r5, carry) = adc(0, r5, carry);
+    let (r6, carry) = mac(r6, value[3], value[3], carry);
+    let (r7, _) = adc(0, r7, carry);
+
+    [r0, r1, r2, r3, r4, r5, r6, r7]
+}
+
+/// The four cancellation rounds of the Montgomery reduction of a 512-bit
+/// value `t < R * modulus`, yielding a value below `2 * modulus`.
+///
+/// This is a macro rather than a helper function on purpose: an extra
+/// function layer here, even an `inline(always)` one, changes LLVM's
+/// inlining decisions for the multiplication that expands it.
+#[cfg(not(target_arch = "x86_64"))]
+macro_rules! montgomery_rounds {
+    ($t:expr, $modulus:expr, $inv:expr) => {{
+        let [r0, r1, r2, r3, r4, r5, r6, r7] = *$t;
+        let modulus: &[u64; 4] = $modulus;
+        let inv: u64 = $inv;
+
+        let k = r0.wrapping_mul(inv);
+        let (_, carry) = mac(r0, k, modulus[0], 0);
+        let (r1, carry) = mac(r1, k, modulus[1], carry);
+        let (r2, carry) = mac(r2, k, modulus[2], carry);
+        let (r3, carry) = mac(r3, k, modulus[3], carry);
+        let (r4, carry2) = adc(r4, 0, carry);
+
+        let k = r1.wrapping_mul(inv);
+        let (_, carry) = mac(r1, k, modulus[0], 0);
+        let (r2, carry) = mac(r2, k, modulus[1], carry);
+        let (r3, carry) = mac(r3, k, modulus[2], carry);
+        let (r4, carry) = mac(r4, k, modulus[3], carry);
+        let (r5, carry2) = adc(r5, carry2, carry);
+
+        let k = r2.wrapping_mul(inv);
+        let (_, carry) = mac(r2, k, modulus[0], 0);
+        let (r3, carry) = mac(r3, k, modulus[1], carry);
+        let (r4, carry) = mac(r4, k, modulus[2], carry);
+        let (r5, carry) = mac(r5, k, modulus[3], carry);
+        let (r6, carry2) = adc(r6, carry2, carry);
+
+        let k = r3.wrapping_mul(inv);
+        let (_, carry) = mac(r3, k, modulus[0], 0);
+        let (r4, carry) = mac(r4, k, modulus[1], carry);
+        let (r5, carry) = mac(r5, k, modulus[2], carry);
+        let (r6, carry) = mac(r6, k, modulus[3], carry);
+        let (r7, _) = adc(r7, carry2, carry);
+
+        [r4, r5, r6, r7]
+    }};
+}
+
+/// Montgomery-reduces a 512-bit value `t < R * modulus` by cancelling its low
+/// half first, returning a result below `2 * modulus`.
+///
+/// The Montgomery quotient `Q` depends only on the low 256 bits of `t`, and
+/// `(t + Q * modulus) / R == (t_lo + Q * modulus) / R + t_hi` exactly, so the
+/// four cancellation rounds can run over four live limbs instead of eight and
+/// the high half is added once at the end. This is how the assembly backend's
+/// squaring and its `mul_by_1` helper are structured. The value produced is
+/// the same as the classical reduction's, limb for limb; only the dependency
+/// graph differs.
+///
+/// `(t_lo + Q * modulus) / R <= modulus` and `t_hi < modulus`, so the sum is
+/// below `2 * modulus` and fits in four limbs.
+#[cfg(any(target_arch = "x86_64", test))]
+#[cfg_attr(not(feature = "uninline-portable"), inline(always))]
+pub(super) const fn montgomery_reduce_low_lazy(
+    t: &[u64; 8],
+    modulus: &[u64; 4],
+    inv: u64,
+) -> [u64; 4] {
+    debug_assert!(modulus[2] == 0);
+
+    let [r0, r1, r2, r3, t4, t5, t6, t7] = *t;
+
+    // Each round chooses k so that the lowest live limb plus k * modulus[0]
+    // vanishes modulo 2^64, adds k * modulus, and drops that limb. The
+    // carry out of the top limb becomes the new top limb. Both Pasta moduli
+    // have a zero third limb, so that product is only a carry propagation.
+    let k = r0.wrapping_mul(inv);
+    let (_, carry) = mac(r0, k, modulus[0], 0);
+    let (r0, carry) = mac(r1, k, modulus[1], carry);
+    let (r1, carry) = adc(r2, 0, carry);
+    let (r2, r3) = mac(r3, k, modulus[3], carry);
+
+    let k = r0.wrapping_mul(inv);
+    let (_, carry) = mac(r0, k, modulus[0], 0);
+    let (r0, carry) = mac(r1, k, modulus[1], carry);
+    let (r1, carry) = adc(r2, 0, carry);
+    let (r2, r3) = mac(r3, k, modulus[3], carry);
+
+    let k = r0.wrapping_mul(inv);
+    let (_, carry) = mac(r0, k, modulus[0], 0);
+    let (r0, carry) = mac(r1, k, modulus[1], carry);
+    let (r1, carry) = adc(r2, 0, carry);
+    let (r2, r3) = mac(r3, k, modulus[3], carry);
+
+    let k = r0.wrapping_mul(inv);
+    let (_, carry) = mac(r0, k, modulus[0], 0);
+    let (r0, carry) = mac(r1, k, modulus[1], carry);
+    let (r1, carry) = adc(r2, 0, carry);
+    let (r2, r3) = mac(r3, k, modulus[3], carry);
+
+    // Add the high half; the sum is below 2 * modulus, so no carry out.
+    let (r0, carry) = adc(r0, t4, 0);
+    let (r1, carry) = adc(r1, t5, carry);
+    let (r2, carry) = adc(r2, t6, carry);
+    let (r3, _) = adc(r3, t7, carry);
+
+    [r0, r1, r2, r3]
+}
+
+/// Adds `k * 2^62` to `value` and `carry`, returning the low and high limbs.
+#[cfg(target_arch = "x86_64")]
+#[inline(always)]
+const fn mac_pasta_modulus_top(value: u64, k: u64, carry: u64) -> (u64, u64) {
+    let (low, carry) = adc(value, k << PASTA_MODULUS_TOP_SHIFT, carry);
+    (low, (k >> PASTA_MODULUS_TOP_OVERFLOW_SHIFT) + carry)
+}
+
+/// Squares and lazily reduces while interleaving independent upper-half work.
+#[cfg(target_arch = "x86_64")]
+#[inline(always)]
+const fn square_reduce_lazy_pasta(value: &[u64; 4], modulus: &[u64; 4], inv: u64) -> [u64; 4] {
+    debug_assert!(modulus[2] == 0);
+    debug_assert!(modulus[3] == 1 << PASTA_MODULUS_TOP_SHIFT);
+
+    let [a0, a1, a2, a3] = *value;
+
+    // Form the low off-diagonal limbs first. The remaining two products do
+    // not affect the low half, so LLVM can overlap them with its reduction.
+    let (r1, carry) = mac(0, a0, a1, 0);
+    let (r2, carry) = mac(0, a0, a2, carry);
+    let (r3, r4) = mac(0, a0, a3, carry);
+    let (r3, cross_carry) = mac(r3, a1, a2, 0);
+
+    let d3 = (r3 << 1) | (r2 >> 63);
+    let d2 = (r2 << 1) | (r1 >> 63);
+    let d1 = r1 << 1;
+
+    let (t0, carry) = mac(0, a0, a0, 0);
+    let (t1, carry) = adc(0, d1, carry);
+    let (t2, carry) = mac(d2, a1, a1, carry);
+    let (t3, square_carry) = adc(0, d3, carry);
+
+    let k = t0.wrapping_mul(inv);
+    let (_, carry) = mac(t0, k, modulus[0], 0);
+    let (q0, carry) = mac(t1, k, modulus[1], carry);
+    let (q1, carry) = adc(t2, 0, carry);
+    let (q2, q3) = mac_pasta_modulus_top(t3, k, carry);
+
+    let k = q0.wrapping_mul(inv);
+    let (_, carry) = mac(q0, k, modulus[0], 0);
+    let (q0, carry) = mac(q1, k, modulus[1], carry);
+    let (q1, carry) = adc(q2, 0, carry);
+    let (q2, q3) = mac_pasta_modulus_top(q3, k, carry);
+
+    let k = q0.wrapping_mul(inv);
+    let (_, carry) = mac(q0, k, modulus[0], 0);
+    let (q0, carry) = mac(q1, k, modulus[1], carry);
+    let (q1, carry) = adc(q2, 0, carry);
+    let (q2, q3) = mac_pasta_modulus_top(q3, k, carry);
+
+    let k = q0.wrapping_mul(inv);
+    let (_, carry) = mac(q0, k, modulus[0], 0);
+    let (q0, carry) = mac(q1, k, modulus[1], carry);
+    let (q1, carry) = adc(q2, 0, carry);
+    let (q2, q3) = mac_pasta_modulus_top(q3, k, carry);
+
+    // Complete the upper off-diagonal limbs and add the diagonal products.
+    let (r4, r5) = mac(r4, a1, a3, cross_carry);
+    let (r5, r6) = mac(r5, a2, a3, 0);
+    let r7 = r6 >> 63;
+    let r6 = (r6 << 1) | (r5 >> 63);
+    let r5 = (r5 << 1) | (r4 >> 63);
+    let r4 = (r4 << 1) | (r3 >> 63);
+
+    let (t4, carry) = mac(r4, a2, a2, square_carry);
+    let (t5, carry) = adc(0, r5, carry);
+    let (t6, carry) = mac(r6, a3, a3, carry);
+    let (t7, _) = adc(0, r7, carry);
+
+    let (q0, carry) = adc(q0, t4, 0);
+    let (q1, carry) = adc(q1, t5, carry);
+    let (q2, carry) = adc(q2, t6, carry);
+    let (q3, _) = adc(q3, t7, carry);
+
+    [q0, q1, q2, q3]
+}
+
+/// Reduces the product of a squaring to a value below `2 * modulus`.
+#[cfg_attr(not(feature = "uninline-portable"), inline(always))]
+#[cfg(not(target_arch = "x86_64"))]
+const fn reduce_square_lazy(t: &[u64; 8], modulus: &[u64; 4], inv: u64) -> [u64; 4] {
+    montgomery_rounds!(t, modulus, inv)
+}
+
+/// Subtracts `modulus` from a value below `2 * modulus` if that does not
+/// underflow, which makes the value canonical.
+#[cfg_attr(not(feature = "uninline-portable"), inline(always))]
+#[cfg_attr(
+    all(
+        feature = "aarch64-asm",
+        target_arch = "aarch64",
+        target_vendor = "apple"
+    ),
+    allow(dead_code)
+)]
+pub(super) const fn canonicalize(value: &[u64; 4], modulus: &[u64; 4]) -> [u64; 4] {
+    let (d0, borrow) = sbb(value[0], modulus[0], 0);
+    let (d1, borrow) = sbb(value[1], modulus[1], borrow);
+    let (d2, borrow) = sbb(value[2], modulus[2], borrow);
+    let (d3, borrow) = sbb(value[3], modulus[3], borrow);
+
+    let (d0, carry) = adc(d0, modulus[0] & borrow, 0);
+    let (d1, carry) = adc(d1, modulus[1] & borrow, carry);
+    let (d2, carry) = adc(d2, modulus[2] & borrow, carry);
+    let (d3, _) = adc(d3, modulus[3] & borrow, carry);
+
+    [d0, d1, d2, d3]
+}
+
+/// Squares `value` `n` times while keeping the accumulator below
+/// `2 * modulus`, instead of canonicalizing after every squaring.
+///
+/// A Montgomery reduction accepts an input below `R * m`. If an accumulator
+/// is below `c * m`, the next one is below `(1 + c^2 * m / R) * m`. Starting
+/// from a canonical value, this bound approaches `2 * m` from below. For both
+/// Pasta moduli, reaching the reduction's limit would require more than
+/// `2^131` squarings, while `n` is a `u32`.
+///
+/// The result must be canonicalized by the caller, either with
+/// [`canonicalize`] or by multiplying it by a canonical value. The latter
+/// product is below `2 * m^2 < R * m`, so the multiplication's reduction
+/// accepts it and returns a canonical result.
+#[cfg_attr(target_arch = "x86_64", inline(never))]
+#[cfg_attr(
+    all(not(target_arch = "x86_64"), not(feature = "uninline-portable")),
+    inline
+)]
+#[cfg_attr(
+    all(
+        feature = "aarch64-asm",
+        target_arch = "aarch64",
+        target_vendor = "apple"
+    ),
+    allow(dead_code)
+)]
+pub(super) fn sqr_n_lazy(value: &[u64; 4], n: u32, modulus: &[u64; 4], inv: u64) -> [u64; 4] {
+    let mut acc = *value;
+    for _ in 0..n {
+        #[cfg(target_arch = "x86_64")]
+        {
+            acc = square_reduce_lazy_pasta(&acc, modulus, inv);
+        }
+
+        #[cfg(not(target_arch = "x86_64"))]
+        {
+            acc = reduce_square_lazy(&square_wide(&acc), modulus, inv);
+        }
+    }
+    acc
+}

--- a/src/fields/portable.rs
+++ b/src/fields/portable.rs
@@ -252,7 +252,7 @@ const fn reduce_square_lazy(t: &[u64; 8], modulus: &[u64; 4], inv: u64) -> [u64;
     all(
         feature = "aarch64-asm",
         target_arch = "aarch64",
-        target_family = "unix",
+        any(target_family = "unix", target_os = "none"),
         target_pointer_width = "64",
         target_endian = "little"
     ),
@@ -294,7 +294,7 @@ pub(super) const fn canonicalize(value: &[u64; 4], modulus: &[u64; 4]) -> [u64; 
     all(
         feature = "aarch64-asm",
         target_arch = "aarch64",
-        target_family = "unix",
+        any(target_family = "unix", target_os = "none"),
         target_pointer_width = "64",
         target_endian = "little"
     ),


### PR DESCRIPTION
Widens the AArch64 assembly backend from Apple silicon to every 64-bit
little-endian Unix AArch64 target, extends it from multiplication and squaring
to addition, subtraction and doubling, and lands the two commits that had to
come first.

**Stacked on #112**, so this targets `dw/f25` rather than `main`. The stack is `main` <- #100 <- #112 <- this.
GitHub will retarget it automatically when #100 merges. Review only the eleven
commits listed below.

## Why these eleven, in this order

The series is a strict chain; each commit needs the one before it.

| # | commit | what |
| --- | --- | --- |
| 1 | Optimize Pasta squaring across portable targets | adds `fields::portable` |
| 2 | chore(pasta): fuse AArch64 repeated squaring | needs `portable::sqr_n_lazy` |
| 3 | Enable Pasta field assembly on Unix AArch64 | widens the gate |
| 4 | Require 64-bit pointers for AArch64 assembly | narrows it back |
| 5 | Require little endian for AArch64 assembly | narrows it back |
| 6 | Optimize Pasta field addition on Apple AArch64 | new operation |
| 7 | Optimize Pasta field subtraction on Apple AArch64 | new operation |
| 8 | Extend asm field add and sub to all Unix AArch64 | widens 6 and 7 |
| 9 | Use Apple runtime addition ASM for field doubling | new operation |
| 10 | Harden AArch64 assembly target support | BTI, non-exec stack |
| 11 | CHANGELOG | kept separate, as CI requires |

Commit 2 is the fourth and last commit of the series #100 carries; it could not
be sent with the other three because its portable branch calls
`portable::sqr_n_lazy` and `portable::canonicalize`, which commit 1 introduces.

Commits 3 to 5 are one change and should be read together: the Apple *vendor*
check becomes a conjunction of the properties the assembly actually depends on.
3 makes the claim, and 4 and 5 are the retreat from it to something defensible,
since ILP32 AArch64 exists and the assembly assumes LP64, and AArch64 can run
big endian while the field limbs are laid out little endian.

## What a reviewer should look at hardest

- **The target predicate.** This is the substance of the PR. The final gate is
  `feature = "aarch64-asm"` and `target_arch = "aarch64"` and
  `target_pointer_width = "64"` and `target_endian = "little"`, plus
  `target_vendor = "apple"` or `target_family = "unix"` depending on the
  routine. Everything else keeps the portable path.
- **Symbol naming.** The assembly file now emits Mach-O or ELF directives
  through a `C_SYMBOL` / `PRIVATE_SYMBOL` indirection, because ELF does not
  take the leading underscore Mach-O requires and spells hidden visibility
  differently.
- **Commit 1 changes behaviour on every target**, not only AArch64. Portable
  squaring chains no longer canonicalize after each squaring, and on x86-64 the
  reduction keeps four limbs live through the cancellation rounds instead of
  eight.
- **The new operators carry a canonicality precondition** enforced only by
  `debug_assert!`, so a release build does not check it. The contract is
  narrower than the inherent portable `add`, which carries into a fifth limb.
- **`ff::Field::double` and the inherent `double` are now different code paths**
  on the assembly target. They agree, and the tests assert it at every boundary
  value, but downstream call sites that want the assembly must say
  `Field::double(&x)`, since an inherent method wins method resolution.

## Testing

On `aarch64-apple-darwin`: 39 tests with default features, 101 with
`--all-features`, 32 with `--no-default-features`, 39 in release, 49 with
`--features aarch64-asm`, and 47 in release with `--features aarch64-asm`,
which is the configuration where the new `debug_assert!` preconditions compile
out. 39 pass on `x86_64-apple-darwin`, where the portable arms actually execute
rather than being type-checked. `cargo fmt --check` clean; `clippy -D warnings`
clean on default and `--all-features`.

Because the point of this series is *which targets compile the assembly*, that
was verified directly rather than assumed:

- `i686-unknown-linux-gnu`, `thumbv6m-none-eabi`, `wasm32-unknown-unknown` and
  `wasm32-wasip1` all build with `--features aarch64-asm` forced on, confirming
  it stays inert off AArch64;
- `aarch64-unknown-linux-gnu` checks clean with the feature on, and the
  assembly cross-assembles to a real ELF object with correctly unprefixed
  global symbols:

  ```
  pasta_mul-armv8.o: ELF 64-bit LSB relocatable, ARM aarch64
  0000000000000580 T pasta_curves_sqr_n_mont_pasta
  ```

Performance figures in the changelog are from an Apple M4. Other AArch64 cores
are expected, but not verified, to benefit; that caution is carried from the
source commits rather than dropped.

## Provenance

These are ports of ten commits from the public
[zakura-core/libraries](https://github.com/zakura-core/libraries) monorepo.
Each keeps its original author, date and message, and appends a trailer with a
`Source-Commit:` hash and the exact `git format-patch` command that regenerates
it, so the derivation is checkable mechanically.

Six applied verbatim with `git am --3way`. Four needed hunks re-sited by hand,
each recorded in its own commit message; every one was context drift rather
than a change in content, the recurring causes being that this crate spells the
trait method `get_lower_32` where the monorepo has `sqrt_hash_key`, elides the
lifetimes the monorepo writes explicitly on the `Add` and `Sub` impl headers,
and has not been through the 2024 style edition.

Two cross-crate hunks were deliberately not carried, both consumer-side changes
in other repositories that this crate does not need in order to build, and both
only makeable after a `pasta_curves` release ships this work: a
`halo2_proofs/Cargo.toml` target predicate, and a `halo2_gadgets` call-site
rewrite from `x.double()` to `Field::double(&x)`. Each is described in the
commit that would otherwise have carried it.